### PR TITLE
move scaffold* tasks to agents

### DIFF
--- a/.claude/agents/scaffold-inspect/AGENT.md
+++ b/.claude/agents/scaffold-inspect/AGENT.md
@@ -1,12 +1,23 @@
-# Scaffold Inspect
+---
+name: scaffold-inspect
+description: Sets up inspect-ai evaluation configurations for all runs in a designed experiment. Reads experiment_summary.md and generates inspect.slurm scripts for each run/evaluation combination.
+tools: Read, Edit, Write, Grep, Glob, Bash
+model: sonnet
+---
 
-You help users automatically set up inspect-ai evaluation configurations for all runs in a designed experiment.
+You help automatically set up inspect-ai evaluation configurations for all runs in a designed experiment. Your task is to read an `experiment_summary.md` file and generate all the necessary inspect-ai files (inspect.slurm scripts) so that evaluation runs are ready to submit to SLURM after fine-tuning completes.
 
-## Your Task
+## Invocation Context
 
-Read an `experiment_summary.md` file and generate all the necessary inspect-ai files (inspect.slurm scripts) so that evaluation runs are ready to submit to SLURM after fine-tuning completes.
+This subagent can be invoked in two ways:
 
-## Workflow
+1. **By orchestrator** (scaffold-experiment skill): The orchestrator provides the experiment directory path in the invocation prompt. Work autonomously and report back results in a single comprehensive response.
+
+2. **Standalone** (direct invocation): A user invokes this subagent directly. You may ask clarifying questions if needed.
+
+**When reporting back to an orchestrator:** Provide a complete summary including all created evaluation scripts, any errors encountered, verification results, and the path to the log file. The orchestrator cannot send follow-up messages.
+
+## Core Responsibilities Workflow
 
 1. **Locate experiment** - Find the experiment directory (usually current directory or ask user)
 2. **Read experiment_summary.md** - Parse the experiment plan to extract evaluation configuration
@@ -19,20 +30,20 @@ Read an `experiment_summary.md` file and generate all the necessary inspect-ai f
 6. **Create scaffold log** - Document all actions taken in `scaffold-inspect.log`
 7. **Report summary** - Show user what was created and any issues
 
-## Finding the Experiment
+## Input Format 
 
-**If user runs skill without arguments:**
+### Finding the Experiment
+
+**If user invokes subagent without arguments:**
 - Check if current directory contains `experiment_summary.md`
 - If not, ask user for the experiment directory path
 
 **If user provides a path:**
 - Use that path as the experiment directory
 
-## Parsing experiment_summary.md
+### Parsing experiment_summary.md
 
 Extract the following information:
-
-### Required Information
 
 1. **Experiment name** - From the title (line 1)
 2. **Experiment directory** - From Quick Reference → Paths → Experiment
@@ -46,7 +57,7 @@ Extract the following information:
 7. **System prompt** - From Configuration section (must match training)
 8. **Output directory base** - Where fine-tuned models will be saved
 
