### PR TITLE
Add GitHub CLI installation to developer setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ Finally, install cruijff_kit as a package so you can use cruijff_kit's utilities
 pip install -e .
 ```
 
+If you plan to contribute to cruijff_kit, you'll also need the GitHub CLI for managing issues and pull requests:
+
+```
+conda install -c conda-forge gh
+```
+
 # Downloading a model
 
 Next you'll need a model to finetune and evaluate with. Here's how to get one *the torchtune way*:


### PR DESCRIPTION
Closes #145

## Summary
- Added `conda install -c conda-forge gh` to the developer setup instructions in README.md
- Positioned after `pip install -e .` as the final setup step for contributors
- Clarifies that this is needed for managing issues and PRs

## Test plan
- [x] Verify the installation instructions are clear and follow logically from the previous steps
- [x] Confirm the conda command works in a fresh environment
- [x] Check that the formatting and markdown rendering look correct on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)