### PR TITLE
Remove references to non-standard /home/$USER/scratch

### DIFF
--- a/generate_slurm_script.py
+++ b/generate_slurm_script.py
@@ -16,9 +16,9 @@ parser.add_argument("--my_wandb_project", type=str, default="PredictingZygosity"
 parser.add_argument("--my_wandb_run_name", type=str, help="Name for when results are synced to wandb; if not provided, a random name will be generated")
 parser.add_argument("--input_formatting", type=str, default="raw", help="Name of the folder where your input files are stored within input_dir; useful for multiple formatting styles (e.g. difference vs raw values)")
 
-parser.add_argument("--output_dir_base", type=str, default="/home/$USER/scratch/", help="Full path to the output file folders (final output folder will be 'zyg_out_' + my_wandb_name within this folder)")
-parser.add_argument("--input_dir_base", type=str, default="/home/$USER/scratch/zyg_in/", help="Full path to the input file folders")
-parser.add_argument("--models_dir", type=str, default="/home/$USER/scratch/torchtune_models/", help="Full path to the model file folders")
+parser.add_argument("--output_dir_base", type=str, default="/scratch/gpfs/$USER/", help="Full path to the output file folders (final output folder will be 'zyg_out_' + my_wandb_name within this folder)")
+parser.add_argument("--input_dir_base", type=str, default="/scratch/gpfs/$USER/zyg_in/", help="Full path to the input file folders")
+parser.add_argument("--models_dir", type=str, default="/scratch/gpfs/$USER/torchtune_models/", help="Full path to the model file folders")
 
 # ----- Optional YAML Args -----
 parser.add_argument("--max_steps_per_epoch", type=int, help="Maximum steps per epoch (useful for debugging)")

--- a/templates/finetune_template.yaml
+++ b/templates/finetune_template.yaml
@@ -9,9 +9,9 @@ my_wandb_project: ""
 my_wandb_run_name: ""
 input_formatting: ""
 
-output_dir: /home/$USER/scratch/zyg_out_${my_wandb_run_name}/
-input_dir: /home/$USER/scratch/zyg_in/${input_formatting}/
-models_dir: /home/$USER/scratch/torchtune_models/
+output_dir: /scratch/gpfs/$USER/zyg_out_${my_wandb_run_name}/
+input_dir: /scratch/gpfs/$USER/zyg_in/${input_formatting}/
+models_dir: /scratch/gpfs/$USER/torchtune_models/
 
 batch_size: 4
 


### PR DESCRIPTION
Closes #30 

# Description

Removed references to `/home/$USER/scratch` (a shortcut I recommend to others) in favor of the absolute path (`/scratch/gpfs/$USER`)

## New Dependencies

_None_

# Testing Instructions

Did a simple run generated with the following to make sure the new defaults work properly:

`python generate_slurm_script.py   --my_wandb_project 30-test   --my_wandb_run_name 30-test-1   --input_formatting 'raw'   --conda_env ttenv-nightly   --account msalganik`