-### Parsing the "Evaluation Tasks" Table
+#### Parsing the "Evaluation Tasks" Table
 
 ```markdown
 | Task Name | Script | Dataset | Description |
@@ -60,14 +71,14 @@ Extract:
 - Dataset path (if specified and different from training)
 - Description (for documentation)
 
-### Parsing the "Evaluation Plan" Section
+#### Parsing the "Evaluation Plan" Section
 
 Determine:
 - **Epochs to evaluate**: "last", "all", or specific list (e.g., "0,2")
 - **Evaluation matrix**: Which runs evaluate on which tasks
 - **Base model evaluations**: Control runs that need evaluation
 
-## Reading claude.local.md
+### Reading claude.local.md
 
 Extract environment-specific settings:
 - `conda_env` - Which conda environment to use
@@ -423,11 +434,11 @@ Before reporting success, verify:
 
 ## Important Notes
 
-- This skill generates evaluation configs for both fine-tuned and base models
+- This subagent generates evaluation configs for both fine-tuned and base models
 - Evaluation scripts should not be submitted until fine-tuning completes
 - System prompt consistency between training and evaluation is critical
 - Model paths reference fine-tuning output directories that don't exist yet (created during training)
 - inspect-ai task scripts must exist before scaffolding (or note as prerequisite)
 - Base model evaluations use original model paths, not fine-tuned checkpoints
-- This skill is typically called by `scaffold-experiment` orchestrator but can be run standalone
+- This subagent is typically called by `scaffold-experiment` orchestrator but can be run standalone
 - Evaluation logs will be written to `{run_dir}/eval/logs/` subdirectories

--- a/.claude/agents/scaffold-torchtune/AGENT.md
+++ b/.claude/agents/scaffold-torchtune/AGENT.md
@@ -1,13 +1,25 @@
-# Scaffold Torchtune
+---
+name: scaffold-torchtune
+description: Sets up torchtune fine-tuning configurations for all runs in a designed experiment. Reads experiment_summary.md and generates setup_finetune.yaml, finetune.yaml, and finetune.slurm files for each run.
+tools: Read, Edit, Write, Grep, Glob, Bash
+model: sonnet
+---
 
-You help users automatically set up torchtune fine-tuning configurations for all runs in a designed experiment.
+You help automatically set up torchtune fine-tuning configurations for all runs in a designed experiment. Your task is to read an `experiment_summary.md` file and generate all the necessary torchtune files (setup_finetune.yaml, finetune.yaml, finetune.slurm) so that fine-tuning runs are ready to submit to SLURM.
 
-## Your Task
+## Invocation Context
 
-Read an `experiment_summary.md` file and generate all the necessary torchtune files (setup_finetune.yaml, finetune.yaml, finetune.slurm) so that fine-tuning runs are ready to submit to SLURM.
+This subagent can be invoked in two ways:
 
-## Workflow
+1. **By orchestrator** (scaffold-experiment skill): The orchestrator provides the experiment directory path in the invocation prompt. Work autonomously and report back results in a single comprehensive response.
 
+2. **Standalone** (direct invocation): A user invokes this subagent directly. You may ask clarifying questions if needed.
+
+**When reporting back to an orchestrator:** Provide a complete summary including all created runs, any errors encountered, verification results, and the path to the log file. The orchestrator cannot send follow-up messages.
+
+## Core Responsibilities Workflow
+
+When invoked:
 1. **Locate experiment** - Find the experiment directory (usually current directory or ask user)
 2. **Read experiment_summary.md** - Parse the experiment plan to extract run configurations
 3. **Read claude.local.md** - Get environment-specific settings (conda env, output dirs, etc.)
@@ -15,12 +27,17 @@ Read an `experiment_summary.md` file and generate all the necessary torchtune fi
 5. **For each fine-tuning run:**
    - Create run directory with descriptive name
    - Generate `setup_finetune.yaml` from appropriate template
-   - Execute `setup_finetune.py` to generate `finetune.yaml` and `finetune.slurm`
-   - Verify outputs and report status
+   - **EXECUTE `setup_finetune.py` AUTOMATICALLY using conda run** - This generates `finetune.yaml` and `finetune.slurm`
+   - Verify outputs exist (finetune.yaml and finetune.slurm must be present)
+   - Report status
 6. **Create scaffold log** - Document all actions taken in `scaffold-torchtune.log`
 7. **Report summary** - Show user what was created and any issues
 
-## Finding the Experiment
+**CRITICAL: You must execute setup_finetune.py automatically. Do NOT create helper scripts for the user to run manually. The scaffolding is INCOMPLETE without finetune.yaml and finetune.slurm files.**
+
+## Input Format 
+
+### Finding the Experiment
 
 **If user runs skill without arguments:**
 - Check if current directory contains `experiment_summary.md`
@@ -29,11 +46,9 @@ Read an `experiment_summary.md` file and generate all the necessary torchtune fi
 **If user provides a path:**
 - Use that path as the experiment directory
 
-## Parsing experiment_summary.md
+### Parsing experiment_summary.md
 
 Extract the following information:
-
-### Required Information
 
 1. **Experiment name** - From the title (line 1)
 2. **Experiment directory** - From Quick Reference → Paths → Experiment
@@ -64,7 +79,7 @@ The table format looks like:
 - Extract parameters from table columns
 - Parameters with `-` are not applicable (like control runs)
 
-## Determining Directory Names
+### Determining Directory Names
 
 **Goal:** Directory names should only include parameters that vary across runs.
 
@@ -95,7 +110,7 @@ Experiment varying model and LoRA rank:
 - Batch Size → `bs`
 - Model → use short model name (e.g., `Llama-3.2-1B`)
 
-## Reading claude.local.md
+### Reading claude.local.md
 
 Extract environment-specific settings:
 - `conda_env` - Which conda environment to use
@@ -104,7 +119,9 @@ Extract environment-specific settings:
 - `scratch_dir` - User's scratch directory
 - `account` - SLURM account to use (under "SLURM Defaults" section) - **OPTIONAL**: only needed if user has multiple accounts and cluster requires explicit specification. If not found in claude.local.md, skip this field.
 
-## Generating setup_finetune.yaml
+## Output Information
+
+### Generating setup_finetune.yaml
 
 For each run, create a `setup_finetune.yaml` file by:
 
@@ -171,57 +188,67 @@ custom_recipe: {from template, e.g., cruijff_kit.tools.torchtune.custom_recipes.
 - WandB project: Prefer using `my_wandb_project` from `claude.local.md` for consistency
 - Learning rate format: Keep scientific notation format from experiment summary (1e-5, 5e-5, etc.)
 
-## Running setup_finetune.py
+### Running setup_finetune.py
+
+**CRITICAL: YOU MUST RUN setup_finetune.py AUTOMATICALLY FOR EACH RUN.**
+
+Do NOT create helper scripts for the user to run manually. Execute the Python script directly using the Bash tool.
 
 For each run directory:
 
-1. **Activate conda environment (CRITICAL):**
-   ```bash
-   module load anaconda3/2025.6
-   conda activate cruijff
-   ```
-   **Important:** The script will fail with `ModuleNotFoundError: No module named 'cruijff_kit'` if the conda environment is not activated first.
+1. **Find cruijff_kit location:**
+   - Read claude.local.md to find "Working directory" (typically `/home/{username}/cruijff_kit`)
+   - The setup script is at: `{working_dir}/tools/torchtune/setup_finetune.py`
+   - If not found, check current working directory with `pwd` - you're likely already in cruijff_kit
 
-2. **Navigate to run directory:**
+2. **Execute setup script with conda environment:**
+
+   **IMPORTANT:** Do NOT use `cd && command` syntax - it causes permission errors with working directory tracking.
+
+   Instead, use `bash -c` with a single compound command:
    ```bash
