### PR TITLE
Update anaconda version in misc/ scripts to 2025.6

### DIFF
--- a/misc/save_all_hiddens.slurm
+++ b/misc/save_all_hiddens.slurm
@@ -14,7 +14,7 @@
 ##SBATCH --constraint=<CONST>
 
 module purge
-module load anaconda3/2024.10
+module load anaconda3/2025.6
 conda activate cruijff
 
 python save_all_hiddens.py --config save_all_hiddens.yaml

--- a/misc/test-utils.slurm
+++ b/misc/test-utils.slurm
@@ -15,7 +15,7 @@
 
 
 module purge
-module load anaconda3/2024.10
+module load anaconda3/2025.6
 conda activate cruijff
 
 python3 test-utils.py


### PR DESCRIPTION
Closes #111

## Summary

Complete the anaconda version update that was partially done in PR #127 (which addressed issue #125). The finetune template and other scripts were updated to `anaconda3/2025.6` in that PR, but these two `misc/` scripts were missed.

## Changes

Updated `anaconda3/2024.10` → `anaconda3/2025.6` in:
- `misc/save_all_hiddens.slurm`
- `misc/test-utils.slurm`

## Context

Issue #111 requested updating to the newer anaconda version. The main template (`tools/torchtune/templates/finetune_template.slurm`) and experiment-specific scripts were updated in PR #127, but the `misc/` directory scripts were overlooked.

This PR completes that work to ensure all SLURM scripts in the repo consistently use `anaconda3/2025.6`.

## Related

- Issue #111 - Original request
- PR #127 - Initial anaconda update (addressed #125)

🤖 Generated with [Claude Code](https://claude.com/claude-code)