### PR TITLE
Simple finetuning test

### DIFF
--- a/tests/finetuning/README.md
+++ b/tests/finetuning/README.md
@@ -36,7 +36,7 @@ This script performs a diagnostic comparison between a pretrained language model
 
 ### Token-level likelihood and perplexity
 
-We begin by tokenizing an arbitrary prompt provided at the command line. Both $M_{\text{base}}$ and $M_{\text{adapter}}$ generate logits $\mathbf{z} \in \mathbb{R}^{T \times V}$ over a vocabulary of size $V$ for each of $T$ tokens. These logits are used to compute a **next-token prediction loss** via cross-entropy, averaged across time steps. The exponential of this loss gives **perplexity**, a standard metric indicating how "confident" the model is in generating the observed text. If fine-tuning is effective, we expect $\text{ppl}_{\text{adapter}} < \text{ppl}_{\text{base}}$, especially when the prompt reflects the fine-tuning domain (and perhaps to do worse when it doesn't, depending on how many epochs were run and on the specific task).
+We begin by tokenizing an arbitrary prompt provided at the command line. Both $M_{\text{base}}$ and $M_{\text{adapter}}$ generate logits $\mathbf{z} \in \mathbb{R}^{T \times V}$ over a vocabulary of size $V$ for each of $T$ tokens. These logits are used to compute a **next-token prediction loss** via cross-entropy, averaged across time steps. The exponential of this loss gives **perplexity**, a standard metric indicating how "confident" the model is in generating the observed text. If fine-tuning is effective, we expect the perplexity of the adapter to be lower than that of the base model, especially when the prompt reflects the fine-tuning domain (depending on how many epochs were run and on the specific task).
 
 ### Logit space divergence
 

--- a/tests/finetuning/README.md
+++ b/tests/finetuning/README.md
@@ -1,0 +1,62 @@
+# Simple tests of whether this model was finetuned
+
+This utility script checks whether a fine-tuned language model using PEFT adapters is meaningfully different from its base model. It does so by computing two metrics — **perplexity** and **logit mean squared error (MSE)** — on a user-provided input prompt.
+
+---
+
+# How to run it?
+
+```
+python is_this_a_finetuned_model.py \
+  --base_model_path /path/to/base_model \
+  --adapter_path /path/to/adapter_checkpoint \
+  --prompt "Add prompt here"
+```
+
+# Example
+
+```
+python is_this_a_finetuned_model.py   --base_model_path /home/ar0241/scratch/torchtune_models/Llama-3.2-1B-Instruct   --adapter_path /home/ar0241/scratch/twins/output_p0/epoch_9 --prompt "The output of 0001011 is 1"
+```
+
+# Example output 
+
+```
+=== Model Comparison ===
+Input: The output of 0001011 is 1
+Base Model Perplexity:    67.575
+Adapter Model Perplexity: 67.129
+Logit MSE Difference:     0.003712
+✅ Adapter model is different — likely fine-tuned.
+```
+
+# Explanation
+
+This script performs a diagnostic comparison between a pretrained language model $M_{\text{base}}$ and a fine-tuned derivative $M_{\text{adapter}}$ built using **parameter-efficient fine-tuning (PEFT)**. The goal is to evaluate whether the adapter has non-trivially altered the functional behavior of the model.
+
+### Token-level likelihood and perplexity
+
+We begin by tokenizing an arbitrary prompt provided at the command line. Both $M_{\text{base}}$ and $M_{\text{adapter}}$ generate logits $\mathbf{z} \in \mathbb{R}^{T \times V}$ over a vocabulary of size $V$ for each of $T$ tokens. These logits are used to compute a **next-token prediction loss** via cross-entropy, averaged across time steps. The exponential of this loss gives **perplexity**, a standard metric indicating how "confident" the model is in generating the observed text. If fine-tuning is effective, we expect $\text{ppl}_{\text{adapter}} < \text{ppl}_{\text{base}}$, especially when the prompt reflects the fine-tuning domain (and perhaps to do worse when it doesn't, depending on how many epochs were run and on the specific task).
+
+### Logit space divergence
+
+Then, this computes the **mean squared error (MSE)** between the raw logits of the two models. Because logits represent the pre-softmax activations over vocabulary tokens, they encode the model's inductive biases before normalization. A small MSE implies that the adapter model is functionally near-identical to the base, suggesting the adapter is not having any measurable effect. This metric is sensitive to even minor deviations in model behavior.
+
+### Summary
+
+Together, these metrics form a complementary diagnostic:
+
+* **Perplexity** captures model confidence over the actual sequence.
+* **Logit MSE** captures the degree of deviation in token-level preferences across the vocabulary space.
+
+The combination allows you to distinguish between (1) models that learned nothing (identical logits and perplexity), (2) models that diverged without gaining fluency (higher perplexity but diverging logits), and (3) successful adapters (lower perplexity and high logit deviation).
+
+
+
+
+
+  
+
+
+  
+

--- a/tests/finetuning/README.md
+++ b/tests/finetuning/README.md
@@ -10,13 +10,15 @@ This utility script checks whether a fine-tuned language model using PEFT adapte
 python is_this_a_finetuned_model.py \
   --base_model_path /path/to/base_model \
   --adapter_path /path/to/adapter_checkpoint \
-  --prompt "Add prompt here"
+  --prompt "Add prompt here" \
+  --ppl_threshold 0.01 \
+  --mse_threshold 0.0001
 ```
 
 # Example
 
 ```
-python is_this_a_finetuned_model.py   --base_model_path /home/ar0241/scratch/torchtune_models/Llama-3.2-1B-Instruct   --adapter_path /home/ar0241/scratch/twins/output_p0/epoch_9 --prompt "The output of 0001011 is 1"
+python is_this_a_finetuned_model.py   --base_model_path /home/ar0241/scratch/torchtune_models/Llama-3.2-1B-Instruct   --adapter_path /home/ar0241/scratch/twins/output_p0/epoch_9 --prompt "The output of 0001011 is 1" --ppl_threshold 0.01  --mse_threshold 0.0001
 ```
 
 # Example output 

--- a/tests/finetuning/is_this_a_finetuned_model.py
+++ b/tests/finetuning/is_this_a_finetuned_model.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+import torch
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from peft import PeftModel
+import argparse
+import torch.nn.functional as F
+
+def compute_perplexity(logits, input_ids):
+    shift_logits = logits[..., :-1, :].contiguous()
+    shift_labels = input_ids[..., 1:].contiguous()
+    loss = F.cross_entropy(
+        shift_logits.view(-1, shift_logits.size(-1)),
+        shift_labels.view(-1),
+        ignore_index=-100,
+        reduction='mean'
+    )
+    return torch.exp(loss).item()
+
+def compare_models(base_model_path, adapter_path, prompt):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    tokenizer = AutoTokenizer.from_pretrained(base_model_path)
+    input_ids = tokenizer(prompt, return_tensors="pt").input_ids.to(device)
+
+    # Load base model
+    base_model = AutoModelForCausalLM.from_pretrained(
+        base_model_path,
+        torch_dtype=torch.float16 if torch.cuda.is_available() else torch.float32,
+        device_map="auto"
+    )
+    base_model.eval()
+
+    # Load adapter model
+    adapter_model = AutoModelForCausalLM.from_pretrained(
+        base_model_path,
+        torch_dtype=torch.float16 if torch.cuda.is_available() else torch.float32,
+        device_map="auto"
+    )
+    adapter_model = PeftModel.from_pretrained(adapter_model, adapter_path)
+    adapter_model.eval()
+
+    with torch.no_grad():
+        base_logits = base_model(input_ids).logits
+        adapter_logits = adapter_model(input_ids).logits
+
+    base_ppl = compute_perplexity(base_logits, input_ids)
+    adapter_ppl = compute_perplexity(adapter_logits, input_ids)
+    mse_diff = F.mse_loss(base_logits, adapter_logits).item()
+
+    print("\n=== Model Comparison ===")
+    print(f"Input: {prompt}")
+    print(f"Base Model Perplexity:    {base_ppl:.3f}")
+    print(f"Adapter Model Perplexity: {adapter_ppl:.3f}")
+    print(f"Logit MSE Difference:     {mse_diff:.6f}")
+
+    if abs(base_ppl - adapter_ppl) < 0.01 and mse_diff < 1e-4:
+        print("⚠️  Adapter model appears very similar to base model — fine-tuning might not have taken effect.")
+    else:
+        print("✅ Adapter model is different — likely fine-tuned.")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Compare base vs adapter model using perplexity and logits.")
+    parser.add_argument("--base_model_path", required=True, help="Path to base model")
+    parser.add_argument("--adapter_path", required=True, help="Path to adapter (PEFT) model")
+    parser.add_argument("--prompt", required=True, help="Input string to evaluate")
+    args = parser.parse_args()
+
+    compare_models(args.base_model_path, args.adapter_path, args.prompt)

--- a/tests/finetuning/is_this_a_finetuned_model.py
+++ b/tests/finetuning/is_this_a_finetuned_model.py
@@ -54,7 +54,7 @@ def compare_models(base_model_path, adapter_path, prompt):
     print(f"Adapter Model Perplexity: {adapter_ppl:.3f}")
     print(f"Logit MSE Difference:     {mse_diff:.6f}")
 
-    if abs(base_ppl - adapter_ppl) < 0.01 and mse_diff < 1e-4:
+    if abs(base_ppl - adapter_ppl) < ppl_threshold and mse_diff < mse_threshold:
         print("⚠️  Adapter model appears very similar to base model — fine-tuning might not have taken effect.")
     else:
         print("✅ Adapter model is different — likely fine-tuned.")
@@ -62,6 +62,8 @@ def compare_models(base_model_path, adapter_path, prompt):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Compare base vs adapter model using perplexity and logits.")
     parser.add_argument("--base_model_path", required=True, help="Path to base model")
+    parser.add_argument("--ppl_threshold", required=True, help="Perplexity threshold")
+    parser.add_argument("--mse_threshold", required=True, help="MSE threshold")
     parser.add_argument("--adapter_path", required=True, help="Path to adapter (PEFT) model")
     parser.add_argument("--prompt", required=True, help="Input string to evaluate")
     args = parser.parse_args()


### PR DESCRIPTION
Closes #37 

# Description

Added a script and a readme file detailing the simple finetuning test idea outlined in #37.  This script compares a base language model and its fine-tuned adapter version using a user-specified input prompt. It calculates perplexity for both models to assess differences in next-token prediction confidence and computes the mean squared error (MSE) between their logits to measure internal behavioral divergence. Low MSE and near-identical perplexity indicate that the adapter likely failed to change the model, while significant differences suggest successful fine-tuning. These two metrics together provide an interpretable diagnostic for whether fine-tuning had any real effect on the model for a prompt given by the user.

## New Dependencies

None

# Testing Instructions

Included in the readme file. 
