### PR TITLE
Add CHANGELOG.md and KNOWN_ISSUES.md for alpha release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to cruijff_kit will be documented in this file.
+
+## [0.1.0] - 2026-01-07
+
+Initial alpha release.
+
+### What Works
+
+- **Core workflow**: design → scaffold → run → summarize experiments
+- **Fine-tuning**: LoRA fine-tuning via torchtune with validation loss tracking
+- **Evaluation**: inspect-ai integration for model evaluation
+- **Multi-model support**: Llama 1B, 3B, 8B, and 70B with model-aware SLURM allocation
+- **Claude Code skills**: Automated workflows for experiment design, scaffolding, and execution
+- **Installation**: Automated setup via `make install`
+
+### Known Limitations
+
+See [KNOWN_ISSUES.md](KNOWN_ISSUES.md) for current limitations and workarounds.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,0 +1,25 @@
+# Known Issues
+
+Current limitations in cruijff_kit with workarounds.
+
+## Inspect Evals Don't Capture Model Names in Metadata
+
+**Issue**: [#174](https://github.com/niznik-dev/cruijff_kit/issues/174)
+
+Model names are not automatically recorded in inspect-ai evaluation metadata, making it harder to identify which model produced which results.
+
+**Workaround**: Check the run directory name, which includes the model identifier.
+
+## get_embeddings() Attention Mask Bug
+
+**Issue**: [#234](https://github.com/niznik-dev/cruijff_kit/issues/234)
+
+The `get_embeddings()` function has incorrect attention mask handling when processing batches with different sequence lengths.
+
+**Workaround**: Use consistent batch sizes or process sequences of similar lengths together.
+
+## Claude Code Agents Fail to Load
+
+Sometimes Claude Code doesn't properly load the scaffold or run agents on startup.
+
+**Workaround**: Restart Claude Code (`/quit` then relaunch).

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ We are grateful to the following funders and supporters: [Princeton AI Lab](http
 
 This project is under active development. The core workflows (design → scaffold → run → summarize experiments) are functional, but you may encounter bugs or breaking changes between updates. You're welcome to use this toolkit on your own, but reaching out to us first will help you get up to speed faster. We'd love to collaborate - your feedback and bug reports are valuable!
 
+See [CHANGELOG.md](CHANGELOG.md) for release history and [KNOWN_ISSUES.md](KNOWN_ISSUES.md) for current limitations.
+
 # Prerequisites
 
 - Cloning and Pulling from GitHub (properly!)


### PR DESCRIPTION
Closes #235

## Summary

- Adds CHANGELOG.md documenting what works in v0.1.0
- Adds KNOWN_ISSUES.md with current limitations and workarounds
- Links both from README.md

## Test plan

- [x] Verify links in README work
- [x] Review CHANGELOG content
- [x] Review KNOWN_ISSUES content

🤖 Generated with [Claude Code](https://claude.com/claude-code)