### PR TITLE
Add Llama-3.1-8B-Instruct support

### DIFF
--- a/tests/integration/test_setup_finetune_slurm.py
+++ b/tests/integration/test_setup_finetune_slurm.py
@@ -101,6 +101,22 @@ class TestModelAwareSlurmResources:
         # (it uses constraint=gpu80 instead)
         assert "#SBATCH --partition=nomig" not in slurm
 
+    def test_8b_default_memory(self, temp_run_dir):
+        """8B model defaults to 80G memory."""
+        slurm = run_setup_finetune(temp_run_dir, "Llama-3.1-8B-Instruct")
+        assert "#SBATCH --mem=80G" in slurm
+
+    def test_8b_gpu80_constraint(self, temp_run_dir):
+        """8B model requires gpu80 constraint."""
+        slurm = run_setup_finetune(temp_run_dir, "Llama-3.1-8B-Instruct")
+        assert "#SBATCH --constraint=gpu80" in slurm
+
+    def test_8b_single_gpu(self, temp_run_dir):
+        """8B model uses single GPU."""
+        slurm = run_setup_finetune(temp_run_dir, "Llama-3.1-8B-Instruct")
+        assert "#SBATCH --gres=gpu:1" in slurm
+        assert "lora_finetune_single_device" in slurm
+
     def test_70b_default_memory(self, temp_run_dir):
         """70B model defaults to 320G memory (4 GPUs × 80GB)."""
         slurm = run_setup_finetune(temp_run_dir, "Llama-3.3-70B-Instruct")
@@ -207,6 +223,11 @@ class TestCpuAllocation:
     def test_3b_default_cpus(self, temp_run_dir):
         """3B model defaults to 4 CPUs."""
         slurm = run_setup_finetune(temp_run_dir, "Llama-3.2-3B-Instruct")
+        assert "#SBATCH --cpus-per-task=4" in slurm
+
+    def test_8b_default_cpus(self, temp_run_dir):
+        """8B model defaults to 4 CPUs."""
+        slurm = run_setup_finetune(temp_run_dir, "Llama-3.1-8B-Instruct")
         assert "#SBATCH --cpus-per-task=4" in slurm
 
     def test_70b_default_cpus(self, temp_run_dir):

--- a/tools/torchtune/setup_finetune.py
+++ b/tools/torchtune/setup_finetune.py
@@ -43,6 +43,21 @@ MODEL_CONFIGS = {
             "gpus": 1,
         },
     },
+    "Llama-3.1-8B-Instruct": {
+        "component": "torchtune.models.llama3_1.lora_llama3_1_8b",
+        "checkpoint_files": {
+            "filename_format": "model-{}-of-{}.safetensors",
+            "max_filename": "00004",
+        },
+        "model_type": "LLAMA3",
+        "slurm": {
+            "mem": "80G",
+            "partition": None,
+            "constraint": "gpu80",
+            "cpus": 4,
+            "gpus": 1,
+        },
+    },
     "Llama-3.3-70B-Instruct": {
         "component": "torchtune.models.llama3_3.lora_llama3_3_70b",
         "checkpoint_files": {
@@ -285,7 +300,7 @@ def create_parser():
 
     # ------ Model Selection -----
     parser.add_argument("--torchtune_model_name", type=str, default="Llama-3.2-1B-Instruct",
-                        help="Model name as listed by 'tune ls' (e.g., 'Llama-3.2-1B-Instruct', 'Llama-3.2-3B-Instruct', 'Llama-3.3-70B-Instruct')")
+                        help="Model name as listed by 'tune ls' (e.g., 'Llama-3.2-1B-Instruct', 'Llama-3.2-3B-Instruct', 'Llama-3.1-8B-Instruct', 'Llama-3.3-70B-Instruct')")
     parser.add_argument("--model_checkpoint", type=str, default=None,
                         help="Model directory name within models_dir (defaults to torchtune_model_name if not provided)")
 


### PR DESCRIPTION
Closes #226

## Summary

- Adds Llama-3.1-8B-Instruct to MODEL_CONFIGS with single-GPU setup
- Note: Issue title says "Llama-3.2-8B" but 8B is from the Llama 3.1 family

## New Dependencies

None

## Testing Instructions

```bash
python -m pytest tests/integration/test_setup_finetune_slurm.py -v
```

All 24 tests pass (20 from 70B branch + 4 new for 8B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)