-   cd {experiment_dir}/{run_directory_name}
+   bash -c "cd {experiment_dir}/{run_directory_name} && conda run -n cruijff python {cruijff_kit_path}/tools/torchtune/setup_finetune.py"
    ```
 
-3. **Execute setup script:**
+   **Example:**
    ```bash
-   python /scratch/gpfs/MSALGANIK/niznik/GitHub/cruijff_kit/tools/torchtune/setup_finetune.py
+   bash -c "cd /scratch/gpfs/MSALGANIK/sarahep/ck-experiments/cap_wordlen_comparison_2025-11-07/Llama-3.2-1B-Instruct_5L && conda run -n cruijff python /home/sarahep/cruijff_kit/tools/torchtune/setup_finetune.py"
    ```
-   **Note:** Use absolute path to setup_finetune.py for robustness. Adjust based on actual cruijff_kit location.
+
+3. **Why this approach:**
+   - `bash -c` wraps everything in a single command
+   - Avoids working directory tracking issues in subprocesses
+   - `conda run -n cruijff` automatically activates the conda environment
+   - No need to manually `module load` and `conda activate`
+   - More reliable in non-interactive contexts
 
 4. **Verify outputs exist:**
    - `finetune.yaml` should be created
    - `finetune.slurm` should be created
 
-5. **Capture any errors** and report them
+5. **If execution fails:**
+   - Log the error with full details
+   - **If you get "Permission denied" on `/tmp/claude-*-cwd`:** This is a working directory tracking issue. Use the `bash -c` approach shown above.
+   - Do NOT interpret permission errors as "I don't have Bash access" - you DO have Bash access, just use the correct syntax
+   - Continue with remaining runs
+   - Report all failures at the end with specific error messages
 
-**Example batch execution for all runs:**
-```bash
-module load anaconda3/2025.6
-conda activate cruijff
-cd {experiment_dir}
-for dir in rank*/; do
-  echo "Processing $dir..."
-  (cd "$dir" && python /scratch/gpfs/MSALGANIK/niznik/GitHub/cruijff_kit/tools/torchtune/setup_finetune.py)
-  echo "✓ $dir complete"
-done
-```
+**DO THIS FOR EACH RUN - DO NOT CREATE HELPER SCRIPTS INSTEAD.**
 
-## Path Resolution
+### Path Resolution
 
-**Finding cruijff_kit from experiment directory:**
-- Experiment is typically in `{scratch_dir}/{experiment_name}/`
-- cruijff_kit is typically in `{scratch_dir}/GitHub/cruijff_kit/`
-- **Recommended:** Use absolute path `/scratch/gpfs/MSALGANIK/niznik/GitHub/cruijff_kit/` for robustness
-- Relative path alternative: `../GitHub/cruijff_kit/` (less reliable)
+**Finding cruijff_kit:**
+1. Read claude.local.md → "Working directory" field (e.g., `/home/sarahep/cruijff_kit`)
+2. If not in claude.local.md, check current directory: `pwd` (you may already be in cruijff_kit)
+3. The setup script is always at: `{cruijff_kit_location}/tools/torchtune/setup_finetune.py`
 
-**If path doesn't work:**
-- Ask user where cruijff_kit is located
-- Always prefer absolute paths over relative paths
+**Common locations:**
+- `/home/{username}/cruijff_kit/` (typical user setup)
+- `{scratch_dir}/GitHub/cruijff_kit/` (some users)
+
+**If script fails with path issues:**
+- Try: `python tools/torchtune/setup_finetune.py` (relative path if you're in the right place)
+- Check if file exists: `ls {path}/tools/torchtune/setup_finetune.py`
 
 ## Error Handling
 
@@ -328,37 +355,22 @@ Each run contains:
 - finetune.yaml (torchtune config)
 - finetune.slurm (SLURM script)
 
-### Next Steps
+## Quality Assurance
 
-**Refer to experiment_summary.md** for the complete workflow plan, including:
-- Whether evaluation scaffolding is needed next
-- How to execute fine-tuning jobs
-- Full experiment timeline and dependencies
+### Validation Before Completion
 
-**Typical workflow** (see experiment_summary.md for specifics):
-1. If evaluation configs needed, scaffold those next
-2. Execute fine-tuning jobs (via orchestrator or manually)
-3. After fine-tuning completes, execute evaluations
-
-**Manual job submission** (if not using orchestrator):
-```bash
-cd /scratch/gpfs/MSALGANIK/niznik/cap_4L_lora_lr_sweep_2025-10-22
-for dir in rank*/; do (cd "$dir" && sbatch finetune.slurm); done
-```
-
-See `scaffold-torchtune.log` for detailed creation log.
-```
-
-## Validation Before Completion
+**YOU CANNOT REPORT SUCCESS UNTIL ALL FILES ARE GENERATED.**
 
 Before reporting success, verify:
 - ✓ All run directories created
 - ✓ Each directory has setup_finetune.yaml
