### PR TITLE
Remove baseline separation from analyze-experiment reports

### DIFF
--- a/.claude/skills/analyze-experiment/SKILL.md
+++ b/.claude/skills/analyze-experiment/SKILL.md
@@ -84,10 +84,9 @@ Create visualizations using inspect-viz:
 
 Create markdown report with metrics and comparisons:
 1. Extract metrics from evaluation dataframe
-2. Identify baseline model (finetuned=False, type="control", or "base" in name)
-3. Compute Wilson score confidence intervals
-4. Generate narrative summary and comparison tables
-5. Write report to `analysis/report.md`
+2. Compute Wilson score confidence intervals
+3. Generate narrative summary and comparison tables
+4. Write report to `analysis/report.md`
 
 Uses `tools/inspect/report_generator.py`:
 ```python
@@ -97,7 +96,7 @@ report = generate_report(
     df=logs_df,
     experiment_name=experiment_name,
     output_path=Path(experiment_dir) / "analysis" / "report.md",
-    config=experiment_config  # Optional, for baseline identification
+    config=experiment_config  # Optional, for research question metadata
 )
 ```
 
@@ -236,7 +235,7 @@ Experiment: `{experiment_dir}`
 ✓ Markdown report: `analysis/report.md`
   - Executive summary with best performer
   - Model comparison table with 95% CIs
-  - Improvement vs baseline table
+  - Calibration metrics (if available)
 
 ### Visualizations Generated
 

--- a/.claude/skills/analyze-experiment/generation.md
+++ b/.claude/skills/analyze-experiment/generation.md
@@ -256,19 +256,10 @@ The generated `report.md` includes:
 
 | Section | Description |
 |---------|-------------|
-| Executive Summary | Best performer, improvement vs baseline |
+| Executive Summary | Best performer and model count |
 | Model Comparison | Table with accuracy, 95% CI, sample size |
-| Improvement vs Baseline | Absolute and relative differences |
 | Calibration & Risk Metrics | ECE, Brier, AUC, Mean Risk Score (if supplementary metrics detected) |
 | Per-Task Breakdown | Best model per task (if multiple tasks) |
-
-### Baseline Identification
-
-The report automatically identifies baseline models using this priority:
-
-1. `finetuned == False` in metadata
-2. `type == "control"` in experiment_summary.yaml
-3. "base" in model name (case-insensitive)
 
 ### Confidence Intervals
 
@@ -277,11 +268,6 @@ Uses Wilson score intervals (preferred over normal approximation):
 - Works well with small samples and extreme proportions
 
 ### Error Handling
-
-**If no baseline found:**
-- Report still generates
-- Comparison section shows "No baseline identified"
-- Narrative focuses on best performer only
 
 **If metrics extraction fails:**
 - Log error

--- a/.claude/skills/analyze-experiment/logging.md
+++ b/.claude/skills/analyze-experiment/logging.md
@@ -50,7 +50,6 @@ Created during analysis to record data loading, visualization selection, and gen
 ### During Report Generation
 - Report output path
 - Number of models included
-- Baseline model identified (or none)
 - Any report generation errors
 
 ### On Completion
@@ -89,7 +88,7 @@ Result: analysis/scores_by_task.html
 
 [2026-01-29 14:00:18] GENERATE_REPORT
 Details: Creating markdown report with metrics and comparisons
-Result: analysis/report.md (3 models, baseline: 1B_base)
+Result: analysis/report.md (3 models)
 
 [2026-01-29 14:00:20] COMPLETE
 Details: All visualizations generated

--- a/tools/inspect/report_generator.py
+++ b/tools/inspect/report_generator.py
@@ -37,21 +37,8 @@ class ModelMetrics:
     sample_size: int
     epoch: Optional[int] = None
     task_name: Optional[str] = None
-    is_baseline: bool = False
-    is_synthetic: bool = False  # True for synthetic baselines (not actual runs)
     balanced_accuracy: Optional[float] = None
     f1: Optional[float] = None
-
-
-@dataclass
-class Comparison:
-    """Comparison between two models."""
-
-    model_a: str
-    model_b: str
-    absolute_diff: float
-    relative_diff: float  # as percentage
-    direction: str  # "improvement" or "decline"
 
 
 @dataclass
