### PR TITLE
Fix max_tokens parameter not being passed to generate() solver

### DIFF
--- a/experiments/synthetic_twins/twins_task.py
+++ b/experiments/synthetic_twins/twins_task.py
@@ -38,7 +38,7 @@ def twins_zygosity(
     config_dir: Optional[str] = None,
     dataset_path: Optional[str] = None,
     system_prompt: str = "",
-    temperature: float = 0.0,
+    temperature: float = 1e-7,
     split: str = "test",
     max_tokens: int = 10
 ) -> Task:
@@ -52,7 +52,7 @@ def twins_zygosity(
                    If provided, reads dataset path and system prompt from config.
         dataset_path: Direct path to dataset JSON file. Used if config_dir not provided.
         system_prompt: System message for the model. Overrides config if both provided.
-        temperature: Generation temperature (default: 0.0 for deterministic output).
+        temperature: Generation temperature (default: 1e-7 for near-deterministic output).
         split: Which data split to use - "train", "validation", or "test" (default: "test").
         max_tokens: Maximum tokens to generate (default: 10, sufficient for binary output).
 
@@ -134,10 +134,10 @@ def twins_zygosity(
     solver_chain = chain(
         system_message(system_prompt),
         prompt_template("{prompt}"),
-        generate({
-            "temperature": temperature,
-            "max_tokens": max_tokens
-        })
+        generate(
+            temperature=temperature,
+            max_tokens=max_tokens
+        )
     )
 
     # Configure scorers for binary classification


### PR DESCRIPTION
Closes #187

## Summary
Fixed a bug where `max_tokens` parameter was not being passed to the `generate()` solver, causing models to generate 2048 tokens per sample instead of the configured 10 tokens, resulting in significantly slower evaluations.

## Root Cause
The task was using dict syntax `generate({"max_tokens": 10})` instead of kwargs syntax `generate(max_tokens=10)`. The dict was being passed as the first positional argument (`tool_calls`) instead of being unpacked as kwargs.

**Note:** The mystery of who decided to wrap the parameters in braces - @niznik-dev or Claude - remains unsolved. Both parties hereby plead the fifth. 🤷

## Changes
1. **experiments/synthetic_twins/twins_task.py**:
   - Changed `generate({...})` to `generate(**kwargs)` syntax
   - Changed default temperature from 0.0 to 1e-7 to avoid HuggingFace error requiring temperature > 0 when `do_sample=True`

## Testing
- Verified with 3-sample test: all outputs exactly 10 tokens, completed in 5 seconds
- Running 10K sample evals on base, rank8, and rank128 models
- All three models now run at same speed (~390 samples/min), confirming token limit is properly enforced

## Performance Impact
**Base model** (which was trained to be verbose and explanatory):
- **Before**: 74 samples/min (generating ~2048 tokens per sample with verbose step-by-step explanations)
- **After**: 389 samples/min (generating exactly 10 tokens per sample)
- **Speedup: 5.3x faster**

**Fine-tuned models** (rank8, rank128):
- Already generated shorter responses naturally (~100-200 tokens)
- Still benefit from enforced token limit
- Now run at identical speed to base model (~390 samples/min)

The base model's verbosity made this bug particularly costly - it was taking 4.5 hours for 20K samples vs ~25 minutes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)