### PR TITLE
Create generate.py

### DIFF
--- a/tests/bit_sequences/generate.py
+++ b/tests/bit_sequences/generate.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
     assert N >= max_unique, (
         f"Total size N must be ≥ number of unique sequences (2^{n}={max_unique}), got {N}"
     )
-    assert 0 <= test_size < N, (
+    assert 1 <= test_size < N, (
         f"test_size must be in [1, N), got {test_size} with N={N}"
     )
 

--- a/tests/bit_sequences/generate.py
+++ b/tests/bit_sequences/generate.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+Generate binary sequence datasets with either parity-based or probabilistic labeling to any outdir.
+
+Usage examples:
+  # Parity dataset (no noise), 2^5=32 unique, N=1000 samples, test_size=200
+  python generate.py --bit_length 5 --N 1000 --test_size 200 --bit_parity True --test_size 1000
+
+  # Probabilistic dataset, p=0.3, N=500
+  python generate.py --bit_length 8 --N 500 --p 0.3 --bit_parity False --test_size 100
+"""
+import argparse
+import itertools
+import json
+from pathlib import Path
+import numpy as np
+
+def compute_parity(bitstr: str) -> str:
+    """Return '0' if even number of '1's, else '1'."""
+    return str(bitstr.count('1') % 2)
+
+def parse_bool(value: str) -> bool:
+    """Parse a boolean CLI argument (True/False)."""
+    val = value.lower()
+    if val in ('true', 't', '1'):
+        return True
+    if val in ('false', 'f', '0'):
+        return False
+    raise argparse.ArgumentTypeError(f"Boolean value expected (True or False), got '{value}'")
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Generate binary sequences labeled by parity or Bernoulli(p)."
+    )
+    parser.add_argument(
+        "--bit_length", type=int, required=True,
+        help="Length of each bit sequence (n ≥ 1)."
+    )
+    parser.add_argument(
+        "--N", type=int, required=True,
+        help="Total number of examples to generate (N ≥ 2^bit_length)."
+    )
+    parser.add_argument(
+        "--test_size", type=int, required=True,
+        help="Number of examples in the test set."
+    )
+    parser.add_argument(
+        "--bit_parity", type=parse_bool, required=True, choices=[True, False],
+        help=(
+            "Choose labeling mode: True for parity-based (with noise p), "
+            "False for Bernoulli(p) labeling."
+        )
+    )
+    parser.add_argument(
+        "--p", type=float, default=0.0,
+        help=(
+            "Probability parameter: if --bit_parity True, noise probability to flip parity labels; "
+            "if False, probability of a positive (1) label."
+        )
+    )
+    parser.add_argument(
+        "--seed", type=int, default=42,
+        help="Random seed for reproducibility."
+    )
+    parser.add_argument(
+        "--outdir", type=Path, default=Path.cwd(),
+        help="Directory to write train.json and test.json."
+    )
+    return parser.parse_args()
+
+def label_sequences(sequences, bit_parity: bool, p: float, rng: np.random.RandomState):
+    """
+    Label each sequence by parity (with noise) or by Bernoulli(p).
+    Returns a list of dicts with keys: instruction, input, output.
+    """
+    data = []
+    for seq in sequences:
+        if bit_parity:
+            true_lbl = int(compute_parity(seq))
+            if not (0.0 <= p <= 1.0):
+                raise ValueError(f"Noise probability p must be in [0,1], got {p}")
+            flip = rng.rand() < p
+            lbl = true_lbl ^ int(flip)
+            label = str(lbl)
+        else:
+            if not (0.0 <= p <= 1.0):
+                raise ValueError(f"Probability p must be in [0,1], got {p}")
+            label = str(int(rng.rand() < p))
+        data.append({"instruction": "", "input": seq, "output": label})
+    return data
+
+if __name__ == "__main__":
+    args = parse_args()
+    n = args.bit_length
+    N = args.N
+    test_size = args.test_size
+    p = args.p
+    bit_parity = args.bit_parity
+    seed = args.seed
+    outdir = args.outdir
+
+    # Basic assertions
+    assert n > 0, f"bit_length must be ≥ 1, got {n}"
+    max_unique = 2 ** n
+    assert N >= max_unique, (
+        f"Total size N must be ≥ number of unique sequences (2^{n}={max_unique}), got {N}"
+    )
+    assert 0 <= test_size < N, (
+        f"test_size must be in [1, N), got {test_size} with N={N}"
+    )
+
+    rng = np.random.RandomState(seed)
+
+    # Generate all unique sequences of length n
+    all_seqs = ["".join(bits) for bits in itertools.product("01", repeat=n)]
+
+    # Label the unique sequences
+    labeled = label_sequences(all_seqs, bit_parity, p, rng)
+
+    # Sample (with replacement if N > unique)
+    replace = N > len(labeled)
+    indices = rng.choice(len(labeled), size=N, replace=replace)
+    dataset = [labeled[i] for i in indices]
+    rng.shuffle(dataset)
+
+    # Write outputs
+    outdir.mkdir(parents=True, exist_ok=True)
+    train, test = dataset[: N - test_size], dataset[N - test_size:]
+    with open(outdir / "train.json", "w") as f:
+        json.dump(train, f, indent=2)
+    with open(outdir / "test.json", "w") as f:
+        json.dump(test, f, indent=2)
+    print(f"✅ Generated {len(train)} train and {len(test)} test examples (bit_parity={bit_parity}, p={p})")

--- a/tests/bit_sequences/generate.py
+++ b/tests/bit_sequences/generate.py
@@ -3,10 +3,10 @@
 Generate binary sequence datasets with either parity-based or probabilistic labeling to any outdir.
 
 Usage examples:
-  # Parity dataset (no noise), 2^5=32 unique, N=1000 samples, test_size=200
+  # Parity dataset (no noise), 2^5=32 unique sequences 
   python generate.py --bit_length 5 --N 1000000 --p 0 --bit_parity True --test_size 1000
 
-  # Probabilistic dataset, p=0.3, N=500
+  # Probabilistic dataset, p=0.3, 2^8=256 unique sequences
   python generate.py --bit_length 8 --N 500000 --p 0.5 --bit_parity False --test_size 1000
 """
 import argparse

--- a/tests/bit_sequences/generate.py
+++ b/tests/bit_sequences/generate.py
@@ -4,10 +4,10 @@ Generate binary sequence datasets with either parity-based or probabilistic labe
 
 Usage examples:
   # Parity dataset (no noise), 2^5=32 unique, N=1000 samples, test_size=200
-  python generate.py --bit_length 5 --N 1000 --test_size 200 --bit_parity True --test_size 1000
+  python generate.py --bit_length 5 --N 1000000 --p 0 --bit_parity True --test_size 1000
 
   # Probabilistic dataset, p=0.3, N=500
-  python generate.py --bit_length 8 --N 500 --p 0.3 --bit_parity False --test_size 100
+  python generate.py --bit_length 8 --N 500000 --p 0.5 --bit_parity False --test_size 1000
 """
 import argparse
 import itertools

--- a/tests/bit_sequences/readme.md
+++ b/tests/bit_sequences/readme.md
@@ -1,0 +1,72 @@
+# Binary Sequence Dataset Generator
+
+This script generates synthetic binary sequence datasets for use in binary classification tasks. Labels can be assigned either by **bit parity** (even/odd number of 1s) or via a **Bernoulli distribution** with probability `p`.
+
+## Features
+
+* Supports both deterministic parity labeling and probabilistic labeling.
+* Option to inject noise when using parity labels (flip labels with probability `p`).
+* Outputs two JSON files: `train.json` and `test.json`, formatted for LLM-style instruction tuning.
+* Ensures at least one copy of each possible binary sequence of length `n` for varying dataset sizes (set $2^\texttt{bitlength} = N$ if you don't want repetition). 
+
+## Usage
+
+To create a parity dataset (no noise) with 2^5=32 unique sequences we could have
+
+```
+python generate.py --bit_length 5 --N 1000000 --p 0 --bit_parity True --test_size 1000
+```
+
+To create a probabilistic dataset with $p = 0.3$ we could have
+
+```
+python generate.py --bit_length 8 --N 500000 --p 0.5 --bit_parity False --test_size 1000
+```
+
+## Arguments
+
+* `--bit_length`: Length of each binary sequence (e.g., 5).
+* `--N`: Total number of examples (must be ≥ 2^bit\_length).
+* `--test_size`: Number of test examples.
+* `--bit_parity`: `True` for parity-based labeling, `False` for probabilistic.
+* `--p`: Noise level (if parity) or Bernoulli probability (if probabilistic).
+* `--seed`: Random seed (default: 42).
+* `--outdir`: Output directory (default: current directory).
+
+## Output Format
+
+Each `.json` file contains a list of examples in this format:
+
+```json
+{
+  "instruction": "",
+  "input": "01011",
+  "output": "1"
+}
+```
+
+## How to integrate it with the codebase
+
+Generate train.json and test.json into your current working directory and then use `generate_slurm_script.py` with the following arguments:
+
+```
+python generate_slurm_script.py \
+  --my_wandb_project predictable_or_not \
+  --my_wandb_run_name binary_sequence_test \
+  --input_dir_base /home/niznik/scratch/GitHub/predicting-zygosity/tests/bit_sequences/ \
+  --input_formatting '' \
+  --dataset_filename train.json \
+  --dataset_val_filename test.json \
+  --train_on_input true \
+  --batch_size 1 \
+  --epochs 10 \
+  --save_adapter_weights_only true \
+  --log_every_n_steps 1 \
+  --run_val_every_n_steps 4 \
+  --conda_env ttenv-nightly \
+  --custom_recipe lora_finetune_single_device_val.py \
+  --account msalganik \
+  --constraint gpu80
+
+sbatch finetune_filled.slurm
+```


### PR DESCRIPTION
Generate bit_squences finetuning tests (bit parity and probabilistic tests). This generates a dataset of binary sequences of a given length (`--bit_length`) and total size (`--N`), then splits it into train/test (`--test_size`). You choose labeling mode with `--bit_parity True` to assign outputs by parity (optionally flipping labels with probability `--p`), or `--bit_parity False` to sample outputs as independent Bernoulli draws with probability `--p`. It validates inputs (`2^bit_length ≤ N`, `0 ≤ p ≤ 1`, etc.), and writes JSON files (`train.json` and `test.json`) to the specified output directory.

Closes #38 

# Description

Made it such that sequence length and sample size are different by introducing sampling with replacement. Made the code more generalizable, added assert statements, integrated with our current workflow (no repetitions). 

# Testing Instructions

This integrates with our current finetuning and evaluation workflow (just finetune on file train.json and evaluate/test on file test.json). 