### PR TITLE
Remove misleading sections from CLAUDE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -215,7 +215,7 @@ Each experiment typically includes:
 - `templates/finetuning/` - Template YAML configs for different dataset formats
 - `input/` - Data generation or preprocessing scripts
 - `utils/` - Experiment-specific helper functions
-- `{name}_inspect_task.py` - Inspect-ai evaluation task (e.g., `inspect_task_capitalization.py`)
+- `inspect_task_{name}.py` - Inspect-ai evaluation task (e.g., `inspect_task_capitalization.py`)
 
 ### Sanity Checks (`sanity_checks/`)
 Synthetic validation sanity checks for workflow testing and learning:
@@ -424,7 +424,7 @@ For users who prefer direct control or don't have Claude Code access. This workf
 2. Add `README.md` with experiment description
 3. Create `setup_finetune.yaml` from template
 4. Add data generation scripts to `input/`
-5. Create inspect-ai evaluation task (e.g., `{name}_task.py`) using `create-inspect-task` skill
+5. Create inspect-ai evaluation task (e.g., `inspect_task_{name}.py`) using `create-inspect-task` skill
 6. Document the workflow in experiment README
 
 ### Using Utilities
@@ -450,8 +450,8 @@ Common utilities in `utils/`:
 ### Environment Assumptions
 
 - **Conda environment** with torchtune, torch, inspect-ai
-- **Shared storage** for models (`/scratch/gpfs/MSALGANIK/pretrained-llms/`)
-- **User scratch space** for outputs (`/scratch/gpfs/MSALGANIK/$USER/`)
+- **Shared storage** for models (configure path in `claude.local.md`)
+- **User scratch space** for outputs (configure path in `claude.local.md`)
 
 ## Extension Points
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ cruijff_kit includes Claude Code skills to streamline common workflows. These sk
 
 **Note**: All skills are optional convenience tools. Users can perform the same operations manually by running the underlying Python scripts and shell commands directly.
 
-**Architecture**: The primary workflow skills (scaffold-experiment, run-experiment) are orchestrators that delegate to specialized worker skills (scaffold-torchtune, scaffold-inspect, run-torchtune, run-inspect) which handle tool-specific operations. See [SKILLS_ARCHITECTURE_SUMMARY.md](SKILLS_ARCHITECTURE_SUMMARY.md) for the complete skills architecture.
+**Architecture**: The primary workflow skills (scaffold-experiment, run-experiment) use modular documentation with `optimizers/` and `evaluators/` subdirectories for tool-specific logic. See [SKILLS_ARCHITECTURE_SUMMARY.md](SKILLS_ARCHITECTURE_SUMMARY.md) for the complete skills architecture.
 
 ## Workflow Testing
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ cruijff_kit supports two workflows for running experiments:
 If you have access to Claude Code, you can use skills to automate the entire experiment workflow:
 
 ### Step 1: Design the Experiment
-Use the `design-experiment` skill to plan your experiment. This creates an `experiment_summary.md` file documenting all runs, parameters, and resources.
+Use the `design-experiment` skill to plan your experiment. This creates an `experiment_summary.yaml` file documenting all runs, parameters, and resources.
 
 ### Step 2: Scaffold the Experiment
 Use the `scaffold-experiment` skill to automatically:
@@ -199,12 +199,13 @@ Use the `scaffold-experiment` skill to automatically:
 
 ### Step 3: Run the Experiment
 Use the `run-experiment` skill to:
-- Submit all jobs to SLURM
-- Monitor their progress
+- Submit fine-tuning jobs to SLURM
+- Monitor their progress until completion
+- Run evaluations on the fine-tuned models
 - Update the experiment status automatically
 
-### Step 4: Evaluate Results
-(Planned) Use the `evaluate-experiment` skill to generate and run evaluations.
+### Step 4: Summarize and Analyze
+Use `summarize-experiment` to generate a summary with key metrics (loss, accuracy) after completion. A more robust `analyze-experiment` skill for plots and statistical comparisons is planned.
 
 See `.claude/skills/*/SKILL.md` files for detailed documentation.
 

--- a/SKILLS_ARCHITECTURE_SUMMARY.md
+++ b/SKILLS_ARCHITECTURE_SUMMARY.md
@@ -37,7 +37,7 @@ Skills that coordinate other skills and track high-level workflow:
 1. **design-experiment**
    - Plans experiments (variables, resources, estimates)
    - Documents full pipeline (torchtune + inspect-ai)
-   - Creates experiment_summary.md
+   - Creates experiment_summary.yaml
    - Status: ✅ Updated
 
 2. **scaffold-experiment**
@@ -75,7 +75,7 @@ Skills that handle torchtune-specific operations:
 1. **run-torchtune**
    - Submits finetune.slurm jobs to SLURM
    - Monitors jobs until completion (1-min polling)
-   - Updates experiment_summary.md status table
+   - Updates experiment_summary.yaml status table
    - Creates run-torchtune.log
    - Status: ✅ Created (extracted from run-experiment)
 
@@ -86,7 +86,7 @@ Skills that handle inspect-ai-specific operations:
    - Verifies fine-tuning complete and checkpoints exist
    - Submits evaluation SLURM jobs
    - Monitors jobs until completion (1-min polling)
