### PR TITLE
Add analyze-to-pdf skill

### DIFF
--- a/.claude/skills/analyze-to-pdf/SKILL.md
+++ b/.claude/skills/analyze-to-pdf/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: analyze-to-pdf
+description: Convert experiment analysis reports (report.md) to PDF using pandoc. Use after analyze-experiment to create shareable PDF reports.
+---
+
+# Analyze to PDF
+
+Convert a markdown file to PDF using pandoc. Designed for experiment analysis reports but works with any markdown file.
+
+## Your Task
+
+1. Check that required system tools are installed
+2. Locate the markdown file to convert
+3. Convert to PDF with pandoc
+4. Report the result
+
+## Dependency Check
+
+Verify tools are available before proceeding:
+
+### Required: pandoc
+
+```bash
+which pandoc
+```
+
+If missing, stop and report:
+```
+pandoc is not installed. Install it with your package manager (e.g., apt install pandoc, dnf install pandoc).
+```
+
+### Required: PDF engine (one of the following, in priority order)
+
+```bash
+which xelatex    # preferred — better Unicode support
+which pdflatex   # fallback
+```
+
+If neither is found, stop and report:
+```
+No PDF engine found. pandoc needs a LaTeX installation to produce PDFs.
+Install texlive (e.g., apt install texlive-xetex or dnf install texlive-xetex).
+```
+
+Record which engine is available for the conversion step.
+
+## Locate Markdown File
+
+**If user provides a path argument:** Use that path directly.
+
+**If no argument provided:**
+1. Check if current directory contains `experiment_summary.yaml`
+2. If yes, look for `analysis/report.md`
+3. If that file exists, use it
+4. Otherwise, ask the user for a path
+
+**Validate** the file exists before proceeding.
+
+## Convert to PDF
+
+**Critical:** Change to the markdown file's parent directory before running pandoc. This ensures relative image paths (e.g., `![](scores_by_task.png)`) resolve correctly.
+
+```bash
+cd {parent_directory}
+pandoc {filename} -o {stem}.pdf --pdf-engine={engine}
+```
+
+Where `{stem}` is the filename without the `.md` extension (e.g., `report.md` → `report.pdf`).
+
+## Report Result
+
+**On success:**
+```
+PDF created: {full_path_to_pdf} ({file_size})
+```
+
+**On failure:** Show the pandoc error output. Common issues:
+- Missing LaTeX packages: suggest `tlmgr install {package}` or a fuller texlive install
+- Image format not supported: suggest converting images to PNG first
+- Unicode issues with pdflatex: suggest installing xelatex instead
+
+## Important Notes
+
+- **No logging file** — this is a lightweight utility, not a multi-stage workflow
+- **Idempotent** — re-running overwrites the existing PDF
+- **Image embedding** — the `cd` into the file's directory is what makes relative image paths work. Do not skip this.
+- **xelatex over pdflatex** — prefer xelatex when available for better Unicode and font handling

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ cruijff_kit includes Claude Code skills to streamline common workflows. These sk
 - **summarize-experiment** ✅ - Generate summary.md with key metrics (loss, accuracy) after experiment completion
 - **create-inspect-task** ✅ - Create custom inspect-ai evaluation tasks with guided workflow (supports experiment-guided and standalone modes)
 - **analyze-experiment** ✅ - Generate interactive HTML visualizations from evaluation logs using inspect-viz (currently supports capitalization experiments)
+- **analyze-to-pdf** ✅ - Convert analysis reports (markdown) to PDF using pandoc
 
 **Note**: All skills are optional convenience tools. Users can perform the same operations manually by running the underlying Python scripts and shell commands directly.
 

--- a/SKILLS_ARCHITECTURE_SUMMARY.md
+++ b/SKILLS_ARCHITECTURE_SUMMARY.md
@@ -99,6 +99,15 @@ Skills that create reusable evaluation tasks:
    - Can run standalone (for general task creation)
    - Status: ⚠️ Existing (not modified in this refactor)
 
+### Utility Skills
+Lightweight tools for common tasks:
+
+1. **analyze-to-pdf**
+   - Converts markdown reports to PDF using pandoc + xelatex/pdflatex
+   - Auto-detects `analysis/report.md` in experiment directories
+   - Also works with any arbitrary markdown file
+   - Status: ✅ Created
+
 ## Key Design Principles
 
 ### 1. Single Responsibility & Modularity


### PR DESCRIPTION
Closes #303

## Description

New lightweight utility skill that converts markdown reports to PDF using pandoc + xelatex. Designed for experiment analysis reports but works with any markdown file.

**Motivation:** Came up during a conversation with a colleague — wanted an easy way to share experiment reports as PDFs rather than pointing people at raw markdown files.

**What it does:**
- Checks for pandoc and a PDF engine (xelatex preferred, pdflatex fallback)
- Auto-detects `analysis/report.md` in experiment directories, or accepts a path argument
- Converts from the file's directory so relative image paths resolve correctly
- Reports clear errors if dependencies are missing

**Files:**
- **Created:** `.claude/skills/analyze-to-pdf/SKILL.md`
- **Modified:** `CLAUDE.md` — added to skills list
- **Modified:** `SKILLS_ARCHITECTURE_SUMMARY.md` — added under new "Utility Skills" section

## New Dependencies

- `pandoc` (system package, already installed on Adroit)
- `xelatex` or `pdflatex` (system package via texlive, already installed on Adroit)

## Testing Instructions

1. Run `/analyze-to-pdf /path/to/any/report.md`
2. Verify PDF is created in the same directory with embedded images
3. Tested on ACS Income analysis report — produces 256K PDF with tables and 6 embedded PNGs

🤖 Generated with [Claude Code](https://claude.com/claude-code)