### PR TITLE
Use descriptive model names in inspect eval instead of hf/local

### DIFF
--- a/.claude/agents/scaffold-inspect.md
+++ b/.claude/agents/scaffold-inspect.md
@@ -332,7 +332,8 @@ SYSTEM_PROMPT="{system_prompt}"
 cd {experiment_dir}/{run_dir}/eval
 
 inspect eval {task_script_path}@{task_name} \\
-  --model hf/local \\
+  {if fine-tuned:}--model hf/{run_name}_epoch_{N} \\
+  {if base model:}--model hf/{run_name}_base \\
   -M model_path="$MODEL_PATH" \\
   -T data_path="$DATA_PATH" \\
   -T prompt="$PROMPT" \\
@@ -398,7 +399,7 @@ PROMPT="{input}"
 SYSTEM_PROMPT=""
 
 inspect eval capitalization.py@capitalization \\
-  --model hf/local \\
+  --model hf/{run_name}_epoch_0 \\
   -M model_path="$MODEL_PATH" \\
   -T data_path="$DATA_PATH" \\
   -T prompt="$PROMPT" \\
@@ -407,6 +408,7 @@ inspect eval capitalization.py@capitalization \\
 ```
 
 **Key points:**
+- The `--model` argument uses a descriptive name (`hf/{run_name}_epoch_{N}`) that gets recorded in the `.eval` file for identification
 - Values are extracted from `setup_finetune.yaml` **at scaffolding time** and baked into the SLURM script
 - No config file parsing happens at eval runtime
 - Ensures exact match between training and evaluation parameters
@@ -423,7 +425,7 @@ PROMPT="{input}"
 SYSTEM_PROMPT=""
 
 inspect eval capitalization.py@capitalization \\
-  --model hf/local \\
+  --model hf/{run_name}_base \\
   -M model_path="$MODEL_PATH" \\
   -T data_path="$DATA_PATH" \\
   -T prompt="$PROMPT" \\
@@ -432,6 +434,7 @@ inspect eval capitalization.py@capitalization \\
 ```
 
 **Key points:**
+- The `--model` argument uses a descriptive name (`hf/{run_name}_base`) that gets recorded in the `.eval` file for identification
 - Base models use the same dataset/prompt/system_prompt as fine-tuned runs for fair comparison
 - Values come from `eval_config.yaml` (generated from experiment_summary.yaml)
 - Mirrors fine-tuned approach: config file → SLURM script for auditability


### PR DESCRIPTION
Closes #174

## Summary
- Updates scaffold-inspect to generate SLURM scripts with meaningful model identifiers instead of `hf/local`
- Fine-tuned models use `hf/{run_name}_epoch_{N}` (e.g., `hf/Llama-3.2-1B-Instruct_rank8_epoch_0`)
- Base models use `hf/{run_name}_base` (e.g., `hf/Llama-3.2-1B-Instruct_base`)
- The `-M model_path=...` arg still points to the actual checkpoint; inspect-ai uses that to load but records the `--model` string in `.eval` files

## New Dependencies
None

## Testing Instructions
1. Run workflow test to scaffold a new experiment
2. Check generated SLURM scripts use descriptive model names
3. Run evaluation and verify `.eval` files record the descriptive name

🤖 Generated with [Claude Code](https://claude.com/claude-code)