### PR TITLE
Fix torchtune recipe cacheing and usage

### DIFF
--- a/.claude/skills/design-experiment/param_selection.md
+++ b/.claude/skills/design-experiment/param_selection.md
@@ -131,17 +131,17 @@ The experiment workflow uses an **orchestrator → worker** pattern:
 ### Should We Include Base Model Controls?
 - Controls evaluate base models without fine-tuning to measure the effect of fine-tuning
 
-### Use Recipe Defaults?
+### Use Model Torchtune Recipe Defaults?
 
-**Ask the user:** "Would you like to use torchtune recipe defaults for unspecified parameters?"
+**Ask the user:** "Would you like to use torchtune recipe defaults for this model to control unspecified hyperparameters?"
 
-Torchtune recipes include sensible defaults for most training parameters (learning rate, gradient accumulation, warmup steps, etc.). When `base_recipe` is specified in experiment_summary.yaml, any parameters not explicitly set will inherit from the recipe.
+Torchtune recipes include sensible defaults for most training parameters (learning rate, gradient accumulation, warmup steps, etc.). When `base_recipe` is specified in experiment_summary.yaml, any hyperparameters not explicitly set will inherit from the recipe.
 
 **Options:**
 - **Yes (recommended):** Specify `base_recipe` (e.g., `"llama3_2/1B_lora_single_device"`) and only set parameters you're actively varying. Reduces configuration complexity.
 - **No:** Explicitly set all training parameters. Useful if you need full control or reproducibility without recipe dependencies.
 
-**If yes:** Note the appropriate recipe name based on model selection:
+**If yes:** Note example appropriate recipe names based on model selection:
 - 1B models: `llama3_2/1B_lora_single_device`
 - 3B models: `llama3_2/3B_lora_single_device`
 - 8B models: `llama3_1/8B_lora_single_device`
@@ -162,7 +162,7 @@ Use `tune ls` to see all available recipes if needed.
 When designing experiments, you can vary any of these parameters. Add varied parameters to `variables` and constant parameters to `controls` in experiment_summary.yaml.
 
 **Recipe Configuration (if user opted to use recipe defaults):**
-- `base_recipe` - Torchtune recipe name for default values (e.g., "llama3_2/1B_lora_single_device"). When specified, recipe defaults are used for parameters not explicitly set. See "Use Recipe Defaults?" section above.
+- `base_recipe` - Torchtune recipe name for default values (e.g., "llama3_2/1B_lora_single_device"). When specified, model recipe defaults are used for parameters not explicitly set. See "Use Recipe Defaults?" section above.
 
 **Core Training Parameters:**
 | Parameter | Description | Typical Values |

--- a/.claude/skills/design-experiment/templates/experiment_summary.yaml
+++ b/.claude/skills/design-experiment/templates/experiment_summary.yaml
@@ -39,10 +39,6 @@ variables:
 controls:
   system_prompt: string            # Training system prompt ("" for blank)
   prompt: string                   # Prompt template with {input} placeholder (e.g., "Capitalize: {input}\n")
-  # OPTIONAL: Torchtune recipe for default hyperparameters
-  base_recipe: string              # e.g., "llama3_2/1B_lora_single_device"
-                                   # When specified, recipe defaults are used for params not set
-                                   # Use `tune ls` to see available recipes
   # Common hyperparameters (see param_selection.md for full list)
   epochs: int                      # Number of training epochs
   batch_size: int                  # Batch size (if not varied)
@@ -58,6 +54,11 @@ models:
     - name: string                 # REQUIRED: Model identifier (e.g., "Llama-3.2-1B-Instruct")
       path: string                 # REQUIRED: Full path to model directory
       size_gb: float               # REQUIRED: Model size for disk estimates
+      base_recipe: string          # OPTIONAL: Torchtune recipe for default hyperparameters
+                                   # e.g., "llama3_2/1B_lora_single_device"
+                                   # When specified, recipe defaults are used for hyperparameters not set
+                                   # Use `tune ls` to see available recipes
+
 
 data:
   training:

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ htmlcov/
 # Environment-specific configuration (users should customize from template)
 claude.local.md
 
