### PR TITLE
Add experiment_name to scaffold-torchtune agent

### DIFF
--- a/.claude/agents/scaffold-torchtune.md
+++ b/.claude/agents/scaffold-torchtune.md
@@ -169,6 +169,7 @@ stash_adapter_weights: 'true'  # From template default
 
 # Output configuration
 output_dir_base: {from claude.local.md}
+experiment_name: {from experiment_summary.md title/line 1}
 conda_env: {from claude.local.md}
 
 # SLURM configuration (optional - only if specified in claude.local.md)
@@ -187,6 +188,7 @@ custom_recipe: {from template, e.g., cruijff_kit.tools.torchtune.custom_recipes.
 - Use absolute paths for robustness (e.g., `/scratch/gpfs/MSALGANIK/niznik/GitHub/cruijff_kit/...`) rather than relative paths
 - WandB project: Prefer using `my_wandb_project` from `claude.local.md` for consistency
 - Learning rate format: Keep scientific notation format from experiment summary (1e-5, 5e-5, etc.)
+- Experiment name: This groups outputs under `{output_dir_base}{experiment_name}/ck-out-{run_name}/` for better organization. Without it, outputs go directly to `{output_dir_base}ck-out-{run_name}/`
 
 ### Running setup_finetune.py
 


### PR DESCRIPTION
Closes #185

## Summary

- Added `experiment_name` field to the `setup_finetune.yaml` template in the scaffold-torchtune agent
- Added documentation explaining how `experiment_name` controls output directory organization
- Outputs now properly group under `{output_dir_base}{experiment_name}/ck-out-{run_name}/` instead of `{output_dir_base}ck-out-{run_name}/`

## Changes

**Modified `.claude/agents/scaffold-torchtune.md`:**
- Line 172: Added `experiment_name: {from experiment_summary.md title/line 1}` to template
- Line 191: Added note explaining experiment_name's role in output organization

## Impact

This fixes the bug where scaffolded fine-tuning runs would create outputs at the wrong directory level, making experiment organization messy. The `setup_finetune.py` script already supported this parameter but the agent wasn't populating it.

## Testing

Can be verified by running scaffold-experiment on any new experiment and checking that generated `setup_finetune.yaml` files contain the `experiment_name` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)