### PR TITLE
Add fine-tuning custom metrics logic to our custom recipe

### DIFF
--- a/custom_recipes/lora_finetune_single_device_val.py
+++ b/custom_recipes/lora_finetune_single_device_val.py
@@ -674,7 +674,6 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
     def _loss_step(self, batch: Dict[str, torch.Tensor]) -> torch.Tensor:
         # Shape [b, s], needed for the loss not the model
         labels = batch.pop("labels")
-        print(batch.keys())
         # run model
         with self.activations_handling_ctx:
             logits = self._model(**batch)
@@ -699,8 +698,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
             labels = labels.reshape(-1)
             logits = logits.reshape(-1, logits.size(-1))
 
-        # loss = self._loss_fn(logits, labels)
-        loss = self._test_loss_fn(logits, labels)
+        loss = self._loss_fn(logits, labels)
 
         # free logits otherwise it peaks backward memory
         del logits

--- a/inspect/interactive.py
+++ b/inspect/interactive.py
@@ -1,0 +1,16 @@
+# %%
+import os
+2 + 2
+# %%
+a = 5
+b = 10
+c = a + b
+print("c = ", c)
+
+# %%
+import pandas as pd
+
+df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
+print(df)
+
+# %%

--- a/utils/finetune_custom_metrics.py
+++ b/utils/finetune_custom_metrics.py
@@ -4,7 +4,7 @@ Custom metrics for model evaluation during fine-tuning
 
 import torch
 import torch.nn.functional as F
-from typing import Dict
+from typing import Dict, List
 
 
 def get_token_id(token: str, tokenizer=None) -> int:
@@ -25,84 +25,19 @@ def get_token_id(token: str, tokenizer=None) -> int:
         raise ValueError(f"Tokenizer is required to look up token '{token}'")
     
     try:
-        token_ids = tokenizer.encode(token, add_special_tokens=False)
+        token_ids = tokenizer.encode(token)
+        print(f'Token IDs for "{token}": {token_ids}')
         if not token_ids:
             raise ValueError(f"Token '{token}' not found in tokenizer vocabulary")
-        return token_ids[0]
+        # TODO - this is cludgy but I can't figure out how to disable BOS/EOS tokens!
+        return token_ids[1]
     except Exception as e:
         raise ValueError(f"Failed to encode token '{token}': {e}")
 
 
-def calculate_mse_from_logits(
-    logits: torch.Tensor, 
-    labels: torch.Tensor, 
-    tokenizer=None,
-    ignore_index: int = -100
-) -> torch.Tensor:
-    """
-    Calculate MSE between probability of class 1 and binary labels.
-    
-    Args:
-        logits: Raw model outputs [batch_size * seq_len, vocab_size]
-        labels: Ground truth labels [batch_size * seq_len]
-        tokenizer: Tokenizer to look up token ID for "1"
-        ignore_index: Index to ignore in loss calculation
-        
-    Returns:
-        MSE loss as tensor
-    """
-    # Filter out ignored labels
-    valid_mask = labels != ignore_index
-    if not valid_mask.any():
-        return torch.tensor(0.0, device=logits.device)
-    
-    valid_logits = logits[valid_mask]
-    valid_labels = labels[valid_mask]
-    
-    # Convert logits to probabilities
-    probs = F.softmax(valid_logits, dim=-1)
-    
-    # Find token ID for "1"
-    token_1_id = get_token_id("1", tokenizer)
-    
-    # Extract probability of token "1"
-    prob_1 = probs[:, token_1_id]
-    
-    # Convert labels to float for MSE calculation
-    binary_labels = valid_labels.float()
-    
-    # Calculate MSE
-    mse = F.mse_loss(prob_1, binary_labels, reduction='mean')
-    
-    return mse
-
-
-def get_third_most_likely_token_info(logits: torch.Tensor) -> tuple[int, float]:
-    """
-    Get the third most likely token ID and its probability for debugging.
-    Uses first valid sample from the batch.
-    
-    Args:
-        logits: Raw model outputs [batch_size, vocab_size]
-        
-    Returns:
-        Tuple of (token_id, probability)
-    """
-    # Get probabilities for first sample
-    probs = F.softmax(logits[0], dim=-1)
-    
-    # Get top 3 token indices and probabilities
-    top_probs, top_indices = torch.topk(probs, k=3, dim=-1)
-    
-    # Return third most likely (index 2)
-    return top_indices[2].item(), top_probs[2].item()
-
-
 def calculate_prob_0_1_sum(
-    logits: torch.Tensor,
-    labels: torch.Tensor,
-    tokenizer=None,
-    ignore_index: int = -100
+    logits: List[torch.Tensor],
+    tokenizer=None
 ) -> torch.Tensor:
     """
     Calculate average sum of p(0) + p(1) to check if model has learned 
@@ -117,29 +52,64 @@ def calculate_prob_0_1_sum(
     Returns:
         Average sum of p(0) + p(1) across valid tokens
     """
