### PR TITLE
Add pre-PR review checklist for documentation sync

### DIFF
--- a/.claude/PR_CHECKLIST.md
+++ b/.claude/PR_CHECKLIST.md
@@ -1,0 +1,55 @@
+# Pre-PR Checklist
+
+This checklist helps ensure nothing gets forgotten before creating a pull request. Not mandatory, just helpful reminders for common oversights.
+
+## Documentation Updates
+
+Consider whether these files need updates based on your changes:
+
+### Core Documentation
+- [ ] **README.md** - Public-facing features, installation, quick start
+- [ ] **ARCHITECTURE.md** - System design, data flow, major architectural decisions
+- [ ] **SKILLS_ARCHITECTURE_SUMMARY.md** - Skill relationships and workflows
+- [ ] **CLAUDE.md** - Workflow instructions, terminology, git process
+
+### Component Documentation
+- [ ] **Skill docs** (`.claude/skills/*/`) - If you modified skill behavior or added submodules
+- [ ] **Experiment READMEs** (`experiments/*/README.md`) - If you changed experiment structure
+- [ ] **Tool docs** (`tools/*/`) - If you modified torchtune recipes, inspect tasks, etc.
+
+### Common Scenarios
+- **Added/removed a skill?** → Update SKILLS_ARCHITECTURE_SUMMARY.md
+- **Changed config structure?** → Update ARCHITECTURE.md and relevant READMEs
+- **Modified workflow?** → Update CLAUDE.md and skill documentation
+- **Added CLI commands?** → Update README.md usage section
+
+## Code Quality
+
+- [ ] **Remove debug code** - No leftover print statements, breakpoints, or test data
+- [ ] **Clean up TODOs** - Either implement them or create issues for them
+- [ ] **Check imports** - Remove unused imports, verify relative imports are correct
+- [ ] **Verify paths** - Ensure no hardcoded paths (use claude.local.md patterns)
+
+## Testing
+
+- [ ] **Run relevant tests** - If tests exist for modified code, run them
+- [ ] **Manual testing** - For skills/workflows, try a quick end-to-end test
+- [ ] **Check dependencies** - If you added imports, note them in PR description
+
+## Git Hygiene
+
+- [ ] **Branch up to date?** - `git fetch origin main && git log HEAD..origin/main` (should be empty)
+- [ ] **Clean commit history?** - Commits are logical and well-described
+- [ ] **No merge conflicts?** - Rebase/merge main if needed
+
+## When to Consult This Checklist
+
+**Claude Code should reference this checklist when:**
+- User asks to create a PR
+- User says "ready to merge" or similar
+- Before running git commit for PR-sized changes
+
+**Users should reference this checklist when:**
+- About to create a PR manually
+- Reviewing Claude's PR draft before submission
+- Want to double-check nothing was forgotten

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,8 @@ Follow the PR template at `.github/pull_request_template.md`:
 - Include Description, New Dependencies, and Testing Instructions sections
 - The "Closes #N" syntax automatically links and closes the issue when the PR is merged
 
+**Before creating a PR**, consult `.claude/PR_CHECKLIST.md` for a helpful reminder list of common things to verify (documentation updates, testing, git hygiene, etc.). This checklist is not mandatory but helps catch oversights.
+
 ### Commit Messages
 
 Follow this format for commits:


### PR DESCRIPTION
Closes #135

## Summary

Created a practical pre-PR checklist to help catch common oversights when preparing pull requests, particularly around documentation updates.

**New file: `.claude/PR_CHECKLIST.md`**
- Documentation update reminders (README, ARCHITECTURE, skill docs, component READMEs)
- Code quality checks (debug code, TODOs, imports, paths)
- Testing reminders
- Git hygiene checks
- Scenario-based guidance ("Added a skill? → Update SKILLS_ARCHITECTURE_SUMMARY.md")

**Updated: `CLAUDE.md`**
- Added reference to checklist in "Pull Request Format" section
- Makes it clear the checklist is helpful but not mandatory

## Design Decisions

- **Not mandatory** - No GitHub enforcement, just helpful reminders
- **Scenario-based** - Maps common changes to relevant docs
- **Practical** - Based on things we actually forget
- **For both humans and Claude** - Clear guidance on when to consult it

## New Dependencies

None

## Testing Instructions

1. Read through `.claude/PR_CHECKLIST.md` and verify items make sense
2. Check that CLAUDE.md properly references the checklist
3. Next time creating a PR, consult the checklist to see if it's helpful

🤖 Generated with [Claude Code](https://claude.com/claude-code)