### PR TITLE
Rename conda environment from ttenv to cruijff

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ module load anaconda3/2025.6
 
 All machines with conda and GPU visibility (including della).  
 
-You'll need to pick a name for your environment.  We recommend `ttenv`, but you can adjust as you wish.
+You'll need to pick a name for your environment.  We recommend `cruijff`, but you can adjust as you wish.
 
 ```
-conda create -n ttenv python=3.13
-conda activate ttenv
+conda create -n cruijff python=3.13
+conda activate cruijff
 pip3 install torch --index-url https://download.pytorch.org/whl/cu126
 pip3 install torchao wandb h5py inspect-ai datasets peft
 pip3 install transformers scikit-learn matplotlib # These are only used for eval.py
@@ -134,7 +134,7 @@ Now that we have a yaml/slurm generator, we can leverage that to make the files 
 * Make sure `conda_env` is the same one you created previously
 
 ```
-python setup_finetune.py --my_wandb_project my_first_tests --my_wandb_run_name my_first_test --input_dir_base /scratch/gpfs/$USER/zyg_in/ --input_formatting '' --conda_env ttenv
+python setup_finetune.py --my_wandb_project my_first_tests --my_wandb_run_name my_first_test --input_dir_base /scratch/gpfs/$USER/zyg_in/ --input_formatting '' --conda_env cruijff
 ```
 
 Then run `sbatch finetune.slurm` and watch the magic happen!

--- a/claude.local.md.template
+++ b/claude.local.md.template
@@ -28,7 +28,7 @@ Copy this file to `claude.local.md` in the repository root and customize it with
 - **Constraint**: `<gpu_constraint>` (e.g., `gpu80` for 80GB VRAM GPUs)
 - **Default time**: `0:59:00` (under 1 hour to use test queue)
 - **Default GPUs**: `1`
-- **Default conda environment**: `<env_name>` (e.g., `ck`, `ttenv`)
+- **Default conda environment**: `cruijff` (recommended)
 
 ## Module System
 
@@ -43,18 +43,18 @@ If not using modules, remove this section.
 
 ## Conda Environment Setup
 
-**Environment name**: `<your_env_name>`
+**Environment name**: `cruijff` (recommended)
 
 **Activation**:
 ```bash
 module load anaconda3/2025.6  # If using modules
-conda activate <your_env_name>
+conda activate cruijff
 ```
 
 **Installation** (if creating new environment):
 ```bash
-conda create -n <your_env_name> python=3.13
-conda activate <your_env_name>
+conda create -n cruijff python=3.13
+conda activate cruijff
 pip3 install torch --index-url https://download.pytorch.org/whl/cu126
 pip3 install torchao wandb h5py inspect-ai datasets peft
 pip3 install transformers scikit-learn matplotlib
@@ -99,7 +99,7 @@ gh project item-add <project_number> --owner <your_username> --url https://githu
 ### Environment Setup
 ```bash
 # Activate conda environment
-conda activate <your_env_name>
+conda activate cruijff
 
 # Navigate to cruijff_kit
 cd <path_to_cruijff_kit>
@@ -194,7 +194,7 @@ Here's a complete example for Princeton's Della cluster:
 - **Constraint**: `gpu80`
 - **Default time**: `0:59:00`
 - **Default GPUs**: `1`
-- **Default conda environment**: `ck`
+- **Default conda environment**: `cruijff`
 
 ## Module System
 ```bash

--- a/misc/save_all_hiddens.slurm
+++ b/misc/save_all_hiddens.slurm
@@ -15,7 +15,7 @@
 
 module purge
 module load anaconda3/2024.10
-conda activate ttenv
+conda activate cruijff
 
 python save_all_hiddens.py --config save_all_hiddens.yaml
 

--- a/misc/test-utils.slurm
+++ b/misc/test-utils.slurm
@@ -16,6 +16,6 @@
 
 module purge
 module load anaconda3/2024.10
-conda activate ttenv
+conda activate cruijff
 
 python3 test-utils.py

--- a/tasks/capitalization/templates/finetuning/setup_finetune_json.yaml
+++ b/tasks/capitalization/templates/finetuning/setup_finetune_json.yaml
@@ -26,7 +26,7 @@ run_val_every_n_steps: 0
 stash_adapter_weights: 'true'
 
 # Environment Configuration