+# User-specific cache directory (i.e., torchtune recipes)
+.claude/cache/
+
 # Data access tiers - exclude all data files but keep documentation
 data/red/*
 !data/red/CLAUDE.md

--- a/tools/torchtune/config_recipe_loader.py
+++ b/tools/torchtune/config_recipe_loader.py
@@ -11,7 +11,6 @@ Key functions:
 """
 
 import subprocess
-import tempfile
 import yaml
 import logging
 from pathlib import Path
@@ -122,12 +121,13 @@ def extract_recipe_config(recipe_name: str, output_path: Optional[str] = None) -
     try:
         # Create output path if not provided
         if output_path is None:
-            # Create a temp file in system temp directory
-            temp_dir = Path(tempfile.gettempdir()) / "cruijff_kit_recipes"
-            temp_dir.mkdir(exist_ok=True)
+            # Create cache directory in project root (.claude/cache/recipes)
+            project_root = Path(__file__).parent.parent.parent
+            cache_dir = project_root / ".claude" / "cache" / "recipes"
+            cache_dir.mkdir(parents=True, exist_ok=True)
             # Use recipe name as filename (replace / with _)
             safe_name = recipe_name.replace('/', '_')
-            output_path = str(temp_dir / f"{safe_name}.yaml")
+            output_path = str(cache_dir / f"{safe_name}.yaml")
 
         output_file = Path(output_path)
         output_file.parent.mkdir(parents=True, exist_ok=True)

--- a/tools/torchtune/setup_finetune.py
+++ b/tools/torchtune/setup_finetune.py
@@ -378,7 +378,7 @@ def main():
         with open(args.config_file, "r") as f:
             config_data = yaml.safe_load(f) or {}
 
-    # Load recipe defaults if base_recipe is specified
+    # Load torchtune recipe hyperparameter defaults if base_recipe is specified
     recipe_defaults = {}
     recipe_config = None
     base_recipe = args.base_recipe or config_data.get('base_recipe')
@@ -387,9 +387,9 @@ def main():
             recipe_config = config_recipe_loader.get_recipe_config(base_recipe)
             recipe_defaults = extract_flat_params(recipe_config, RECIPE_PARAM_MAPPING)
         except config_recipe_loader.RecipeConfigError as e:
-            print(f"Warning: Could not load recipe '{base_recipe}': {e}. Using built-in defaults.")
+            raise SystemExit(f"ERROR: Could not load recipe '{base_recipe}': {e}")
 
-    # Apply recipe defaults (only if at argparse default AND not overridden in config_file)
+    # Apply default hyperparameters (only if at argparse default AND not overridden in config_file)
     # Precedence: CLI > config_file > recipe > argparse_default
     for key, value in recipe_defaults.items():
         if hasattr(args, key) and key not in config_data:


### PR DESCRIPTION
Closes #{270}, #{262}

# Description

- Creates `.claude/cache/recipes` -- when a `base_recipe` is specified, it will be copied to the cruijff_kit local repo instead of a shared HPC directory; this will prevent the issue that Mattie found where I owned the `tmp` dir (whoops)
- Adds `.claude/cache` to `.gitignore`
- Moves `base_recipe` from a control configuration to the respective `model` attributes; Claude had begun doing this on its own in the `design-experiment` skill when varying the model, and I agree that it logically fits more with the model. 
- Clarifies the role of `base_recipe` as a **hyperparameter** controller, whereas `custom_recipe` is the stable version in cruijff_kit that should be submitted for the slurm job

- Additionally, provides scaffolding agent with more direction on choosing the single-device vs distributed custom recipe based on the run's model (connection with the base recipe being attached to the model also seemed to help it make this choice correctly)

## New Dependencies

NA

# Testing Instructions

Can run `workflow_test_recipe.yaml` -- should see `llama3_2/1B_lora_single_device` torchtune recipe copied to the local cacheing directory during `scaffold-torchtune`