@@ -62,13 +49,11 @@ class CalibrationResult:
     metrics: dict[str, Optional[float]]  # metric_name -> value (None if NA)
     sample_size: int
     epoch: Optional[int] = None
-    is_baseline: bool = False
 
 
 def extract_calibration_metrics(
     df: pd.DataFrame,
     supplementary_metrics: list[str],
-    config: Optional[dict] = None,
 ) -> list[CalibrationResult]:
     """
     Extract calibration / risk metrics from evaluation dataframe.
@@ -76,15 +61,12 @@ def extract_calibration_metrics(
     Args:
         df: DataFrame with score columns (from evals_df_prep + parse_eval_metadata)
         supplementary_metrics: List of supplementary metric names (from DetectedMetrics)
-        config: Optional experiment config for baseline identification
 
     Returns:
         List of CalibrationResult per model/epoch combination
     """
     if not supplementary_metrics:
         return []
-
-    baseline_info = identify_baseline(df, config)
 
     # Determine sample size column
     sample_col = None
@@ -108,11 +90,6 @@ def extract_calibration_metrics(
 
         n = int(group_df[sample_col].iloc[0]) if sample_col else 0
 
-        is_baseline = (
-            baseline_info.model_name is not None
-            and model_name == baseline_info.model_name
-        )
-
         metric_values: dict[str, Optional[float]] = {}
         for metric_name in supplementary_metrics:
             col_name = f"score_{metric_name}"
@@ -132,7 +109,6 @@ def extract_calibration_metrics(
                 metrics=metric_values,
                 sample_size=n,
                 epoch=epoch,
-                is_baseline=is_baseline,
             )
         )
 
@@ -168,14 +144,13 @@ def _format_calibration_table(results: list[CalibrationResult]) -> str:
 
     lines = [header_line, separator]
 
-    # Sort by model name, with baselines first
-    sorted_results = sorted(results, key=lambda r: (not r.is_baseline, r.model_name))
+    # Sort by model name
+    sorted_results = sorted(results, key=lambda r: r.model_name)
 
     for r in sorted_results:
         epoch_str = str(r.epoch) if r.epoch is not None else "-"
-        baseline_marker = " *" if r.is_baseline else ""
 
-        cells = [f"{r.model_name}{baseline_marker}", epoch_str]
+        cells = [r.model_name, epoch_str]
         for metric_name in all_metric_names:
             val = r.metrics.get(metric_name)
             cells.append(f"{val:.3f}" if val is not None else "-")
@@ -238,72 +213,8 @@ def _z_score(confidence: float) -> float:
     return z_scores.get(confidence, 1.96)
 
 
