### PR TITLE
Allow for longer sequence lengths in predictable_or_not

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ tune download meta-llama/<model_name> --output-dir <model_dir> --hf-token <hf-to
 
 # Formatting Input Files to JSON
 
-## With capitalization dataset
+## With capitalization dataset (tests/input_training)
 
-The file already exists for you (coming soon)!
+The file already exists for you - you'll just need to reference it when running the generator in the next step!
 
 ## With twin dataset
 
@@ -105,7 +105,7 @@ When complete, multiple JSON files will be created in the same input folder you 
 
 ## With capitalization dataset
 
-Coming soon!
+For full instructions, see the README.md in tests/input_training (NB - if you haven't already, you'll need to the **ttenv-nightly** environment for this test!)
 
 ## With twin dataset
 

--- a/tests/predictable_or_not/generate_data.py
+++ b/tests/predictable_or_not/generate_data.py
@@ -1,13 +1,21 @@
+import argparse
 import copy
 import json
 import random
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--in_seq_len", type=int, default=5, help="Input sequence length")
+args = parser.parse_args()
+
+if args.in_seq_len < 1:
+    raise ValueError("Input sequence length must be at least 1.")
 
 # Predictable input and output
 pp = []
 for i in range(1000):
     line = {'input': '', 'output': ''}
-    start = random.randint(0, 1000)
-    for j in range(5):
+    start = random.randint(0, 1000 - args.in_seq_len - 1)
+    for j in range(args.in_seq_len):
         line['input'] += str(start + j) + ','
     line['output'] = str(start + j + 1)
     pp.append(line)


### PR DESCRIPTION
Closes #35 

# Description

A bit of code cleanup more than anything. Most of this issue was running additional tests to learn about spikiness in tokens per second but while doing that I discovered that we had some outstanding problems in our current README.md that I should correct when closing this issue. Primarily, this was to add instructions for preparing data and doing a test run with the new test datasets.

## New Dependencies

(None)

# Testing Instructions

None I'm aware of - this should be merged as soon as we can