-   - Updates experiment_summary.md evaluation status table
+   - Updates experiment_summary.yaml evaluation status table
    - Creates run-inspect.log
    - Status: ✅ Created (new)
 
@@ -95,7 +95,7 @@ Skills that create reusable evaluation tasks:
 
 1. **create-inspect-task**
    - Creates custom inspect-ai evaluation tasks
-   - Can read from experiment_summary.md (experiment-guided mode)
+   - Can read from experiment_summary.yaml (experiment-guided mode)
    - Can run standalone (for general task creation)
    - Status: ⚠️ Existing (not modified in this refactor)
 
@@ -145,7 +145,7 @@ design-experiment documents which tools are used:
 
 ```
 experiment_name/
-├── experiment_summary.md         # Design (from design-experiment)
+├── experiment_summary.yaml         # Design (from design-experiment)
 ├── design-experiment.log         # Planning log
 ├── scaffold.log                  # Scaffolding log (from scaffold-experiment)
 ├── run-experiment.log            # Execution orchestration log
@@ -186,7 +186,7 @@ experiment_name/
 ### What Actually Happens (Worker Skills)
 ```bash
 # design-experiment
-#   → Creates experiment_summary.md with full pipeline docs
+#   → Creates experiment_summary.yaml with full pipeline docs
 
 # scaffold-experiment
 #   → Executes torchtune scaffolding (optimizers/torchtune.md)
@@ -277,7 +277,7 @@ experiment_name/
 **User impact:**
 - Orchestrator skill names unchanged (scaffold-experiment, run-experiment)
 - Output structure unchanged (same directories, same files)
-- experiment_summary.md format enhanced but compatible
+- experiment_summary.yaml format enhanced but compatible
 
 **Developer impact:**
 - Must understand modular documentation pattern
@@ -312,7 +312,7 @@ Before deploying to production:
 3. Verify log files are created correctly at all levels
 4. Check that sequential execution works (run-torchtune → run-inspect)
 5. Test error handling (what happens if fine-tuning fails?)
-6. Verify experiment_summary.md updates correctly
+6. Verify experiment_summary.yaml updates correctly
 
 ## Terminology Clarification: Experiments vs Tasks
 
@@ -322,7 +322,7 @@ Before deploying to production:
 The word "task" was overloaded with three different meanings:
 1. `tasks/` folder = Research domains (capitalization, twins, etc.)
 2. Inspect-ai tasks = Evaluation scripts (`.py` files)
-3. Skills refer to "tasks" in experiment_summary.md
+3. Skills refer to "tasks" in experiment_summary.yaml
 
 ### The Solution
 Renamed `tasks/` → `experiments/` to clarify:

--- a/sanity_checks/bit_sequences/README.md
+++ b/sanity_checks/bit_sequences/README.md
@@ -44,7 +44,7 @@ data/green/bit_sequences/
 └── sanity_check_bit_sequences_YYYY-MM-DD/
     ├── parity_run/
     ├── probabilistic_run/
-    ├── experiment_summary.md
+    ├── experiment_summary.yaml
     ├── design-experiment.log
     └── scaffold-experiment.log
 ```
@@ -88,7 +88,7 @@ The skills-based workflow automates experiment planning, config generation, and 
 cd sanity_checks/bit_sequences
 
 # 2. Design experiment (creates experiment plan)
-# Claude Code will ask questions and create experiment_summary.md
+# Claude Code will ask questions and create experiment_summary.yaml
 /design-experiment
 
 # 3. Generate all configs (creates run directories with configs and SLURM scripts)

--- a/sanity_checks/predictable_or_not/README.md
+++ b/sanity_checks/predictable_or_not/README.md
@@ -66,7 +66,7 @@ data/green/predictable_or_not/
     ├── up_input_and_output/
     ├── uu_output_only/
     ├── uu_input_and_output/
-    ├── experiment_summary.md
+    ├── experiment_summary.yaml
     ├── design-experiment.log
     └── scaffold-experiment.log
 ```
@@ -105,7 +105,7 @@ The skills-based workflow automates experiment planning, config generation, and 
 cd sanity_checks/predictable_or_not
 
 # 2. Design experiment (creates experiment plan with all 8 runs)
-# Claude Code will ask questions and create experiment_summary.md
+# Claude Code will ask questions and create experiment_summary.yaml
 /design-experiment
 
 # 3. Generate all configs (creates 8 run directories with configs and SLURM scripts)


### PR DESCRIPTION
Closes #186

## Summary

- Removes "Pre-approved Commands" section — doesn't actually work (CLAUDE.md cannot modify Claude Code's permission system)
- Removes "Supporting Workflows (Planned)" section — lists skills that don't exist and may never be built
- Fixes `experiment_summary.md` → `.yaml` across all docs (14 occurrences)
- Updates README workflow steps to reflect actual skills (run-experiment includes eval, add summarize-experiment)
- Fixes CLAUDE.md architecture description (modular subdirs, not separate worker skills)
- Fixes inspect task naming pattern in ARCHITECTURE.md
- Removes hardcoded Princeton paths from ARCHITECTURE.md

## Test plan

- [x] Verify all docs render correctly
- [x] Confirm no broken references
- [x] Grep for `experiment_summary.md` returns no results

🤖 Generated with [Claude Code](https://claude.com/claude-code)