-    # Filter out ignored labels
-    valid_mask = labels != ignore_index
-    if not valid_mask.any():
-        return torch.tensor(0.0, device=logits.device)
-    
-    valid_logits = logits[valid_mask]
+
+    # Flatten logits because they come in as a 3D list of shape
+    # [batch_size, seq_len, vocab_size]
+    # logits: [batch_size, seq_len, vocab_size]
+    final_logits_list = []
+    for tensor in logits:
+        final_pos_logits = tensor[:, -1, :]  # Get last token logits for each batch
+        final_logits_list.append(final_pos_logits)
+    final_logits = torch.cat(final_logits_list, dim=0)  # Concatenate along batch dimension, so new shape is [batch_size, vocab_size]
     
     # Convert logits to probabilities
-    probs = F.softmax(valid_logits, dim=-1)
+    final_probs = F.softmax(final_logits, dim=-1)
     
     # Find token IDs for "0" and "1"
     token_0_id = get_token_id("0", tokenizer)
     token_1_id = get_token_id("1", tokenizer)
     
     # Sum p(0) + p(1) for each valid token
-    prob_0_1_sum = probs[:, token_0_id] + probs[:, token_1_id]
+    prob_0 = final_probs[:, token_0_id].mean().item()
+    prob_1 = final_probs[:, token_1_id].mean().item()
+    prob_sum = prob_0 + prob_1
+
+    top_k = 10
+    avg_probs = final_probs.mean(dim=0)
+    top_probs, top_indices = torch.topk(avg_probs, k=top_k)
+    
+    # More robust token decoding with error handling
+    top_tokens = []
+    for idx in top_indices:
+        try:
+            token = tokenizer.decode([idx.item()])
+            # Handle potential whitespace/special chars for cleaner display
+            if token == '':
+                token = '<empty>'
+            elif token.isspace():
+                token = f'<space:{repr(token)}>'
+            top_tokens.append(token)
+        except:
+            top_tokens.append(f'<decode_error:{idx.item()}>')
+
+    print(f"Top {top_k} tokens and their avg probabilities:")
+    for token, prob in zip(top_tokens, top_probs):
+        print(f"  '{token}': {prob:.4f}")
+
+    print(f"p(0): {avg_probs[token_0_id]:.4f}")
+    print(f"p(1): {avg_probs[token_1_id]:.4f}")
+    print(f"p(0) + p(1): {avg_probs[token_0_id] + avg_probs[token_1_id]:.4f}")
+
+    # Optional: Show what tokens 0 and 1 actually decode to for verification
+    print(f"Token {token_0_id} decodes to: '{tokenizer.decode([token_0_id])}'")
+    print(f"Token {token_1_id} decodes to: '{tokenizer.decode([token_1_id])}'")
     
     # Return average across all valid tokens
-    return prob_0_1_sum.mean()
+    return prob_sum
 
 
 def calculate_custom_metrics(
-    logits: torch.Tensor,
+    logits: List[torch.Tensor],
     labels: torch.Tensor,
     tokenizer=None,
     ignore_index: int = -100
@@ -149,25 +119,16 @@ def calculate_custom_metrics(
     
     Args:
         logits: Raw model outputs
-        labels: Ground truth labels
+        labels: Ground truth labels (to be used in MSE calculation)
         tokenizer: Tokenizer to look up token IDs
-        ignore_index: Index to ignore in calculations
+        ignore_index: Index to ignore in calculations (e.g., -100 for padding)
         
     Returns:
         Dictionary of metric names to values
     """
     metrics = {}
-    
-    # MSE metric
-    metrics['mse'] = calculate_mse_from_logits(logits, labels, tokenizer, ignore_index)
-    
+        
     # Average sum of p(0) + p(1) 
-    metrics['avg_prob_0_1_sum'] = calculate_prob_0_1_sum(logits, labels, tokenizer, ignore_index)
-    
-    # Debug metrics: third most likely token and its probability
-    if logits.numel() > 0:
-        third_token, third_prob = get_third_most_likely_token_info(logits)
-        metrics['third_most_likely_token'] = torch.tensor(float(third_token))
-        metrics['third_token_prob'] = torch.tensor(third_prob)
+    metrics['prob_0_1_sum'] = calculate_prob_0_1_sum(logits, tokenizer)
     
     return metrics


### PR DESCRIPTION
Closes #18 

# Description

Working with Claude Code (which is amazing by the way), we were able to design a pretty clean way to insert custom metrics into a custom recipe. Considering the options, I'm increasingly convinced this is the cleanest way to accomplish what we want. I'm more concerned about double-checking the logic for the exact metrics that @msalganik asked for, which I should compare against how @alessandramaranca has been calculating things in the eval.py script.

## New Dependencies

None, because Claude convinced me that for what we're doing we actually don't need torch eval...yet

# Testing Instructions

This is TBD - I need to see if these new metrics come out nicely in W&B.

**This will be discussed on Friday at our Unconference**