-@dataclass
-class BaselineInfo:
-    """Information about the baseline for comparison."""
-
-    model_name: Optional[str] = None  # Model name if baseline is in experiment
-    accuracy: Optional[float] = None  # Known accuracy if synthetic baseline
-    source: Optional[str] = None  # Description of where baseline comes from
-
-
-def identify_baseline(
-    df: pd.DataFrame, config: Optional[dict] = None
-) -> BaselineInfo:
-    """
-    Identify baseline model or value from dataframe or config.
-
-    Priority order:
-    1. finetuned == False in metadata
-    2. type == "control" in experiment_summary.yaml config
-    3. "base" in model name (case-insensitive)
-    4. evaluation.baseline.accuracy in config (known value like random chance)
-
-    Args:
-        df: DataFrame with model column and optional finetuned column
-        config: Optional experiment_summary.yaml config dict
-
-    Returns:
-        BaselineInfo with either model_name or accuracy/source populated
-    """
-    # Priority 1: Look for finetuned == False
-    if "finetuned" in df.columns:
-        not_finetuned = df[df["finetuned"] == False]  # noqa: E712
-        if not not_finetuned.empty:
-            return BaselineInfo(model_name=not_finetuned["model"].iloc[0])
-
-    # Priority 2: Check config for type == "control"
-    if config and "runs" in config:
-        for run in config["runs"]:
-            if run.get("type") == "control":
-                # Try to match run name to model in df
-                run_name = run.get("name", "")
-                matching = df[df["model"].str.contains(run_name, case=False, na=False)]
-                if not matching.empty:
-                    return BaselineInfo(model_name=matching["model"].iloc[0])
-
-    # Priority 3: Look for "base" in model name
-    model_col = "model" if "model" in df.columns else None
-    if model_col:
-        base_models = df[df[model_col].str.contains("base", case=False, na=False)]
-        if not base_models.empty:
-            return BaselineInfo(model_name=base_models[model_col].iloc[0])
-
-    # Priority 4: Check config for evaluation.baseline with known accuracy
-    if config:
-        eval_config = config.get("evaluation", {})
-        baseline_config = eval_config.get("baseline", {})
-        if baseline_config.get("accuracy") is not None:
-            return BaselineInfo(
-                accuracy=baseline_config["accuracy"],
-                source=baseline_config.get("source", "specified in config"),
-            )
-
-    return BaselineInfo()
-
-
 def extract_metrics(
-    df: pd.DataFrame, config: Optional[dict] = None
+    df: pd.DataFrame,
 ) -> list[ModelMetrics]:
     """
     Extract ModelMetrics from evaluation dataframe.
@@ -311,13 +222,11 @@ def extract_metrics(
     Args:
         df: DataFrame with columns: model, sample_size (or results_total_samples),
             and score columns (e.g., score_match_accuracy)
-        config: Optional experiment config for baseline identification
 
     Returns:
-        List of ModelMetrics dataclasses (includes synthetic baseline if configured)
+        List of ModelMetrics dataclasses
     """
     metrics = []
-    baseline_info = identify_baseline(df, config)
 
     # Determine sample size column
     sample_col = None