-conda_env: ttenv
+conda_env: cruijff
 
 # Custom Recipe
 custom_recipe: cruijff_kit.tools.torchtune.custom_recipes.lora_finetune_single_device_v1

--- a/tasks/capitalization/templates/finetuning/setup_finetune_parquet.yaml
+++ b/tasks/capitalization/templates/finetuning/setup_finetune_parquet.yaml
@@ -23,7 +23,7 @@ run_val_every_n_steps: 0
 stash_adapter_weights: 'true'
 
 # Environment Configuration
-conda_env: ttenv
+conda_env: cruijff
 
 # Custom Recipe
 custom_recipe: cruijff_kit.tools.torchtune.custom_recipes.lora_finetune_single_device_v1

--- a/tests/bit_sequences/README.md
+++ b/tests/bit_sequences/README.md
@@ -63,7 +63,7 @@ python setup_finetune.py \
   --save_adapter_weights_only true \
   --log_every_n_steps 1 \
   --run_val_every_n_steps 4 \
-  --conda_env ttenv-nightly \
+  --conda_env cruijff \
   --custom_recipe lora_finetune_single_device_val.py \
   --account msalganik \
   --constraint gpu80

--- a/tests/predictable_or_not/README.md
+++ b/tests/predictable_or_not/README.md
@@ -43,7 +43,7 @@ python setup_finetune.py \
   --save_adapter_weights_only true \
   --log_every_n_steps 1 \
   --run_val_every_n_steps 4 \
-  --conda_env ttenv-nightly \
+  --conda_env cruijff \
   --custom_recipe lora_finetune_single_device_val.py \
   --account msalganik \
   --constraint gpu80
@@ -70,7 +70,7 @@ python setup_finetune.py \
   --save_adapter_weights_only true \
   --log_every_n_steps 1 \
   --run_val_every_n_steps 4 \
-  --conda_env ttenv-nightly \
+  --conda_env cruijff \
   --custom_recipe lora_finetune_single_device_val.py \
   --account msalganik \
   --constraint gpu80

--- a/tools/torchtune/setup_finetune.py
+++ b/tools/torchtune/setup_finetune.py
@@ -66,7 +66,7 @@ parser.add_argument("--dataset_type", type=str, default="instruct_dataset", help
 # ------ Slurm Args -----
 parser.add_argument("--time", type=str, default="00:15:00", help="Time to run the job (HH:MM:SS)")
 parser.add_argument("--gpus", type=int, default=1, help="Number of GPUs to use")
-parser.add_argument("--conda_env", type=str, default="ttenv", help="Name of the conda environment to use")
+parser.add_argument("--conda_env", type=str, default="cruijff", help="Name of the conda environment to use")
 parser.add_argument("--venv", type=str, default="", help="Path to the virtual environment to use (if not using conda)")
 parser.add_argument("--modules", type=str, default="", help="Modules to load before running the script, separated by commas (e.g. '2024,Python/3.12.3')")
 


### PR DESCRIPTION
Closes #132

# Description

Updated all references to the default conda environment name from `ttenv` to `cruijff` throughout the codebase. This provides better alignment with the project name (cruijff_kit) and improves clarity for new users.

**Changes made:**
- Updated `README.md` installation instructions and usage examples
- Updated `claude.local.md.template` environment configuration template
- Changed default `conda_env` parameter in `tools/torchtune/setup_finetune.py`
- Updated YAML configuration templates in `tasks/capitalization/`
- Updated test instructions in `tests/bit_sequences/` and `tests/predictable_or_not/`
- Updated SLURM scripts in `misc/` directory

The new recommended environment name is now `cruijff` everywhere in the codebase.

## New Dependencies

No changes to dependencies.

# Testing Instructions

1. Verify all documentation references `cruijff` instead of `ttenv`:
   ```bash
   # Should return no results (except in git history)
   grep -r "ttenv" --exclude-dir=.git .
   ```

2. Test that setup scripts use the new default:
   ```bash
   python tools/torchtune/setup_finetune.py --help | grep conda_env
   # Should show default='cruijff'
   ```

3. For existing users: Clone your current environment to `cruijff`:
   ```bash
   conda create --name cruijff --clone <your_old_env>
   conda activate cruijff
   ```