### PR TITLE
Change some default paths and naming conventions

### DIFF
--- a/generate_slurm_script.py
+++ b/generate_slurm_script.py
@@ -32,9 +32,9 @@ parser.add_argument("--input_formatting", type=str, default="raw", help="Name of
 parser.add_argument("--dataset_filename", type=str, default="tune.json", help="Name of the dataset file (should be in input_dir)")
 parser.add_argument("--dataset_val_filename", type=str, default="val.json", help="Name of the model to use (should be in models_dir)")
 
-parser.add_argument("--output_dir_base", type=str, default="/scratch/gpfs/$USER/", help="Full path to the output file folders (final output folder will be 'zyg_out_' + my_wandb_name within this folder)")
-parser.add_argument("--input_dir_base", type=str, default="/scratch/gpfs/$USER/zyg_in/", help="Full path to the input file folders")
-parser.add_argument("--models_dir", type=str, default="/scratch/gpfs/$USER/torchtune_models/", help="Full path to the model file folders")
+parser.add_argument("--output_dir_base", type=str, default="/scratch/gpfs/MSALGANIK/$USER/", help="Full path to the output file folders (final output folder will be 'ck-out-' + my_wandb_name within this folder)")
+parser.add_argument("--input_dir_base", type=str, default="/scratch/gpfs/MSALGANIK/$USER/zyg_in/", help="Full path to the input file folders")
+parser.add_argument("--models_dir", type=str, default="/scratch/gpfs/MSALGANIK/pretrained-llms/", help="Full path to the model file folders")
 
 # ----- Optional YAML Args -----
 parser.add_argument("--batch_size", type=int, default=4, help="Batch size for training")
@@ -80,7 +80,7 @@ for key, value in vars(args).items():
     elif key == "input_dir_base":
         config["input_dir"] = value + args.input_formatting + ("/" if args.input_formatting else "")
     elif key == "output_dir_base":
-        full_output_dir = value + "zyg_out_" + model_run_name + "/"
+        full_output_dir = value + "ck-out-" + model_run_name + "/"
         config["output_dir"] = full_output_dir
     elif key == "dataset_split_point":
         config["dataset"]["split"] = f"train[:{value}%]"

--- a/templates/finetune_template.yaml
+++ b/templates/finetune_template.yaml
@@ -12,9 +12,9 @@ input_formatting: ""
 dataset_filename: ""
 dataset_val_filename: ""
 
-output_dir: /scratch/gpfs/$USER/zyg_out_${my_wandb_run_name}/
-input_dir: /scratch/gpfs/$USER/zyg_in/${input_formatting}/
-models_dir: /scratch/gpfs/$USER/torchtune_models/
+output_dir: /scratch/gpfs/MSALGANIK/$USER/zyg_out_${my_wandb_run_name}/
+input_dir: /scratch/gpfs/MSALGANIK/$USER/zyg_in/${input_formatting}/
+models_dir: /scratch/gpfs/MSALGANIK/$USER/pretrained-llms/
 
 batch_size: 4
 

--- a/tests/capitalization/README.md
+++ b/tests/capitalization/README.md
@@ -24,8 +24,8 @@ Use `generate_slurm_script.py` with the following arguments:
 ```bash
 python generate_slurm_script.py \
   --my_wandb_project capitalization \
-  --my_wandb_run_name finetune-five \
-  --input_dir_base /home/niznik/scratch/GitHub/predicting-zygosity/tests/capitalization/input/ \
+  --my_wandb_run_name oct1-prompt-1 \
+  --input_dir_base /home/niznik/scratch/GitHub/cruijff-kit/tests/capitalization/input/ \
   --input_formatting '' \
   --dataset_filename finetune_words_5L_4000.json \
   --system_prompt 'Capitalize the given word...' \
@@ -36,8 +36,7 @@ python generate_slurm_script.py \
   --save_adapter_weights_only true \
   --conda_env ttenv-nightly \
   --custom_recipe lora_finetune_single_device_val.py \
-  --account msalganik \
-  --constraint gpu80
+  --account msalganik
 ```
 
 Then, run


### PR DESCRIPTION
Closes #90 

# Description

Quality of life changes as I've been using the code for capitalization tests
* Use the new PI group folder structure
* Change the default prefix for output to `ck-out-` instead of `zyg_out_`
* Fix a reference to old name (predicting-zygosity)
* Add a new suggested default for capitalization run names
* Remove gpu80 requirement (these can be run on MIG partitions or 40 GB A100s just fine since they're small tests)

## New Dependencies

(None)

# Testing Instructions

Just a sanity check