@@ -366,12 +275,6 @@ def extract_metrics(
         # Compute confidence interval
         ci_lower, ci_upper = compute_wilson_ci(acc, n)
 
-        # Check if baseline (model in experiment)
-        is_baseline = (
-            baseline_info.model_name is not None
-            and model_name == baseline_info.model_name
-        )
-
         # Get optional metrics
         balanced_acc = None
         f1 = None
@@ -389,110 +292,28 @@ def extract_metrics(
                 sample_size=n,
                 epoch=epoch,
                 task_name=task_name,
-                is_baseline=is_baseline,
                 balanced_accuracy=balanced_acc,
                 f1=f1,
-            )
-        )
-
-    # Add synthetic baseline if configured (known accuracy value)
-    if baseline_info.accuracy is not None:
-        # Use median sample size from actual data for CI calculation
-        median_n = 1000  # Conservative default for synthetic baseline
-        if metrics:
-            median_n = int(sorted(m.sample_size for m in metrics)[len(metrics) // 2])
-
-        ci_lower, ci_upper = compute_wilson_ci(baseline_info.accuracy, median_n)
-        baseline_name = baseline_info.source or "baseline"
-
-        metrics.append(
-            ModelMetrics(
-                name=baseline_name,
-                accuracy=baseline_info.accuracy,
-                ci_lower=ci_lower,
-                ci_upper=ci_upper,
-                sample_size=median_n,
-                epoch=None,
-                task_name=None,
-                is_baseline=True,
-                is_synthetic=True,
             )
         )
 
     return metrics
 
 
-def compute_comparisons(
-    metrics: list[ModelMetrics], baseline_name: Optional[str] = None
-) -> list[Comparison]:
-    """
-    Compute comparisons between models, relative to baseline if available.
-
-    Args:
-        metrics: List of ModelMetrics to compare
-        baseline_name: Optional explicit baseline model name
-
-    Returns:
-        List of Comparison dataclasses
-    """
-    comparisons = []
-
-    # Find baseline
-    baseline = None
-    if baseline_name:
-        baseline = next((m for m in metrics if m.name == baseline_name), None)
-    else:
-        baseline = next((m for m in metrics if m.is_baseline), None)
-
-    if not baseline:
-        # No baseline - compare all pairs? Or skip comparisons
-        return comparisons
-
-    for m in metrics:
-        if m.name == baseline.name:
-            continue
-
-        abs_diff = m.accuracy - baseline.accuracy
-        rel_diff = (abs_diff / baseline.accuracy * 100) if baseline.accuracy > 0 else 0
-        direction = "improvement" if abs_diff > 0 else "decline"
-
-        comparisons.append(
-            Comparison(
-                model_a=m.name,
-                model_b=baseline.name,
-                absolute_diff=abs_diff,
-                relative_diff=rel_diff,
-                direction=direction,
-            )
-        )
-
-    return comparisons
-
-
-def generate_narrative(
-    metrics: list[ModelMetrics], comparisons: list[Comparison]
-) -> str:
+def generate_narrative(metrics: list[ModelMetrics]) -> str:
     """
     Generate executive summary narrative.
 
     Args:
         metrics: List of model metrics
-        comparisons: List of model comparisons
 
     Returns:
         Markdown-formatted narrative string
     """
-    # Separate actual runs from synthetic baselines
-    actual_runs = [m for m in metrics if not m.is_synthetic]
-
-    if not actual_runs:
+    if not metrics:
         return "No model metrics available for analysis."
 
-    # Find best performer (among actual runs only)
-    best = max(actual_runs, key=lambda m: m.accuracy)
-
-    # Find baseline (could be synthetic or actual)
-    baseline = next((m for m in metrics if m.is_baseline), None)
+    best = max(metrics, key=lambda m: m.accuracy)
 
     lines = []
 
@@ -502,21 +323,8 @@ def generate_narrative(
         f"**{best.accuracy:.1%}** (95% CI: {best.ci_lower:.1%}-{best.ci_upper:.1%})."
     )
 
-    # Comparison to baseline if available
-    if baseline and baseline.name != best.name:
-        improvement = best.accuracy - baseline.accuracy
-        rel_improvement = (
-            (improvement / baseline.accuracy * 100) if baseline.accuracy > 0 else 0
-        )
-        lines.append(
-            f"This represents a **{improvement:.1%} absolute improvement** "
-            f"({rel_improvement:.1f}% relative) over the baseline ({baseline.name})."
-        )
-    elif baseline and not baseline.is_synthetic:
-        lines.append("The baseline model was the best performer.")
-
-    # Model count (actual runs only)
-    lines.append(f"\n{len(actual_runs)} model configurations were evaluated.")
+    # Model count
+    lines.append(f"\n{len(metrics)} model configurations were evaluated.")
 
     return "\n".join(lines)
 
@@ -546,10 +354,8 @@ def _format_model_table(
                 if name not in supp_names:
                     supp_names.append(name)
 
-    # Check if sample sizes are uniform (excluding synthetic baselines)
-    actual_sizes = set(
-        m.sample_size for m in metrics if not m.is_synthetic
-    )
+    # Check if sample sizes are uniform
+    actual_sizes = set(m.sample_size for m in metrics)
     uniform_sample_size = actual_sizes.pop() if len(actual_sizes) == 1 else None
 
     # Header
@@ -562,25 +368,14 @@ def _format_model_table(
     separator = "| " + " | ".join("---" for _ in headers) + " |"
     lines = [header_line, separator]
 
-    # Sort by accuracy descending, with synthetic baselines last
-    sorted_metrics = sorted(
-        metrics,
-        key=lambda x: (x.is_synthetic, -x.accuracy),
-    )
+    # Sort by accuracy descending
+    sorted_metrics = sorted(metrics, key=lambda x: -x.accuracy)
 
-    seen_synthetic = False
     for m in sorted_metrics:
-        # Add separator before first synthetic baseline
-        if m.is_synthetic and not seen_synthetic:
-            empty_row = "| " + " | ".join("" for _ in headers) + " |"
-            lines.append(empty_row)
-            seen_synthetic = True
-
         epoch_str = str(int(m.epoch)) if m.epoch is not None and not pd.isna(m.epoch) else "-"
-        baseline_marker = " *" if m.is_baseline else ""
 
         cells = [
-            f"{m.name}{baseline_marker}",
+            m.name,
             epoch_str,
             f"{m.accuracy:.3f}",
         ]
@@ -594,13 +389,12 @@ def _format_model_table(
                 cells.append(f"{val:.3f}" if val is not None else "-")
 
         if uniform_sample_size is None:
-            sample_str = "-" if m.is_synthetic else str(m.sample_size)
-            cells.append(sample_str)
+            cells.append(str(m.sample_size))
 
         lines.append("| " + " | ".join(cells) + " |")
 
     # Build footnotes
-    footnotes = ["*\\* indicates baseline model*"]
+    footnotes = []
     if uniform_sample_size is not None:
         footnotes.append(f"*Sample size: {uniform_sample_size} per model*")
     if calibration:
@@ -611,33 +405,10 @@ def _format_model_table(
     return "\n".join(lines), footnotes
 
 
-def _format_improvement_table(comparisons: list[Comparison]) -> str:
-    """Format improvement vs baseline table."""
-    if not comparisons:
-        return "*No baseline identified for comparison.*"
-
-    lines = [
-        "| Model | Absolute | Relative |",
-        "|-------|----------|----------|",
-    ]
-
-    for c in sorted(comparisons, key=lambda x: x.absolute_diff, reverse=True):
-        sign = "+" if c.absolute_diff > 0 else ""
-        lines.append(
-            f"| {c.model_a} | {sign}{c.absolute_diff:.1%} | "
-            f"{sign}{c.relative_diff:.1f}% |"
-        )
-
-    return "\n".join(lines)
-
-
 def _format_per_task_breakdown(metrics: list[ModelMetrics]) -> str:
     """Format per-task breakdown if multiple tasks exist."""
-    # Group by task (exclude synthetic baselines)
     tasks = {}
     for m in metrics:
-        if m.is_synthetic:
-            continue
         task = m.task_name or "default"
         if task not in tasks:
             tasks[task] = []
@@ -758,17 +529,14 @@ def generate_report(
         )
     """
     # Extract metrics
-    metrics = extract_metrics(df, config)
-
-    # Compute comparisons
-    comparisons = compute_comparisons(metrics)
+    metrics = extract_metrics(df)
 
     # Generate narrative
-    narrative = generate_narrative(metrics, comparisons)
+    narrative = generate_narrative(metrics)
 
     # Build report
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
-    model_count = len(set(m.name for m in metrics if not m.is_synthetic))
+    model_count = len(set(m.name for m in metrics))
 
     report_lines = [
         "# Experiment Analysis Report\n",
@@ -787,7 +555,7 @@ def generate_report(
     calibration_results = None
     if detected.supplementary:
         calibration_results = extract_calibration_metrics(
-            df, detected.supplementary, config
+            df, detected.supplementary
         ) or None
 
     model_table, footnotes = _format_model_table(metrics, calibration_results)
@@ -797,13 +565,10 @@ def generate_report(
         narrative + "\n",
         "## Model Comparison\n",
         model_table + "\n",
-        "  \n".join(footnotes) + "\n",
     ])
 
-    report_lines.extend([
-        "## Improvement vs Baseline\n",
-        _format_improvement_table(comparisons) + "\n",
-    ])
+    if footnotes:
+        report_lines.append("  \n".join(footnotes) + "\n")
 
     # Add per-task breakdown if applicable
     task_breakdown = _format_per_task_breakdown(metrics)


### PR DESCRIPTION
Closes #297

## Summary
- Removed heuristic-based baseline auto-detection (`identify_baseline()`, `BaselineInfo`) which was too vague and often incorrect
- Base models now appear as regular rows alongside fine-tuned models in all tables
- Removed `Comparison` dataclass, `compute_comparisons()`, `_format_improvement_table()`, and the "Improvement vs Baseline" report section
- Removed `is_baseline`/`is_synthetic` fields from `ModelMetrics` and `CalibrationResult`
- Updated skill docs (SKILL.md, generation.md, logging.md) to reflect removal
- Net: 31 insertions, 315 deletions

## Test plan
- [x] All 17 report_generator unit tests pass
- [x] Full test suite (223 passed, 13 skipped)
- [x] Grep confirms zero stale references to removed APIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)