### PR TITLE
Add stash_adapter_weights option to prevent inspect-ai confusion

### DIFF
--- a/custom_recipes/lora_finetune_single_device_v1.py
+++ b/custom_recipes/lora_finetune_single_device_v1.py
@@ -16,7 +16,7 @@ import torchtune.modules.common_utils as common_utils
 from omegaconf import DictConfig, ListConfig
 
 # !--- cruijff-kit patch ---!
-from custom_recipes.custom_recipe_utils import filter_dataset_by_split
+from custom_recipes.custom_recipe_utils import filter_dataset_by_split, stash_adapter_files
 import os
 # !--- end cruijff-kit patch ---!
 
@@ -169,6 +169,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         self._epochs_to_save = [self.total_epochs - 1] if self._save_last_epoch_only else cfg.get("epochs_to_save", 'all')
         if self._epochs_to_save == 'all':
             self._epochs_to_save = list(range(self.total_epochs))
+        self._stash_adapter_weights = cfg.get("stash_adapter_weights", False)
         # !--- end cruijff-kit patch ---!
         self._gradient_accumulation_steps = cfg.gradient_accumulation_steps
         self._clip_grad_norm = cfg.get("clip_grad_norm", None)
@@ -838,6 +839,11 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                             time.perf_counter() - start_save_checkpoint
                         )
                     )
+
+                    # Stash adapter files if configured (to avoid confusing inspect-ai)
+                    if self._stash_adapter_weights and not self._save_adapter_weights_only:
+                        log.info("Stashing adapter files from merged model checkpoint...")
+                        stash_adapter_files(self._output_dir, curr_epoch, log)
                 else:
                     log.info(f"Skipping checkpoint save for epoch {curr_epoch}...")
                 # !--- end cruijff-kit patch ---!

--- a/generate_slurm_script.py
+++ b/generate_slurm_script.py
@@ -45,6 +45,7 @@ parser.add_argument("--batch_size", type=int, default=4, help="Batch size for tr
 parser.add_argument("--epochs", type=int, default=1, help="Number of epochs to train for")
 parser.add_argument("--save_adapter_weights_only", type=str, default="false", help="Whether to save only the adapter weights (true/false)")
 parser.add_argument("--save_last_epoch_only", type=str, default="false", help="Whether to save only the last epoch (true/false)")
+parser.add_argument("--stash_adapter_weights", type=str, default="false", help="Whether to stash adapter files in subdirectory to avoid confusing inspect-ai (true/false)")
 parser.add_argument("--epochs_to_save", type=parse_epochs, default="all", help="Comma delimited epochs to save checkpoints at; can also be 'all' or 'none'.")
 parser.add_argument("--max_steps_per_epoch", type=int, help="Maximum steps per epoch (useful for debugging)")
 parser.add_argument("--log_every_n_steps", type=int, default=5, help="How often to log (in steps)")
@@ -129,6 +130,8 @@ for key, value in vars(args).items():
         config["save_adapter_weights_only"] = (value == "true")
     elif key == "save_last_epoch_only":
         config["save_last_epoch_only"] = (value == "true")
+    elif key == "stash_adapter_weights":
+        config["stash_adapter_weights"] = (value == "true")
     elif key == "train_on_input":
         config["dataset"]["train_on_input"] = (value == "true")
     # The rest are straightforward

--- a/tests/capitalization/total_config.yaml
+++ b/tests/capitalization/total_config.yaml
@@ -18,6 +18,9 @@ epochs: 1
 log_every_n_steps: 1
 run_val_every_n_steps: 0
 
+# Checkpoint Options
+stash_adapter_weights: 'true'
+
 # Environment Configuration
 conda_env: ttenv
 


### PR DESCRIPTION
Closes #98 

# Description

Added code so that a merged model from torchtune can now stash its adapter weight information in a folder called `adapter_weights` so that inspect-ai doesn't get confused when it sees them and thus refuses to load the model. This is triggered by a new yaml configuration called `stash_adapter_weights` which is false by default. The capitalization test will turn this on and we may consider making it default to true in the future, but let's see where #99 goes first.

## New Dependencies

(None)

# Testing Instructions

Will merge into #94 for full testing but I was able to see the adapter weights move into the correct folder when running tests tonight
