### PR TITLE
Add support for base models + more model families

### DIFF
--- a/.claude/agents/scaffold-inspect.md
+++ b/.claude/agents/scaffold-inspect.md
@@ -494,6 +494,7 @@ inspect eval capitalization.py@capitalization \\
 
 For control (not fine-tuned) models, scaffold-inspect generates `eval_config.yaml` (see "Extracting Values for Control Models" above), then reads from it at scaffolding time:
 
+**For instruct models:**
 ```bash
 # Values extracted from eval_config.yaml at scaffolding time:
 MODEL_PATH="/path/to/pretrained-llms/Llama-3.2-1B-Instruct"
@@ -539,6 +540,7 @@ inspect eval capitalization.py@capitalization \\
 
 **Key points:**
 - The `--model` argument uses a descriptive name (`hf/{run_name}_control`) that gets recorded in the `.eval` file for identification
+- The `vis_label` task arg sets a dynamic task name suffix (e.g., `capitalization_1B_control`) for visualization
 - Control models use the same dataset/prompt/system_prompt as fine-tuned runs for fair comparison
 - Values come from `eval_config.yaml` (generated from experiment_summary.yaml)
 - Mirrors fine-tuned approach: config file → SLURM script for auditability

--- a/experiments/capitalization/inspect_task_capitalization.py
+++ b/experiments/capitalization/inspect_task_capitalization.py
@@ -1,13 +1,22 @@
 """
-Eval task for capitalization with chat_completion dataset.
+Eval task for capitalization.
 
+Supports both instruct models (chat_completion) and base models (text_completion).
 Reads prompt and system_prompt from setup_finetune.yaml to ensure train/eval parity.
 
 Usage:
+    # For instruct models (chat_completion, default):
     inspect eval inspect_task_capitalization.py --model hf/local \
         -M model_path=/path/to/checkpoint \
         -T config_path=/path/to/setup_finetune.yaml \
         -T data_path=/path/to/words_5L_80P_1000.json
+
+    # For base models (text_completion):
+    inspect eval inspect_task_capitalization.py --model hf/local \
+        -M model_path=/path/to/checkpoint \
+        -T config_path=/path/to/setup_finetune.yaml \
+        -T data_path=/path/to/words_5L_80P_1000.json \
+        -T use_chat_template=false
 """
 
 import yaml
@@ -24,9 +33,10 @@ def capitalization(
     split: str = "test",
     temperature: float = 1e-7,
     max_tokens: int = 20,
+    use_chat_template: bool = True,
 ) -> Task:
     """
-    Eval task for capitalization trained with chat_completion.
+    Eval task for capitalization.
 
     Args:
         data_path: Path to JSON file with {"train": [...], "validation": [...], "test": [...]}
@@ -34,6 +44,8 @@ def capitalization(
         split: Which split to evaluate on (default: test)
         temperature: Generation temperature
         max_tokens: Max tokens to generate
+        use_chat_template: If True, use chat format with system message (instruct models).
+                          If False, use simple text (base models). Should match training.
     """
     # Read prompt config from YAML
     prompt_str = "{input}"
@@ -46,7 +58,7 @@ def capitalization(
         system_prompt = config.get('system_prompt', '')
 
     def record_to_sample(record):
-        # Wrap input with prompt template - same as chat_completion training
+        # Wrap input with prompt template - same as training
         formatted_input = prompt_str.format(input=record["input"])
         return Sample(
             input=formatted_input,
@@ -61,12 +73,22 @@ def capitalization(
         sample_fields=record_to_sample,
     )
 
-    return Task(
-        dataset=dataset,
-        solver=chain(
+    # Build solver chain based on chat template usage
+    if use_chat_template:
+        # Instruct models: use chat format with system message
+        solver = chain(
             system_message(system_prompt),
             generate(temperature=temperature, max_tokens=max_tokens),
-        ),
+        )
+    else:
+        # Base models: simple text, no system message
+        solver = chain(
+            generate(temperature=temperature, max_tokens=max_tokens),
+        )
+
+    return Task(
+        dataset=dataset,
+        solver=solver,
         scorer=[
             match(location="exact", ignore_case=False),
             includes(ignore_case=False),

--- a/experiments/folktexts/inspect_task_acs.py
+++ b/experiments/folktexts/inspect_task_acs.py
@@ -29,6 +29,7 @@ def _create_acs_task(
     split: str = "test",
     temperature: float = 1e-7,
     max_tokens: int = 5,
+    use_chat_template = True
 ) -> Task:
     """
     Create an ACS binary prediction eval task.
@@ -66,12 +67,20 @@ def _create_acs_task(
         sample_fields=record_to_sample,
     )
 
-    return Task(
-        dataset=dataset,
-        solver=chain(
+    if use_chat_template:
+        # Instruct models: use chat format with system message
+        solver = chain(
             system_message(system_prompt),
             generate(temperature=temperature, max_tokens=max_tokens),
-        ),
+        )
+    else:
+        solver = chain(
+            generate(temperature=temperature, max_tokens=max_tokens),
+        )
+
+    return Task(
+        dataset=dataset,
+        solver=solver,
         scorer=[
             match(location="exact", ignore_case=False),
             includes(ignore_case=False),
@@ -87,42 +96,43 @@ def acs_binary(
     split: str = "test",
     temperature: float = 1e-7,
     max_tokens: int = 5,
+    use_chat_template = True
 ) -> Task:
     """Generic ACS binary prediction task. Works with any ACS dataset."""
-    return _create_acs_task(data_path, config_path, split, temperature, max_tokens)
+    return _create_acs_task(data_path, config_path, split, temperature, max_tokens, use_chat_template)
 
 
 # Task-specific aliases for clarity in eval logs
 @task
 def acs_income(data_path: str, config_path: str = "", split: str = "test",
-               temperature: float = 1e-7, max_tokens: int = 5) -> Task:
+               temperature: float = 1e-7, max_tokens: int = 5, use_chat_template = True) -> Task:
     """ACS income prediction (>$50k)."""
-    return _create_acs_task(data_path, config_path, split, temperature, max_tokens)
+    return _create_acs_task(data_path, config_path, split, temperature, max_tokens, use_chat_template)
 
 
 @task
 def acs_employment(data_path: str, config_path: str = "", split: str = "test",
-                   temperature: float = 1e-7, max_tokens: int = 5) -> Task:
+                   temperature: float = 1e-7, max_tokens: int = 5, use_chat_template = True) -> Task:
     """ACS employment prediction (employed as civilian)."""
-    return _create_acs_task(data_path, config_path, split, temperature, max_tokens)
+    return _create_acs_task(data_path, config_path, split, temperature, max_tokens, use_chat_template)
 
 
 @task
 def acs_mobility(data_path: str, config_path: str = "", split: str = "test",
-                 temperature: float = 1e-7, max_tokens: int = 5) -> Task:
+                 temperature: float = 1e-7, max_tokens: int = 5, use_chat_template = True) -> Task:
     """ACS mobility prediction (moved in last year)."""
-    return _create_acs_task(data_path, config_path, split, temperature, max_tokens)
+    return _create_acs_task(data_path, config_path, split, temperature, max_tokens, use_chat_template)
 
 
 @task
 def acs_publiccoverage(data_path: str, config_path: str = "", split: str = "test",
-                       temperature: float = 1e-7, max_tokens: int = 5) -> Task:
+                       temperature: float = 1e-7, max_tokens: int = 5, use_chat_template = True) -> Task:
     """ACS public health coverage prediction."""
-    return _create_acs_task(data_path, config_path, split, temperature, max_tokens)
+    return _create_acs_task(data_path, config_path, split, temperature, max_tokens, use_chat_template)
 
 
 @task
 def acs_traveltime(data_path: str, config_path: str = "", split: str = "test",
-                   temperature: float = 1e-7, max_tokens: int = 5) -> Task:
+                   temperature: float = 1e-7, max_tokens: int = 5, use_chat_template = True) -> Task:
     """ACS travel time prediction (>20 min commute)."""
-    return _create_acs_task(data_path, config_path, split, temperature, max_tokens)
+    return _create_acs_task(data_path, config_path, split, temperature, max_tokens, use_chat_template)

--- a/experiments/synthetic_twins/inspect_task_twins.py
+++ b/experiments/synthetic_twins/inspect_task_twins.py
@@ -1,13 +1,21 @@
 """
-Eval task for twins zygosity with chat_completion dataset.
+Eval task for twins zygosity.
 
 Reads prompt and system_prompt from setup_finetune.yaml to ensure train/eval parity.
 
 Usage:
+    # For instruct models (chat_completion, default):
     inspect eval inspect_task_twins.py --model hf/local \
         -M model_path=/path/to/checkpoint \
         -T config_path=/path/to/setup_finetune.yaml \
         -T data_path=/path/to/twins.json
+
+    # For base models (text_completion):
+    inspect eval inspect_task_twins.py --model hf/local \
+        -M model_path=/path/to/checkpoint \
+        -T config_path=/path/to/setup_finetune.yaml \
+        -T data_path=/path/to/twins.json \
+        -T use_chat_template=false
 """
 
 import yaml
@@ -24,8 +32,20 @@ def twins(
     split: str = "test",
     temperature: float = 1e-7,
     max_tokens: int = 5,
+    use_chat_template: bool = True,
 ) -> Task:
-    """Eval task for twins zygosity trained with chat_completion."""
+    """
+    Eval task for twins zygosity.
+
+    Args:
+        data_path: Path to JSON file with {"train": [...], "test": [...]}
+        config_path: Path to setup_finetune.yaml (reads prompt/system_prompt from it)
+        split: Which split to evaluate on (default: test)
+        temperature: Generation temperature
+        max_tokens: Max tokens to generate
+        use_chat_template: If True, use chat format with system message (instruct models).
+                          If False, use simple text (base models). Should match training.
+    """
     # Read prompt config from YAML
     prompt_str = "{input}"
     system_prompt = ""
@@ -51,12 +71,20 @@ def twins(
         sample_fields=record_to_sample,
     )
 
-    return Task(
-        dataset=dataset,
-        solver=chain(
+    if use_chat_template:
+        # Instruct models: use chat format with system message
+        solver = chain(
             system_message(system_prompt),
             generate(temperature=temperature, max_tokens=max_tokens),
-        ),
+        )
+    else:
+        solver = chain(
+            generate(temperature=temperature, max_tokens=max_tokens),
+        )
+
+    return Task(
+        dataset=dataset,
+        solver=solver,
         scorer=[
             match(location="exact", ignore_case=False),
             includes(ignore_case=False),

--- a/sanity_checks/predictable_or_not/inspect_task_predictable_or_not.py
+++ b/sanity_checks/predictable_or_not/inspect_task_predictable_or_not.py
@@ -1,13 +1,21 @@
 """
-Eval task for predictable_or_not with chat_completion dataset.
+Eval task for predictable_or_not.
 
 Reads prompt and system_prompt from setup_finetune.yaml to ensure train/eval parity.
 
 Usage:
+    # For instruct models (chat_completion, default):
     inspect eval inspect_task_predictable_or_not.py --model hf/local \
         -M model_path=/path/to/checkpoint \
         -T config_path=/path/to/setup_finetune.yaml \
         -T data_path=/path/to/pp.json
+
+    # For base models (text_completion):
+    inspect eval inspect_task_predictable_or_not.py --model hf/local \
+        -M model_path=/path/to/checkpoint \
+        -T config_path=/path/to/setup_finetune.yaml \
+        -T data_path=/path/to/pp.json \
+        -T use_chat_template=false
 """
 
 import yaml
@@ -24,9 +32,10 @@ def predictable_or_not(
     split: str = "validation",
     temperature: float = 1e-7,
     max_tokens: int = 10,
+    use_chat_template: bool = True,
 ) -> Task:
     """
-    Eval task for predictable_or_not trained with chat_completion.
+    Eval task for predictable_or_not.
 
     Args:
         data_path: Path to JSON file with {"train": [...], "validation": [...]}
@@ -34,6 +43,8 @@ def predictable_or_not(
         split: Which split to evaluate on (default: validation)
         temperature: Generation temperature
         max_tokens: Max tokens to generate
+        use_chat_template: If True, use chat format with system message (instruct models).
+                          If False, use simple text (base models). Should match training.
     """
     # Read prompt config from YAML
     prompt_str = "{input}"
@@ -60,12 +71,20 @@ def predictable_or_not(
         sample_fields=record_to_sample,
     )
 
-    return Task(
-        dataset=dataset,
-        solver=chain(
+    if use_chat_template:
+        # Instruct models: use chat format with system message
+        solver = chain(
             system_message(system_prompt),
             generate(temperature=temperature, max_tokens=max_tokens),
-        ),
+        )
+    else:
+        solver = chain(
+            generate(temperature=temperature, max_tokens=max_tokens),
+        )
+
+    return Task(
+        dataset=dataset,
+        solver=solver,
         scorer=[
             match(location="exact", ignore_case=False),
             includes(ignore_case=False),

--- a/tests/unit/test_model_configs.py
+++ b/tests/unit/test_model_configs.py
@@ -1,0 +1,213 @@
+"""Unit tests for tools/torchtune/model_configs.py
+
+Run these tests when adding a new model to verify the configuration is correct:
+    pytest tests/unit/test_model_configs.py -v
+
+These tests verify:
+- All models have required tokenizer configuration
+- All tokenizer path_types are valid and handled
+- configure_tokenizer() works correctly for all supported model families
+"""
+
+import pytest
+from cruijff_kit.tools.torchtune.model_configs import (
+    MODEL_CONFIGS,
+    configure_tokenizer,
+    VALID_TOKENIZER_PATH_TYPES,
+)
+
+
+# =============================================================================
+# Tests for configure_tokenizer()
+# =============================================================================
+
+class TestConfigureTokenizerByFamily:
+    """Test tokenizer configuration for each supported model family."""
+
+    def test_llama_tokenizer(self):
+        """Test Llama tokenizer configuration (SentencePiece)."""
+        config = {"tokenizer": {}}
+        model_config = {
+            "tokenizer": {
+                "component": "torchtune.models.llama3.llama3_tokenizer",
+                "path_type": "llama",
+            }
+        }
+
+        result = configure_tokenizer(config, model_config, "Llama-3.2-1B-Instruct", "Llama-3.2-1B-Instruct")
+
+        assert result["tokenizer"]["_component_"] == "torchtune.models.llama3.llama3_tokenizer"
+        assert result["tokenizer"]["path"] == "${models_dir}/Llama-3.2-1B-Instruct/original/tokenizer.model"
+        assert "merges_file" not in result["tokenizer"]
+
+    def test_qwen_tokenizer(self):
+        """Test Qwen tokenizer configuration (BPE with vocab.json + merges.txt)."""
+        config = {"tokenizer": {}}
+        model_config = {
+            "tokenizer": {
+                "component": "torchtune.models.qwen2_5.qwen2_5_tokenizer",
+                "path_type": "qwen",
+            }
+        }
+
+        result = configure_tokenizer(config, model_config, "Qwen2.5-3B-Instruct", "Qwen2.5-3B-Instruct")
+
+        assert result["tokenizer"]["_component_"] == "torchtune.models.qwen2_5.qwen2_5_tokenizer"
+        assert result["tokenizer"]["path"] == "${models_dir}/Qwen2.5-3B-Instruct/vocab.json"
+        assert result["tokenizer"]["merges_file"] == "${models_dir}/Qwen2.5-3B-Instruct/merges.txt"
+
+
+class TestConfigureTokenizerErrors:
+    """Test error handling in configure_tokenizer()."""
+
+    def test_unknown_path_type_raises_error(self):
+        """Test that unknown path_type raises ValueError."""
+        config = {"tokenizer": {}}
+        model_config = {
+            "tokenizer": {
+                "component": "torchtune.models.some.tokenizer",
+                "path_type": "unknown_type",
+            }
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            configure_tokenizer(config, model_config, "SomeModel", "SomeModel")
+
+        assert "Unknown tokenizer path_type" in str(exc_info.value)
+        assert "unknown_type" in str(exc_info.value)
+        assert "SomeModel" in str(exc_info.value)
+
+    def test_missing_path_type_raises_error(self):
+        """Test that missing path_type raises ValueError."""
+        config = {"tokenizer": {}}
+        model_config = {
+            "tokenizer": {
+                "component": "torchtune.models.some.tokenizer",
+                # path_type is missing
+            }
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            configure_tokenizer(config, model_config, "SomeModel", "SomeModel")
+
+        assert "Unknown tokenizer path_type" in str(exc_info.value)
+        assert "None" in str(exc_info.value)
+
+    def test_missing_tokenizer_config_raises_error(self):
+        """Test that missing tokenizer config raises ValueError."""
+        config = {"tokenizer": {}}
+        model_config = {}  # No tokenizer config at all
+
+        with pytest.raises(ValueError) as exc_info:
+            configure_tokenizer(config, model_config, "SomeModel", "SomeModel")
+
+        assert "Unknown tokenizer path_type" in str(exc_info.value)
+
+
+class TestConfigureTokenizerBehavior:
+    """Test general behavior of configure_tokenizer()."""
+
+    def test_preserves_existing_config(self):
+        """Test that existing tokenizer config values are preserved."""
+        config = {"tokenizer": {"max_seq_len": 4096, "existing_key": "value"}}
+        model_config = {
+            "tokenizer": {
+                "component": "torchtune.models.llama3.llama3_tokenizer",
+                "path_type": "llama",
+            }
+        }
+
+        result = configure_tokenizer(config, model_config, "Llama-3.2-1B", "Llama-3.2-1B")
+
+        # Original values should still be present
+        assert result["tokenizer"]["max_seq_len"] == 4096
+        assert result["tokenizer"]["existing_key"] == "value"
+        # New values should be added
+        assert result["tokenizer"]["_component_"] == "torchtune.models.llama3.llama3_tokenizer"
+        assert result["tokenizer"]["path"] == "${models_dir}/Llama-3.2-1B/original/tokenizer.model"
+
+
+# =============================================================================
+# Tests for MODEL_CONFIGS validation
+# =============================================================================
+
+class TestModelConfigsStructure:
+    """Validate that all MODEL_CONFIGS entries have required fields."""
+
+    def test_all_models_have_tokenizer_config(self):
+        """Test that all MODEL_CONFIGS entries have tokenizer configuration."""
+        for model_name, config in MODEL_CONFIGS.items():
+            assert "tokenizer" in config, f"Model '{model_name}' missing tokenizer config"
+            assert "component" in config["tokenizer"], f"Model '{model_name}' missing tokenizer component"
+            assert "path_type" in config["tokenizer"], f"Model '{model_name}' missing tokenizer path_type"
+
+    def test_all_models_have_valid_path_type(self):
+        """Test that all MODEL_CONFIGS have a valid tokenizer path_type."""
+        for model_name, config in MODEL_CONFIGS.items():
+            path_type = config["tokenizer"]["path_type"]
+            assert path_type in VALID_TOKENIZER_PATH_TYPES, (
+                f"Model '{model_name}' has invalid path_type '{path_type}'. "
+                f"Valid types: {VALID_TOKENIZER_PATH_TYPES}"
+            )
+
+    def test_all_models_have_required_fields(self):
+        """Test that all MODEL_CONFIGS entries have all required fields."""
+        required_fields = {"component", "checkpoint_files", "model_type", "dataset_type", "tokenizer", "slurm"}
+
+        for model_name, config in MODEL_CONFIGS.items():
+            missing = required_fields - set(config.keys())
+            assert not missing, f"Model '{model_name}' missing required fields: {missing}"
+
+    def test_all_models_have_slurm_config(self):
+        """Test that all MODEL_CONFIGS entries have SLURM configuration."""
+        slurm_fields = {"mem", "cpus", "gpus"}
+
+        for model_name, config in MODEL_CONFIGS.items():
+            assert "slurm" in config, f"Model '{model_name}' missing slurm config"
+            missing = slurm_fields - set(config["slurm"].keys())
+            assert not missing, f"Model '{model_name}' missing slurm fields: {missing}"
+
+
+class TestModelConfigsIntegration:
+    """Test that configure_tokenizer works with all actual MODEL_CONFIGS."""
+
+    @pytest.mark.parametrize("model_name", list(MODEL_CONFIGS.keys()))
+    def test_configure_tokenizer_works_for_model(self, model_name):
+        """Test that configure_tokenizer works for each model in MODEL_CONFIGS."""
+        config = {"tokenizer": {}}
+        model_config = MODEL_CONFIGS[model_name]
+
+        # Should not raise any exception
+        result = configure_tokenizer(config, model_config, model_name, model_name)
+
+        # Should have set component and path
+        assert "_component_" in result["tokenizer"], f"Model '{model_name}' missing _component_"
+        assert "path" in result["tokenizer"], f"Model '{model_name}' missing path"
+
+
+# =============================================================================
+# Tests for VALID_TOKENIZER_PATH_TYPES
+# =============================================================================
+
+class TestValidTokenizerPathTypes:
+    """Test the VALID_TOKENIZER_PATH_TYPES constant."""
+
+    def test_contains_expected_types(self):
+        """Test that VALID_TOKENIZER_PATH_TYPES contains expected entries."""
+        assert "llama" in VALID_TOKENIZER_PATH_TYPES
+        assert "qwen" in VALID_TOKENIZER_PATH_TYPES
+
+    def test_all_types_have_handler(self):
+        """Test that all valid path_types have a handler in configure_tokenizer."""
+        for path_type in VALID_TOKENIZER_PATH_TYPES:
+            config = {"tokenizer": {}}
+            model_config = {
+                "tokenizer": {
+                    "component": f"torchtune.models.test.test_tokenizer",
+                    "path_type": path_type,
+                }
+            }
+
+            # Should not raise - each path_type should have a handler
+            result = configure_tokenizer(config, model_config, "TestModel", "TestModel")
+            assert "_component_" in result["tokenizer"]

--- a/tests/unit/test_model_configs.py
+++ b/tests/unit/test_model_configs.py
@@ -5,7 +5,7 @@ Run these tests when adding a new model to verify the configuration is correct:
 
 These tests verify:
 - All models have required tokenizer configuration
-- All tokenizer path_types are valid and handled
+- All tokenizer model_familys are valid and handled
 - configure_tokenizer() works correctly for all supported model families
 """
 
@@ -13,7 +13,7 @@ import pytest
 from cruijff_kit.tools.torchtune.model_configs import (
     MODEL_CONFIGS,
     configure_tokenizer,
-    VALID_TOKENIZER_PATH_TYPES,
+    SUPPORTED_MODEL_FAMILIES,
 )
 
 
@@ -30,7 +30,7 @@ class TestConfigureTokenizerByFamily:
         model_config = {
             "tokenizer": {
                 "component": "torchtune.models.llama3.llama3_tokenizer",
-                "path_type": "llama",
+                "model_family": "llama",
             }
         }
 
@@ -46,7 +46,7 @@ class TestConfigureTokenizerByFamily:
         model_config = {
             "tokenizer": {
                 "component": "torchtune.models.qwen2_5.qwen2_5_tokenizer",
-                "path_type": "qwen",
+                "model_family": "qwen",
             }
         }
 
@@ -60,37 +60,37 @@ class TestConfigureTokenizerByFamily:
 class TestConfigureTokenizerErrors:
     """Test error handling in configure_tokenizer()."""
 
-    def test_unknown_path_type_raises_error(self):
-        """Test that unknown path_type raises ValueError."""
+    def test_unknown_model_family_raises_error(self):
+        """Test that unknown model_family raises ValueError."""
         config = {"tokenizer": {}}
         model_config = {
             "tokenizer": {
                 "component": "torchtune.models.some.tokenizer",
-                "path_type": "unknown_type",
+                "model_family": "unknown_type",
             }
         }
 
         with pytest.raises(ValueError) as exc_info:
             configure_tokenizer(config, model_config, "SomeModel", "SomeModel")
 
-        assert "Unknown tokenizer path_type" in str(exc_info.value)
+        assert "Unknown tokenizer model_family" in str(exc_info.value)
         assert "unknown_type" in str(exc_info.value)
         assert "SomeModel" in str(exc_info.value)
 
-    def test_missing_path_type_raises_error(self):
-        """Test that missing path_type raises ValueError."""
+    def test_missing_model_family_raises_error(self):
+        """Test that missing model_family raises ValueError."""
         config = {"tokenizer": {}}
         model_config = {
             "tokenizer": {
                 "component": "torchtune.models.some.tokenizer",
-                # path_type is missing
+                # model_family is missing
             }
         }
 
         with pytest.raises(ValueError) as exc_info:
             configure_tokenizer(config, model_config, "SomeModel", "SomeModel")
 
-        assert "Unknown tokenizer path_type" in str(exc_info.value)
+        assert "Unknown tokenizer model_family" in str(exc_info.value)
         assert "None" in str(exc_info.value)
 
     def test_missing_tokenizer_config_raises_error(self):
@@ -101,7 +101,7 @@ class TestConfigureTokenizerErrors:
         with pytest.raises(ValueError) as exc_info:
             configure_tokenizer(config, model_config, "SomeModel", "SomeModel")
 
-        assert "Unknown tokenizer path_type" in str(exc_info.value)
+        assert "Unknown tokenizer model_family" in str(exc_info.value)
 
 
 class TestConfigureTokenizerBehavior:
@@ -113,7 +113,7 @@ class TestConfigureTokenizerBehavior:
         model_config = {
             "tokenizer": {
                 "component": "torchtune.models.llama3.llama3_tokenizer",
-                "path_type": "llama",
+                "model_family": "llama",
             }
         }
 
@@ -139,15 +139,15 @@ class TestModelConfigsStructure:
         for model_name, config in MODEL_CONFIGS.items():
             assert "tokenizer" in config, f"Model '{model_name}' missing tokenizer config"
             assert "component" in config["tokenizer"], f"Model '{model_name}' missing tokenizer component"
-            assert "path_type" in config["tokenizer"], f"Model '{model_name}' missing tokenizer path_type"
+            assert "model_family" in config["tokenizer"], f"Model '{model_name}' missing tokenizer model_family"
 
-    def test_all_models_have_valid_path_type(self):
-        """Test that all MODEL_CONFIGS have a valid tokenizer path_type."""
+    def test_all_models_have_valid_model_family(self):
+        """Test that all MODEL_CONFIGS have a valid tokenizer model_family."""
         for model_name, config in MODEL_CONFIGS.items():
-            path_type = config["tokenizer"]["path_type"]
-            assert path_type in VALID_TOKENIZER_PATH_TYPES, (
-                f"Model '{model_name}' has invalid path_type '{path_type}'. "
-                f"Valid types: {VALID_TOKENIZER_PATH_TYPES}"
+            model_family = config["tokenizer"]["model_family"]
+            assert model_family in SUPPORTED_MODEL_FAMILIES, (
+                f"Model '{model_name}' has invalid model_family '{model_family}'. "
+                f"Valid types: {SUPPORTED_MODEL_FAMILIES}"
             )
 
     def test_all_models_have_required_fields(self):
@@ -186,28 +186,28 @@ class TestModelConfigsIntegration:
 
 
 # =============================================================================
-# Tests for VALID_TOKENIZER_PATH_TYPES
+# Tests for SUPPORTED_MODEL_FAMILIES
 # =============================================================================
 
 class TestValidTokenizerPathTypes:
-    """Test the VALID_TOKENIZER_PATH_TYPES constant."""
+    """Test the SUPPORTED_MODEL_FAMILIES constant."""
 
     def test_contains_expected_types(self):
-        """Test that VALID_TOKENIZER_PATH_TYPES contains expected entries."""
-        assert "llama" in VALID_TOKENIZER_PATH_TYPES
-        assert "qwen" in VALID_TOKENIZER_PATH_TYPES
+        """Test that SUPPORTED_MODEL_FAMILIES contains expected entries."""
+        assert "llama" in SUPPORTED_MODEL_FAMILIES
+        assert "qwen" in SUPPORTED_MODEL_FAMILIES
 
     def test_all_types_have_handler(self):
-        """Test that all valid path_types have a handler in configure_tokenizer."""
-        for path_type in VALID_TOKENIZER_PATH_TYPES:
+        """Test that all valid model_familys have a handler in configure_tokenizer."""
+        for model_family in SUPPORTED_MODEL_FAMILIES:
             config = {"tokenizer": {}}
             model_config = {
                 "tokenizer": {
                     "component": f"torchtune.models.test.test_tokenizer",
-                    "path_type": path_type,
+                    "model_family": model_family,
                 }
             }
 
-            # Should not raise - each path_type should have a handler
+            # Should not raise - each model_family should have a handler
             result = configure_tokenizer(config, model_config, "TestModel", "TestModel")
             assert "_component_" in result["tokenizer"]

--- a/tools/torchtune/datasets/__init__.py
+++ b/tools/torchtune/datasets/__init__.py
@@ -3,9 +3,17 @@ from .chat_completion import (
     ChatCompletionDataset,
     chat_completion_dataset,
 )
+from .text_completion import (
+    TextCompletionConfig,
+    TextCompletionDataset,
+    text_completion_dataset,
+)
 
 __all__ = [
     "ChatCompletionConfig",
     "ChatCompletionDataset",
     "chat_completion_dataset",
+    "TextCompletionConfig",
+    "TextCompletionDataset",
+    "text_completion_dataset",
 ]

--- a/tools/torchtune/datasets/text_completion.py
+++ b/tools/torchtune/datasets/text_completion.py
@@ -1,0 +1,158 @@
+"""
+TextCompletionDataset: Fine-tuning dataset for base/foundation models.
+
+Uses simple text concatenation (no chat template) for models without
+instruction-following capabilities. Ensures exact tokenization parity
+with evaluation by using HuggingFace tokenizer directly.
+"""
+
+import json
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import torch
+from torch.utils.data import Dataset
+
+
+@dataclass
+class TextCompletionConfig:
+    """Configuration for text completion dataset."""
+
+    model_path: str  # Path to HuggingFace model (for loading tokenizer)
+    prompt: str = "{input}"  # Format string to wrap input
+    input_key: str = "input"
+    output_key: str = "output"
+    max_length: Optional[int] = None
+    train_on_input: bool = False  # False = output only, True = full sequence
+
+
+class TextCompletionDataset(Dataset):
+    """
+    Fine-tuning dataset for base/foundation models.
+
+    Uses simple text concatenation: prompt.format(**row) + output
+    No chat template is applied, matching evaluation for base models.
+
+    Returns {"tokens": tensor, "labels": tensor} where labels has -100
+    for prompt tokens (not trained) and token IDs for output response.
+    """
+
+    def __init__(
+        self,
+        rows: list[dict[str, Any]],
+        tokenizer,  # Ignored - we load our own HF tokenizer
+        *,
+        cfg: TextCompletionConfig,
+    ):
+        self.rows = rows
+        self.cfg = cfg
+
+        # Load HuggingFace tokenizer (ignore passed torchtune tokenizer)
+        from transformers import AutoTokenizer
+
+        self.tok = AutoTokenizer.from_pretrained(cfg.model_path)
+
+        # Ensure we have a pad token
+        if self.tok.pad_token is None:
+            self.tok.pad_token = self.tok.eos_token
+
+    def __len__(self) -> int:
+        return len(self.rows)
+
+    def __getitem__(self, idx: int) -> dict[str, torch.Tensor]:
+        row = self.rows[idx]
+
+        # 1. Format prompt with input
+        formatted_prompt = self.cfg.prompt.format(**row)
+        output = row[self.cfg.output_key]
+
+        # 2. Tokenize prompt only (for masking calculation)
+        prompt_ids = self.tok.encode(formatted_prompt, add_special_tokens=True)
+
+        # 3. Tokenize full sequence: prompt + output
+        full_text = formatted_prompt + output
+        full_ids = self.tok.encode(full_text, add_special_tokens=True)
+
+        # 4. Determine prompt length for masking
+        # Note: Due to tokenization, prompt_ids may not be exact prefix of full_ids,
+        # but the lengths should be usable for masking
+        prompt_len = len(prompt_ids)
+
+        # 5. Create labels
+        if self.cfg.train_on_input:
+            labels = full_ids.copy()
+        else:
+            # Mask prompt tokens, train on output only
+            labels = [-100] * prompt_len + full_ids[prompt_len:]
+
+        # 6. Optional truncation
+        if self.cfg.max_length is not None:
+            full_ids = full_ids[: self.cfg.max_length]
+            labels = labels[: self.cfg.max_length]
+
+        return {
+            "tokens": torch.tensor(full_ids, dtype=torch.long),
+            "labels": torch.tensor(labels, dtype=torch.long),
+        }
+
+
+def text_completion_dataset(
+    tokenizer,  # Ignored - we load our own HF tokenizer
+    *,
+    source: str,
+    data_files: str,
+    model_path: str,  # Required: path to HF model for tokenizer
+    prompt: str = "{input}",
+    input_key: str = "input",
+    output_key: str = "output",
+    max_length: Optional[int] = None,
+    train_on_input: bool = False,
+    split: str = "train",
+    packed: bool = False,  # Accepted but not used - recipe reads this for collate_fn selection
+) -> TextCompletionDataset:
+    """
+    Factory function for torchtune YAML instantiation.
+
+    Usage in finetune.yaml:
+        dataset:
+          _component_: cruijff_kit.tools.torchtune.datasets.text_completion.text_completion_dataset
+          source: json
+          data_files: /path/to/data.json
+          model_path: /path/to/Llama-3.2-1B
+          split: train
+          prompt: "{input}"
+          input_key: input
+          output_key: output
+          train_on_input: false
+
+    Note: The `tokenizer` argument is ignored. This dataset loads its own
+    HuggingFace tokenizer from model_path to ensure consistent tokenization
+    between training and evaluation (which also uses HF tokenizer).
+
+    Note: No system_prompt parameter - base models don't use chat format.
+    The prompt template should include any prefixes needed.
+    """
+    if source != "json":
+        raise ValueError(f"Only 'json' source supported, got: {source}")
+
+    with open(data_files) as f:
+        data = json.load(f)
+
+    # Handle both flat list and {"train": [...], "validation": [...]} formats
+    if isinstance(data, dict) and split in data:
+        rows = data[split]
+    elif isinstance(data, list):
+        rows = data
+    else:
+        raise ValueError(f"Unexpected JSON structure: expected list or dict with '{split}' key")
+
+    cfg = TextCompletionConfig(
+        model_path=model_path,
+        prompt=prompt,
+        input_key=input_key,
+        output_key=output_key,
+        max_length=max_length,
+        train_on_input=train_on_input,
+    )
+
+    return TextCompletionDataset(rows, tokenizer, cfg=cfg)

--- a/tools/torchtune/model_configs.py
+++ b/tools/torchtune/model_configs.py
@@ -1,0 +1,197 @@
+"""Model configurations for torchtune fine-tuning.
+
+This module contains model-specific configurations for all supported models,
+including tokenizer settings, checkpoint file patterns, and SLURM resource
+requirements.
+
+To add a new model:
+1. Add an entry to MODEL_CONFIGS with the model directory name as the key
+2. If the model uses a new tokenizer format, add a handler in configure_tokenizer()
+   and update VALID_TOKENIZER_PATH_TYPES
+"""
+
+# Valid tokenizer path types - update when adding new model families
+VALID_TOKENIZER_PATH_TYPES = {"llama", "qwen"}
+
+# Model-specific configurations
+# Keys are model directory names (e.g., "Llama-3.2-3B-Instruct")
+# SLURM resources follow RAM=VRAM rule to ensure checkpoint saving doesn't OOM
+MODEL_CONFIGS = {
+    # -------------------------------------------------------------------------
+    # Llama models - use SentencePiece tokenizer (original/tokenizer.model)
+    # -------------------------------------------------------------------------
+    # Base/foundation models - use text_completion
+    "Llama-3.2-1B": {
+        "component": "torchtune.models.llama3_2.lora_llama3_2_1b",
+        "checkpoint_files": ["model.safetensors"],
+        "model_type": "LLAMA3_2",
+        "dataset_type": "text_completion",
+        "tokenizer": {
+            "component": "torchtune.models.llama3.llama3_tokenizer",
+            "path_type": "llama",
+        },
+        "slurm": {
+            "mem": "40G",
+            "partition": "nomig",
+            "constraint": None,
+            "cpus": 4,
+            "gpus": 1,
+        },
+    },
+    # Instruct models - use chat_completion
+    "Llama-3.2-1B-Instruct": {
+        "component": "torchtune.models.llama3_2.lora_llama3_2_1b",
+        "checkpoint_files": ["model.safetensors"],
+        "model_type": "LLAMA3_2",
+        "dataset_type": "chat_completion",
+        "tokenizer": {
+            "component": "torchtune.models.llama3.llama3_tokenizer",
+            "path_type": "llama",
+        },
+        "slurm": {
+            "mem": "40G",
+            "partition": "nomig",  # Avoid MIG partitions by default
+            "constraint": None,
+            "cpus": 4,
+            "gpus": 1,
+        },
+    },
+    "Llama-3.2-3B-Instruct": {
+        "component": "torchtune.models.llama3_2.lora_llama3_2_3b",
+        "checkpoint_files": {
+            "filename_format": "model-{}-of-{}.safetensors",
+            "max_filename": "00002",
+        },
+        "model_type": "LLAMA3_2",
+        "dataset_type": "chat_completion",
+        "tokenizer": {
+            "component": "torchtune.models.llama3.llama3_tokenizer",
+            "path_type": "llama",
+        },
+        "slurm": {
+            "mem": "80G",
+            "partition": None,
+            "constraint": "gpu80",
+            "cpus": 4,
+            "gpus": 1,
+        },
+    },
+    "Llama-3.1-8B-Instruct": {
+        "component": "torchtune.models.llama3_1.lora_llama3_1_8b",
+        "checkpoint_files": {
+            "filename_format": "model-{}-of-{}.safetensors",
+            "max_filename": "00004",
+        },
+        "model_type": "LLAMA3",
+        "dataset_type": "chat_completion",
+        "tokenizer": {
+            "component": "torchtune.models.llama3.llama3_tokenizer",
+            "path_type": "llama",
+        },
+        "slurm": {
+            "mem": "80G",
+            "partition": None,
+            "constraint": "gpu80",
+            "cpus": 4,
+            "gpus": 1,
+        },
+    },
+    "Llama-3.3-70B-Instruct": {
+        "component": "torchtune.models.llama3_3.lora_llama3_3_70b",
+        "checkpoint_files": {
+            "filename_format": "model-{}-of-{}.safetensors",
+            "max_filename": "00030",
+        },
+        "model_type": "LLAMA3",
+        "dataset_type": "chat_completion",
+        "tokenizer": {
+            "component": "torchtune.models.llama3.llama3_tokenizer",
+            "path_type": "llama",
+        },
+        "slurm": {
+            "mem": "320G",
+            "partition": None,
+            "constraint": "gpu80",
+            "cpus": 16,
+            "gpus": 4,
+        },
+    },
+    # -------------------------------------------------------------------------
+    # Qwen2.5 models - use BPE tokenizer (vocab.json + merges.txt)
+    # -------------------------------------------------------------------------
+    "Qwen2.5-3B": {
+        "component": "torchtune.models.qwen2_5.lora_qwen2_5_3b",
+        "checkpoint_files": {
+            "filename_format": "model-{}-of-{}.safetensors",
+            "max_filename": "00002",
+        },
+        "model_type": "QWEN2",
+        "dataset_type": "text_completion",
+        "tokenizer": {
+            "component": "torchtune.models.qwen2_5.qwen2_5_tokenizer",
+            "path_type": "qwen",
+        },
+        "slurm": {
+            "mem": "80G",
+            "partition": None,
+            "constraint": "gpu80",
+            "cpus": 4,
+            "gpus": 1,
+        },
+    },
+    "Qwen2.5-3B-Instruct": {
+        "component": "torchtune.models.qwen2_5.lora_qwen2_5_3b",
+        "checkpoint_files": {
+            "filename_format": "model-{}-of-{}.safetensors",
+            "max_filename": "00002",
+        },
+        "model_type": "QWEN2",
+        "dataset_type": "chat_completion",
+        "tokenizer": {
+            "component": "torchtune.models.qwen2_5.qwen2_5_tokenizer",
+            "path_type": "qwen",
+        },
+        "slurm": {
+            "mem": "80G",
+            "partition": None,
+            "constraint": "gpu80",
+            "cpus": 4,
+            "gpus": 1,
+        },
+    },
+}
+
+def configure_tokenizer(config, model_config, model_dir, model_name):
+    """Configure tokenizer settings based on model family.
+
+    Args:
+        config: The configuration dictionary to modify (must have 'tokenizer' key)
+        model_config: Model-specific configuration from MODEL_CONFIGS
+        model_dir: Directory name of the model within models_dir
+        model_name: Name of the model (for error messages)
+
+    Returns:
+        Modified configuration dictionary
+
+    Raises:
+        ValueError: If tokenizer path_type is missing or unknown
+    """
+    tokenizer_config = model_config.get("tokenizer", {})
+    path_type = tokenizer_config.get("path_type")
+
+    if path_type == "llama":
+        # Llama models use SentencePiece tokenizer
+        config["tokenizer"]["_component_"] = tokenizer_config["component"]
+        config["tokenizer"]["path"] = f"${{models_dir}}/{model_dir}/original/tokenizer.model"
+    elif path_type == "qwen":
+        # Qwen models use BPE tokenizer with vocab.json + merges.txt
+        config["tokenizer"]["_component_"] = tokenizer_config["component"]
+        config["tokenizer"]["path"] = f"${{models_dir}}/{model_dir}/vocab.json"
+        config["tokenizer"]["merges_file"] = f"${{models_dir}}/{model_dir}/merges.txt"
+    else:
+        raise ValueError(
+            f"Unknown tokenizer path_type '{path_type}' for model '{model_name}'. "
+            f"Supported path_types: {sorted(VALID_TOKENIZER_PATH_TYPES)}"
+        )
+
+    return config

--- a/tools/torchtune/setup_finetune.py
+++ b/tools/torchtune/setup_finetune.py
@@ -8,8 +8,7 @@ from cruijff_kit.utils import run_names
 from cruijff_kit.tools.torchtune import config_recipe_loader
 from cruijff_kit.tools.torchtune.model_configs import (
     MODEL_CONFIGS,
-    configure_tokenizer,
-    VALID_TOKENIZER_PATH_TYPES,
+    configure_tokenizer
 )
 
 # Calculate paths relative to this script


### PR DESCRIPTION
Closes #{263}

# Description

(1) Base model support
- Adds the `TextCompletionDataset` (analogous to `ChatCompletionDataset` for instruction-tuned models) for base models; unlike the instruction-tuned models, we don't need `apply_chat_template` from HuggingFace, so this class mostly exists to tokenize the data with the HuggingFace tokenizer to ensure parity between torchtune and inspect data formats on silly things like EOS tokens. 
- Standardizes the language used in skills (scaffold-torchtune, design-experiment, scaffold-inspect) on "base" model as referring to text completion foundation models, whereas "control" models are for runs that are not fine-tuned on this particular task (formerly called "base" models in the skills).
- Add parameters to inspect tasks to chain system prompt when `use_chat_template` parameter is specified, which scaffold-inspect agent infers from either (1) `dataset_type` (in MODEL_CONFIG for setup_finetune.py) or (2) the name of the model (`-Instruct`) for control runs that are not scaffolded w/ torchtune.

(2) Onboards Qwen-2.5-3B* models + refactor for future model additions
- Adds model-family-specific tokenizer logic and a list of supported model families 
-  Creates `model_configs.py`; if onboarding a new model, just have to add config to MODEL_CONFIG dictionary; if new model family, also check what tokenizer is used.
- Adds tests to ensure all models in MODEL_CONFIG have correct parameters + tokenizer exists for that family. 

## New Dependencies

NA

# Testing Instructions

Sample fine-tuning of base model with cruijff_kit on HPC -- `sarahep/ck-experiments/acs_income_base_finetuned_few_shot_2026-01-26`

Sample fine-tuning of Qwen-2.5-3B and Qwen-2.5-3B-Instruct on HPC -- `sarahep/ck-experiments/acs_income_qwen_base_vs_instruct_2026-01-26`