### PR TITLE
Add config for save_last_epoch_only

### DIFF
--- a/custom_recipes/lora_finetune_single_device_val.py
+++ b/custom_recipes/lora_finetune_single_device_val.py
@@ -861,7 +861,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                         )
                     )
                 else:
-                    log.info(f"Skipping checkpoint save for epoch {curr_epoch + 1} to save disk space.")
+                    log.info(f"Skipping checkpoint save for epoch {curr_epoch + 1}...")
 
     def cleanup(self) -> None:
         self._metric_logger.close()

--- a/custom_recipes/lora_finetune_single_device_val.py
+++ b/custom_recipes/lora_finetune_single_device_val.py
@@ -154,6 +154,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         self.global_step = 0
         self._resume_from_checkpoint = cfg.resume_from_checkpoint
         self._save_adapter_weights_only = cfg.get("save_adapter_weights_only", False)
+        self._save_last_epoch_only = cfg.get("save_last_epoch_only", False)
         self._gradient_accumulation_steps = cfg.gradient_accumulation_steps
         self._clip_grad_norm = cfg.get("clip_grad_norm", None)
 
@@ -848,14 +849,19 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                         break
 
                 self.epochs_run += 1
-                start_save_checkpoint = time.perf_counter()
-                log.info("Starting checkpoint save...")
-                self.save_checkpoint(epoch=curr_epoch)
-                log.info(
-                    "Checkpoint saved in {:.2f} seconds.".format(
-                        time.perf_counter() - start_save_checkpoint
+                
+                # If self._save_last_epoch_only is true, only save checkpoint on the final epoch to save disk space
+                if not self._save_last_epoch_only or curr_epoch == self.total_epochs - 1:
+                    start_save_checkpoint = time.perf_counter()
+                    log.info("Starting checkpoint save...")
+                    self.save_checkpoint(epoch=curr_epoch)
+                    log.info(
+                        "Checkpoint saved in {:.2f} seconds.".format(
+                            time.perf_counter() - start_save_checkpoint
+                        )
                     )
-                )
+                else:
+                    log.info(f"Skipping checkpoint save for epoch {curr_epoch + 1} to save disk space.")
 
     def cleanup(self) -> None:
         self._metric_logger.close()

--- a/generate_slurm_script.py
+++ b/generate_slurm_script.py
@@ -68,6 +68,11 @@ for key, value in vars(args).items():
     elif key == "dataset_split_point":
         config["dataset"]["split"] = f"train[:{value}%]"
         config["dataset_val"]["split"] = f"train[{value}%:]"
+    # TODO - change these to actual booleans in argparse?
+    elif key == "save_adapter_weights_only":
+        config["save_adapter_weights_only"] = (value == "true")
+    elif key == "save_last_epoch_only":
+        config["save_last_epoch_only"] = (value == "true")
     elif key == "train_on_input":
         config["dataset"]["train_on_input"] = (value == "true")
     # The rest are straightforward

--- a/generate_slurm_script.py
+++ b/generate_slurm_script.py
@@ -27,6 +27,7 @@ parser.add_argument("--models_dir", type=str, default="/scratch/gpfs/$USER/torch
 parser.add_argument("--batch_size", type=int, default=4, help="Batch size for training")
 parser.add_argument("--epochs", type=int, default=1, help="Number of epochs to train for")
 parser.add_argument("--save_adapter_weights_only", type=str, default="false", help="Whether to save only the adapter weights (true/false)")
+parser.add_argument("--save_last_epoch_only", type=str, default="false", help="Whether to save only the last epoch (true/false)")
 parser.add_argument("--max_steps_per_epoch", type=int, help="Maximum steps per epoch (useful for debugging)")
 parser.add_argument("--log_every_n_steps", type=int, default=5, help="How often to log (in steps)")
 parser.add_argument("--run_val_every_n_steps", type=int, default=50, help="How often to run validation (in steps)")

--- a/templates/finetune_template.yaml
+++ b/templates/finetune_template.yaml
@@ -44,6 +44,7 @@ checkpointer:
   model_type: LLAMA3_2
 resume_from_checkpoint: False
 save_adapter_weights_only: False
+save_last_epoch_only: False
 
 # Optimizer and Scheduler
 optimizer:


### PR DESCRIPTION
Closes #39 

# Description

A new config option called save_last_epoch_only has been added to the yaml template (defaults to false). This can be changed via the generator with `--save_last_epoch_only true`.

## New Dependencies

(None)

# Testing Instructions

* Create a run using a test dataset (I'm using predictable_or_not) with `--save_last_epoch_only true` -> only the final epoch (minus 1, computer science counting!) has a save folder with model weights (or adapter weights based on what you chose)
* Create a run using a test dataset (I'm using predictable_or_not) with `--save_last_epoch_only false` -> all epochs have a save folder with model weights (or adapter weights based on what you chose)
  * Repeat the above with the argument left out entirely -> should be the same result (all epochs have a save folder)
