### PR TITLE
Update troubleshooting to reference Makefile installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ python -c "import cruijff_kit; print('cruijff_kit installed successfully')"
 ## Troubleshooting
 
 **Issue**: Import errors for cruijff_kit
-**Solution**: Ensure you ran `pip install -e .` from the repository root directory
+**Solution**: Ensure you ran `make install` (or `make install-dev` for contributors) from the repository root directory
 
 # Downloading a model
 


### PR DESCRIPTION
Closes #257

## Description

Updates the Troubleshooting section in the README to reference `make install` (or `make install-dev`) instead of the raw `pip install -e .` command, keeping it consistent with the recommended installation workflow documented elsewhere in the README.

## New Dependencies

None

## Testing Instructions

Visual inspection - documentation change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)