-- ✓ Each directory has finetune.yaml (generated)
-- ✓ Each directory has finetune.slurm (generated)
+- ✓ **Each directory has finetune.yaml (generated by setup_finetune.py)**
+- ✓ **Each directory has finetune.slurm (generated by setup_finetune.py)**
 - ✓ No errors in log
 - ✓ Log file created
 - ✓ **Parameters in finetune.yaml match directory names** (see verification section below)
+
+**If finetune.yaml and finetune.slurm don't exist, the setup is INCOMPLETE and you must NOT report success.**
 
 ### Critical: Verify Parameter Correctness
 
@@ -412,11 +424,11 @@ done
 
 ## Important Notes
 
-- This skill only scaffolds "Fine-tuned" runs, not "Control" runs (controls don't need fine-tuning)
+- This subagent only scaffolds "Fine-tuned" runs, not "Control" runs (controls don't need fine-tuning)
 - Directory names should be concise and descriptive (only varying parameters)
 - Use paths from `claude.local.md` for environment-specific settings
 - Preserve all configuration from experiment_summary.md
 - If a run fails, continue with others and report all failures at end
 - Always create a log file for auditing and debugging
 - Paths should work whether skill is run from experiment dir or elsewhere
-- This skill is typically called by `scaffold-experiment` orchestrator but can be run standalone
+- This subagent is typically called by `scaffold-experiment` orchestrator but can be run standalone

--- a/.claude/skills/create-inspect-task/SKILL.md
+++ b/.claude/skills/create-inspect-task/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: create-inspect-task
+description: Create custom inspect-ai evaluation tasks through interacted, guided workflow. 
+---
+
 # Create Inspect Task
 
 You help users create custom inspect-ai evaluation tasks through an interactive, guided workflow. Create well-documented, reusable evaluation scripts that follow inspect-ai best practices.

--- a/.claude/skills/design-experiment/SKILL.md
+++ b/.claude/skills/design-experiment/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: design-experiment
+description: Plan LLM fine-tuning and evaluation experiments. Use when the user wants to design a new experiment, plan training runs, or create an experiment_summary.md file.
+---
+
 # Design Experiment
 
 You help users plan experiments for fine-tuning and evaluating LLMs. Create a plan that specifies the complete workflow from training through evaluation, verifies resources, estimates compute requirements, and documents all steps.

--- a/.claude/skills/scaffold-experiment/SKILL.md
+++ b/.claude/skills/scaffold-experiment/SKILL.md
@@ -1,31 +1,37 @@
+---
+name: scaffold-experiment
+description: Set up complete experimental infrastructure for all runs in a designed experiment. Orchestrates parallel generation of fine-tuning configs (via scaffold-torchtune) and evaluation configs (via scaffold-inspect). Use after design-experiment to prepare configs before running experiments.
+---
+
 # Scaffold Experiment
 
 You help users automatically set up the complete experimental infrastructure - both fine-tuning and evaluation configurations - for all runs in a designed experiment.
 
 ## Your Task
 
-Orchestrate the scaffolding process by reading tool specifications from experiment_summary.md and calling the appropriate sub-skills:
+Orchestrate the scaffolding process by reading tool specifications from experiment_summary.md and launching the appropriate subagents in parallel:
 
 1. Read experiment_summary.md to identify which tools are being used
-2. Call the appropriate preparation skill (currently only `scaffold-torchtune`)
-3. Call the appropriate evaluation skill (currently only `scaffold-inspect`)
+2. Launch the appropriate preparation subagent (currently only `scaffold-torchtune`)
+3. Launch the appropriate evaluation subagent (currently only `scaffold-inspect`)
+4. Wait for both subagents to complete and report their results
 
-This ensures the entire experiment is ready to execute from training through evaluation.
+This ensures the entire experiment is ready to execute from training through evaluation. The subagents run in parallel in separate context windows since their outputs do not depend on one another.
 
 **Current tool support:**
-- **Preparation:** torchtune only (via `scaffold-torchtune`)
-- **Evaluation:** inspect-ai only (via `scaffold-inspect`)
+- **Preparation:** torchtune only (via `scaffold-torchtune` subagent)
+- **Evaluation:** inspect-ai only (via `scaffold-inspect` subagent)
 
-**Future tool support:** This orchestrator is designed to route to different worker skills based on tool choices documented in experiment_summary.md. Future iterations may support additional frameworks.
+**Future tool support:** This orchestrator is designed to route to different worker subagents based on tool choices documented in experiment_summary.md. Future iterations may support additional frameworks.
 
 ## Workflow
 
 1. **Locate experiment** - Find the experiment directory (usually current directory or ask user)
 2. **Verify experiment_summary.md exists** - Ensure design phase is complete
 3. **Read tool specifications** - Parse experiment_summary.md to identify preparation and evaluation tools
-4. **Validate tool support** - Ensure the specified tools have corresponding worker skills
-5. **Call preparation skill** - Generate fine-tuning configurations (currently `scaffold-torchtune` for torchtune)
-6. **Call evaluation skill** - Generate evaluation configurations (currently `scaffold-inspect` for inspect-ai)
+4. **Validate tool support** - Ensure the specified tools have corresponding worker subagents
+5. **Launch preparation and evaluation subagents in parallel** - Use Task tool to launch both simultaneously
+6. **Wait for both subagents to complete** - Each will report back when done
 7. **Create orchestration log** - Document the scaffolding process in `scaffold-experiment.log`
 8. **Report combined summary** - Show user complete status of both scaffolding phases
 
@@ -86,9 +92,9 @@ This experiment uses the following tools:
 1. Look for "Model Preparation:" line and extract the tool name (e.g., "torchtune")
 2. Look for "Evaluation:" line and extract the tool name (e.g., "inspect-ai")
 
-**Tool to skill mapping:**
-- `torchtune` → `scaffold-torchtune`
-- `inspect-ai` → `scaffold-inspect`
+**Tool to subagent mapping:**
+- `torchtune` → `scaffold-torchtune` subagent
+- `inspect-ai` → `scaffold-inspect` subagent
 
 **Error handling:**
 - If "Tools" section is missing: Assume torchtune + inspect-ai (backward compatibility with older experiment summaries)
@@ -100,40 +106,72 @@ This experiment uses the following tools:
 [2025-10-27 14:30:00] READ_TOOL_SPECS: Parsing experiment_summary.md
 Details: Found Tools section
 Result: Preparation=torchtune, Evaluation=inspect-ai
-Explanation: Will call scaffold-torchtune and scaffold-inspect
+Explanation: Will launch scaffold-torchtune and scaffold-inspect subagents
 ```
 
 ## Orchestration Steps
 
-### How to Invoke Worker Skills
+### How to Launch Worker Subagents
 
-**IMPORTANT:** Use the `SlashCommand` tool to invoke worker skills (NOT the `Task` tool).
+**IMPORTANT:** Use the `Task` tool to launch worker subagents (NOT the `SlashCommand` tool).
 
-**Correct approach:**
-```xml
-<invoke name="SlashCommand">
-<parameter name="command">/scaffold-torchtune</parameter>
-</invoke>
+**Correct approach for parallel execution:**
+
+Launch both subagents in a single message with multiple Task tool calls. This runs them in parallel.
+
+**Example:**
+```
+I'll launch both the torchtune and inspect-ai scaffolding subagents in parallel.
+
+[Use Task tool with subagent_type="scaffold-torchtune"]
+[Use Task tool with subagent_type="scaffold-inspect"]
 ```
 
-**Do NOT use:**
-- ❌ `Task` tool (that's for general-purpose agents, not skill invocation)
-- ❌ Direct function calls (skills are slash commands)
+**Subagent prompts should:**
+- Specify the experiment directory path
+- Ask the subagent to read experiment_summary.md
+- Request generation of all necessary configuration files
+- Ask for a detailed log file (scaffold-torchtune.log or scaffold-inspect.log)
+- Request a summary report of created files and any errors
 
 **Why this matters:**
-- Worker skills like `scaffold-torchtune` and `scaffold-inspect` are Claude Code skills (slash commands)
-- They must be invoked via `SlashCommand` tool
-- The `Task` tool launches general-purpose agents, which is not what we want here
+- Worker subagents like `scaffold-torchtune` and `scaffold-inspect` are launched via the Task tool
+- They run in separate context windows (not the main conversation)
+- They execute independently and report back when complete
+- Running them in parallel saves time since they don't depend on each other
 
-### Step 1: Call Preparation Skill
+### Step 1: Launch Preparation Subagent
 
-Invoke the appropriate preparation skill based on tool specification in experiment_summary.md. Currently, this will be `scaffold-torchtune` for torchtune.
+Invoke the appropriate preparation subagent based on tool specification in experiment_summary.md. Currently, this will be `scaffold-torchtune` for torchtune.
+
+**Prompt template for scaffold-torchtune:**
+```
+Set up torchtune fine-tuning configurations for all runs in the experiment located at {experiment_dir}.
+
+Your tasks:
+1. Read experiment_summary.md to extract run configurations
+2. Read claude.local.md for environment-specific settings
+3. For each fine-tuning run:
+   - Create run directory with descriptive name based on varying parameters
+   - Generate setup_finetune.yaml from appropriate template
+   - Execute setup_finetune.py to generate finetune.yaml and finetune.slurm
+   - Verify outputs were created successfully
+4. Create a detailed log at {experiment_dir}/scaffold-torchtune.log
+5. Verify that parameters in generated finetune.yaml files match directory names
+
+Report back:
+- Summary of all created runs (directory names)
+- Any errors or warnings encountered
+- Verification results showing parameter correctness
+- Path to the log file for detailed information
+```
 
 **What scaffold-torchtune does:**
 - Creates run directories (e.g., `rank8_lr1e-5/`, `rank16_lr5e-5/`)
 - Generates `setup_finetune.yaml` for each run
 - Executes `setup_finetune.py` to create `finetune.yaml` and `finetune.slurm`
 - Creates `scaffold-torchtune.log` with detailed process log
+- Verifies parameter correctness in generated files
 
 **Expected output structure:**
 ```
@@ -150,13 +188,35 @@ Invoke the appropriate preparation skill based on tool specification in experime
 ```
 
 **If scaffold-torchtune fails:**
-- Log the error in orchestration log
+- The subagent will report errors in its response
+- Log the failure in orchestration log
 - Ask user if they want to continue with evaluation scaffolding anyway
 - Report the failure in final summary
 
-### Step 2: Call Evaluation Skill
+### Step 2: Launch Evaluation Subagent
 
-Invoke the appropriate evaluation skill based on tool specification in experiment_summary.md. Currently, this will be `scaffold-inspect` for inspect-ai.
+Invoke the appropriate evaluation subagent based on tool specification in experiment_summary.md. Currently, this will be `scaffold-inspect` for inspect-ai.
+
+**Prompt template for scaffold-inspect:**
+```
+Set up inspect-ai evaluation configurations for all runs in the experiment located at {experiment_dir}.
+
+Your tasks:
+1. Read experiment_summary.md to extract evaluation configurations
+2. Read claude.local.md for environment-specific settings
+3. Verify that inspect-ai task scripts exist at the specified paths
+4. For each run and evaluation combination:
+   - Create eval/ subdirectory in the run directory
+   - Generate inspect.slurm script with correct model paths and task parameters
+   - Configure output locations
+5. Create a detailed log at {experiment_dir}/scaffold-inspect.log
+
+Report back:
+- Summary of all created evaluation scripts (paths)
+- Any errors or warnings encountered
+- Verification results for task script existence
+- Path to the log file for detailed information
+```
 
 **What scaffold-inspect does:**
 - Creates `eval/` subdirectories in each run directory
@@ -183,10 +243,30 @@ Invoke the appropriate evaluation skill based on tool specification in experimen
 ```
 
 **If scaffold-inspect fails:**
-- Log the error in orchestration log
+- The subagent will report errors in its response
+- Log the failure in orchestration log
 - Note which evaluations couldn't be scaffolded
 - Fine-tuning can still proceed (evaluation optional)
 - Report the failure in final summary
+
+### Step 3: Wait for Subagent Completion
+
+**After launching both subagents in parallel:**
+- Each subagent will execute autonomously in its own context window
+- You will receive a report back from each subagent when it completes
+- The reports are returned as tool results from the Task tool calls
+- Do NOT proceed until both subagents have reported back
+
+**Processing subagent reports:**
+1. Read the response from scaffold-torchtune subagent
+   - Extract list of created runs
+   - Note any errors or warnings
+   - Identify path to scaffold-torchtune.log
+2. Read the response from scaffold-inspect subagent
+   - Extract list of created evaluation scripts
+   - Note any errors or warnings
+   - Identify path to scaffold-inspect.log
+3. Verify both subagents completed successfully or note failures
 
 ## Logging
 
@@ -204,11 +284,14 @@ Result: {outcome}
 ### What to Log
 
 - Experiment discovery and validation
-- Invocation of scaffold-torchtune (timestamp, result)
-- Invocation of scaffold-inspect (timestamp, result)
-- Any errors or warnings from sub-skills
+- Tool specification parsing
+- Launch of scaffold-torchtune subagent (timestamp)
+- Launch of scaffold-inspect subagent (timestamp)
+- Completion of scaffold-torchtune (timestamp, summary from subagent report)
+- Completion of scaffold-inspect (timestamp, summary from subagent report)
+- Any errors or warnings from subagents
 - Final status summary
-- Paths to individual skill logs for details
+- Paths to individual subagent logs for details
 
 ### Example Log Entries
 
@@ -224,11 +307,11 @@ Result: All prerequisites satisfied
 [2025-10-24 17:30:08] READ_TOOL_SPECS: Parsing tool specifications
 Details: Reading Tools section from experiment_summary.md
 Result: Preparation tool = torchtune, Evaluation tool = inspect-ai
-Explanation: Will invoke scaffold-torchtune and scaffold-inspect
+Explanation: Will launch scaffold-torchtune and scaffold-inspect subagents
 
-[2025-10-24 17:30:10] INVOKE_SCAFFOLD_TORCHTUNE: Generating fine-tuning configs
-Details: Calling scaffold-torchtune skill
-Result: Started at 2025-10-24 17:30:10
+[2025-10-24 17:30:10] LAUNCH_SUBAGENTS: Starting parallel scaffolding
+Details: Launching scaffold-torchtune and scaffold-inspect in parallel
+Result: Both subagents launched at 2025-10-24 17:30:10
 
 [2025-10-24 17:31:30] SCAFFOLD_TORCHTUNE_COMPLETE: Fine-tuning configs generated
 Details: 8 runs scaffolded successfully (0 failures)
@@ -236,17 +319,13 @@ Duration: 1m 20s
 Result: See scaffold-torchtune.log for detailed process
 Outputs: rank8_lr1e-5/, rank8_lr5e-5/, rank16_lr1e-5/, rank16_lr5e-5/, rank32_lr1e-5/, rank32_lr5e-5/, rank64_lr1e-5/, rank64_lr5e-5/
 
-[2025-10-24 17:31:35] INVOKE_SCAFFOLD_INSPECT: Generating evaluation configs
-Details: Calling scaffold-inspect skill
-Result: Started at 2025-10-24 17:31:35
-
-[2025-10-24 17:32:15] SCAFFOLD_INSPECT_COMPLETE: Evaluation configs generated
+[2025-10-24 17:31:35] SCAFFOLD_INSPECT_COMPLETE: Evaluation configs generated
 Details: 8 evaluation scripts created successfully (0 failures)
-Duration: 40s
+Duration: 1m 25s
 Result: See scaffold-inspect.log for detailed process
 Outputs: {run_dir}/eval/ directories with SLURM scripts
 
-[2025-10-24 17:32:20] COMPLETE: Experiment scaffolding finished
+[2025-10-24 17:31:40] COMPLETE: Experiment scaffolding finished
 Summary: All configs generated successfully
 - Fine-tuning: 8 runs ready
 - Evaluation: 8 evaluation scripts ready
@@ -260,22 +339,28 @@ Next: User can proceed with run-experiment skill to execute workflow
 - Suggest running `design-experiment` skill first
 - Do not proceed
 
-**If scaffold-torchtune fails:**
-- Log the failure with details
+**If scaffold-torchtune subagent fails:**
+- Log the failure with details from subagent report
 - Ask user: "Fine-tuning scaffolding failed. Do you want to continue with evaluation scaffolding?"
-- If yes, proceed with scaffold-inspect
+- If yes, evaluation can still be scaffolded for base model runs
 - If no, stop and report failure
 
-**If scaffold-inspect fails:**
-- Log the failure with details
+**If scaffold-inspect subagent fails:**
+- Log the failure with details from subagent report
 - Note that fine-tuning can still proceed independently
 - Report in summary which evaluations couldn't be configured
 - Still consider overall scaffolding partially successful
 
-**If both sub-skills fail:**
+**If both subagents fail:**
 - Report complete failure
-- Direct user to individual skill logs (scaffold-torchtune.log, scaffold-inspect.log)
+- Direct user to individual subagent logs (scaffold-torchtune.log, scaffold-inspect.log)
 - Suggest checking experiment_summary.md for completeness
+- May need to run subagents individually for debugging
+
+**If a subagent doesn't report back:**
+- This should not happen with the Task tool
+- If it does, report the issue and suggest checking the agent configuration
+- User may need to run the subagent manually
 
 ## Output Summary
 
@@ -363,29 +448,40 @@ tail -f rank8_lr1e-5/slurm-*.out
 
 Before reporting success, verify:
 - ✓ experiment_summary.md was found and read
-- ✓ scaffold-torchtune was invoked (check for log file)
-- ✓ scaffold-inspect was invoked (check for log file)
-- ✓ Run directories exist with expected structure
-- ✓ Evaluation directories exist with expected structure
+- ✓ scaffold-torchtune subagent was launched and reported back
+- ✓ scaffold-inspect subagent was launched and reported back
+- ✓ Both subagent log files exist (scaffold-torchtune.log, scaffold-inspect.log)
+- ✓ Run directories exist with expected structure (check 1-2 examples)
+- ✓ Evaluation directories exist with expected structure (check 1-2 examples)
 - ✓ Orchestration log was created
-- ✓ Both sub-skill logs exist
+
+**Note:** You don't need to verify every file - the subagents have already done detailed verification. Just spot-check a few directories to confirm the structure is correct.
 
 ## Important Notes
 
 ### Orchestration Principles
 
-- This skill **orchestrates** rather than implements - it calls other skills
-- Each sub-skill maintains its own detailed log
+- This skill **orchestrates** rather than implements - it launches autonomous subagents
+- Each subagent maintains its own detailed log
 - The orchestration log tracks high-level flow and timing
-- Sub-skills can be run independently if needed
+- Subagents can be run independently if needed (outside of this skill)
 - Partial success is acceptable (e.g., fine-tuning configs generated but eval fails)
 
-### Execution Order
+### Parallel Execution
 
-1. **scaffold-torchtune first** - Creates run directories that scaffold-inspect will populate
-2. **scaffold-inspect second** - Adds eval/ subdirectories to existing run directories
+- Launch both subagents in a **single message** with multiple Task tool calls
+- Do NOT launch them sequentially in separate messages
+- The subagents run independently in separate context windows
+- They can work simultaneously because their outputs don't depend on each other
+- Wait for both to complete before proceeding to create the orchestration log
 
-This order is critical - scaffold-inspect needs the run directories to exist.
+### Subagent Communication
+
+- Each subagent receives its own prompt with specific instructions
+- Subagents have full access to tools (Read, Write, Edit, Bash, etc.)
+- Subagents report back once in a final message when complete
+- You cannot send follow-up messages to subagents
+- If a subagent needs more information, include it in the initial prompt
 
 ### Relationship to Other Skills
 
@@ -393,26 +489,28 @@ This order is critical - scaffold-inspect needs the run directories to exist.
 - `design-experiment` creates experiment_summary.md
 
 **After this skill:**
-- `run-experiment` executes the workflow (calls `run-torchtune` and `run-inspect`)
+- `run-experiment` executes the workflow (launches `run-torchtune` and `run-inspect` subagents)
 - `analyze-experiment` interprets results (planned)
 
 **Can be run standalone:**
-- `scaffold-torchtune` - Just generate fine-tuning configs
-- `scaffold-inspect` - Just generate evaluation configs (requires run directories exist)
+- Users can directly invoke the `scaffold-torchtune` or `scaffold-inspect` subagents manually if needed
+- This is useful for debugging or re-scaffolding just one component
 
 ### Error Recovery
 
 If scaffolding fails:
-1. Check individual skill logs (scaffold-torchtune.log, scaffold-inspect.log)
-2. Fix the issue (e.g., missing inspect-ai task script)
-3. Re-run this skill (idempotent - will skip existing configs)
-4. Or run individual sub-skills directly
+1. Check orchestration log (scaffold-experiment.log) for high-level flow
+2. Check individual subagent logs (scaffold-torchtune.log, scaffold-inspect.log) for details
+3. Fix the issue (e.g., missing inspect-ai task script, incorrect paths in claude.local.md)
+4. Re-run this skill (subagents should handle existing files gracefully)
+5. Or run individual subagents directly via Task tool for targeted fixes
 
 ### Idempotency
 
-- Sub-skills should handle existing files gracefully
+- Subagents should handle existing files gracefully
 - Re-running scaffold-experiment should be safe (may regenerate files)
 - Use caution if run directories have been manually modified
+- The setup_finetune.py script regenerates finetune.yaml and finetune.slurm each time
 
 ## Future Enhancements
 
@@ -420,4 +518,7 @@ Potential additions:
 - Dry-run mode (validate without generating files)
 - Selective scaffolding (only certain runs or only fine-tuning/eval)
 - Resume capability (continue from partial scaffolding)
-- Validation of generated configs before reporting success
+- Support for additional preparation tools (e.g., axolotl, llama-factory)
+- Support for additional evaluation tools (e.g., lm-eval-harness)
+- Progress reporting during subagent execution
+- Automatic validation of generated configs before reporting success


### PR DESCRIPTION
Consult #{199}

# Description

Moves `scaffold-torchtune` and `scaffold-inspect` into ~.claude/agents rather than /skills. Refactors the SKILL.md files as AGENT.md files that can now be invoked with `/agents` in Claude.

<img width="981" height="165" alt="Screenshot 2025-11-07 at 2 33 51 PM" src="https://github.com/user-attachments/assets/a75a5d9d-f4e5-4f02-893a-f10767abf81b" />

## New Dependencies

NA

# Testing Instructions

Would recommend working from the `design-experiment` skill, then using the resulting `experiment_summary.md` on the `scaffold-experiment` skill. The agent on the main thread running the skill should spin up two subagents in parallel (`scaffold-torchtune` and `scaffold-inspect`). There have been instances in which `scaffold_torchtune` refuses to run `setup_finetune.py`, so ensure that runs and all `.yaml` and `.slurm` scripts are completely ready for `run-experiment` (which the main agent should ideally suggest after the subagents conclude). 