### PR TITLE
Add per-sample risk plots to analyze-experiment

### DIFF
--- a/.claude/skills/analyze-experiment/SKILL.md
+++ b/.claude/skills/analyze-experiment/SKILL.md
@@ -196,6 +196,9 @@ After running, the experiment directory will contain:
 │   ├── scores_by_task.png      (if playwright available)
 │   ├── scores_heatmap.html
 │   ├── scores_heatmap.png      (if playwright available)
+│   ├── roc_curves.png          (if risk_scorer used)
+│   ├── calibration_curves.png  (if risk_scorer used)
+│   ├── prediction_histogram.png (if risk_scorer used)
 │   └── ...
 ├── analyze-experiment.log
 └── experiment_summary.yaml

--- a/.claude/skills/analyze-experiment/data_loading.md
+++ b/.claude/skills/analyze-experiment/data_loading.md
@@ -94,6 +94,29 @@ def get_subdirs_from_config(config):
 subdirs = get_subdirs_from_config(config)
 ```
 
+### extract_per_sample_risk_data()
+
+Load per-sample `(y_true, y_score)` pairs from eval files for ROC and calibration plots:
+
+```python
+from tools.inspect.viz_helpers import extract_per_sample_risk_data
+
+risk_data = extract_per_sample_risk_data(kept)  # list[PerSampleRiskData]
+# Each entry has: model_name, y_true, y_score, n_total, n_valid
+```
+
+**Important:** This reads the full eval log (all samples), not just aggregate metrics, so it's slower than `evals_df_prep()`. Models with <2 valid samples or only one class are automatically skipped.
+
+### has_risk_scorer
+
+Check whether per-sample risk plots should be generated:
+
+```python
+detected = detect_metrics(logs_df)
+if detected.has_risk_scorer:
+    # Generate ROC + calibration plots (see generation.md)
+```
+
 ## Required Columns by View Type
 
 | View | Required Columns |

--- a/.claude/skills/analyze-experiment/generation.md
+++ b/.claude/skills/analyze-experiment/generation.md
@@ -224,6 +224,34 @@ except ImportError:
 - Skip views that require those columns
 - Report in summary
 
+## Per-Sample Risk Plots (ROC & Calibration)
+
+When the experiment used `risk_scorer`, generate overlay plots from per-sample data. These are **matplotlib PNGs** (not inspect-viz HTML), gated on `detected.has_risk_scorer`:
+
+```python
+from tools.inspect.viz_helpers import (
+    extract_per_sample_risk_data, generate_roc_overlay,
+    generate_calibration_overlay, generate_prediction_histogram,
+)
+
+if detected.has_risk_scorer:
+    risk_data = extract_per_sample_risk_data(kept)  # kept = deduplicated .eval paths
+    if risk_data:
+        roc_path = generate_roc_overlay(risk_data, f"{output_dir}/roc_curves.png")
+        cal_path = generate_calibration_overlay(risk_data, f"{output_dir}/calibration_curves.png")
+        hist_path = generate_prediction_histogram(risk_data, f"{output_dir}/prediction_histogram.png")
+        if roc_path:
+            generated_pngs.append(str(roc_path))
+        if cal_path:
+            generated_pngs.append(str(cal_path))
+        if hist_path:
+            generated_pngs.append(str(hist_path))
+```
+
+**Performance note:** `extract_per_sample_risk_data()` reads full eval logs (all samples), so it's slower than the aggregate `evals_df_prep()` path. For a 5000-sample eval this typically takes a few seconds per file.
+
+**Skipped models:** Models with <2 valid samples or only one class (e.g., zeroshot models that always predict the same thing) are silently skipped. The function logs which models were skipped at INFO level.
+
 ## Analysis & Interpretation (Required)
 
 **This step is required by default.** After generating visualizations and before calling `generate_report()`, write a `future_directions` string that interprets results and suggests next steps.

--- a/tests/unit/test_risk_plots.py
+++ b/tests/unit/test_risk_plots.py
@@ -1,0 +1,277 @@
+"""Unit tests for per-sample risk data extraction and plot generation."""
+
+import numpy as np
+import pytest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from cruijff_kit.tools.inspect.viz_helpers import (
+    DetectedMetrics,
+    PerSampleRiskData,
+    _extract_risk_from_log,
+    extract_per_sample_risk_data,
+    generate_roc_overlay,
+    generate_calibration_overlay,
+    generate_prediction_histogram,
+)
+
+
+# =============================================================================
+# Helpers — build fake eval log structures
+# =============================================================================
+
+def _make_sample(risk_score, target, option_probs):
+    """Create a minimal fake sample with risk_scorer metadata."""
+    return SimpleNamespace(
+        scores={
+            "risk_scorer": SimpleNamespace(
+                metadata={
+                    "risk_score": risk_score,
+                    "target": target,
+                    "option_probs": option_probs,
+                }
+            )
+        }
+    )
+
+
+def _make_log(samples, model="hf/test_model", vis_label=None):
+    """Create a minimal fake eval log."""
+    task_args = {}
+    if vis_label is not None:
+        task_args["vis_label"] = vis_label
+    return SimpleNamespace(
+        eval=SimpleNamespace(model=model, task_args=task_args),
+        samples=samples,
+    )
+
+
+def _make_binary_samples(n=100, seed=42):
+    """Create n samples with random risk_score and balanced binary targets."""
+    rng = np.random.default_rng(seed)
+    samples = []
+    for i in range(n):
+        target = "0" if i < n // 2 else "1"
+        risk = float(rng.uniform(0.2 if target == "0" else 0.6, 0.5 if target == "0" else 0.95))
+        samples.append(_make_sample(risk, target, {"0": risk, "1": 1 - risk}))
+    return samples
+
+
+# =============================================================================
+# PerSampleRiskData
+# =============================================================================
+
+class TestPerSampleRiskData:
+
+    def test_construction(self):
+        d = PerSampleRiskData("m", [1.0, 0.0], [0.9, 0.1], 10, 2)
+        assert d.model_name == "m"
+        assert d.n_total == 10
+        assert d.n_valid == 2
+
+
+# =============================================================================
+# _extract_risk_from_log
+# =============================================================================
+
+class TestExtractRiskFromLog:
+
+    def test_basic_extraction(self):
+        samples = _make_binary_samples(20)
+        log = _make_log(samples)
+        result = _extract_risk_from_log(log)
+        assert result is not None
+        assert result.model_name == "hf/test_model"
+        assert result.n_total == 20
+        assert result.n_valid == 20
+        assert len(result.y_true) == 20
+        assert len(result.y_score) == 20
+
+    def test_vis_label_used(self):
+        samples = _make_binary_samples(10)
+        log = _make_log(samples, vis_label="My Model")
+        result = _extract_risk_from_log(log)
+        assert result.model_name == "My Model"
+
+    def test_skips_single_class(self):
+        """All targets the same -> only one class -> returns None."""
+        samples = [_make_sample(0.8, "0", {"0": 0.8, "1": 0.2}) for _ in range(10)]
+        log = _make_log(samples)
+        assert _extract_risk_from_log(log) is None
+
+    def test_skips_too_few_samples(self):
+        """Fewer than 2 valid samples -> returns None."""
+        samples = [_make_sample(0.8, "0", {"0": 0.8, "1": 0.2})]
+        log = _make_log(samples)
+        assert _extract_risk_from_log(log) is None
+
+    def test_skips_missing_risk_scorer(self):
+        """Samples without risk_scorer key are skipped."""
+        samples = [
+            SimpleNamespace(scores={"match": SimpleNamespace(metadata={})}),
+            SimpleNamespace(scores={"match": SimpleNamespace(metadata={})}),
+        ]
+        log = _make_log(samples)
+        assert _extract_risk_from_log(log) is None
+
+    def test_skips_missing_metadata_fields(self):
+        """Samples with partial metadata are skipped."""
+        s1 = SimpleNamespace(
+            scores={"risk_scorer": SimpleNamespace(metadata={"risk_score": 0.5})}
+        )  # missing target + option_probs
+        samples = [s1, s1]
+        log = _make_log(samples)
+        assert _extract_risk_from_log(log) is None
+
+    def test_empty_samples(self):
+        log = _make_log([])
+        assert _extract_risk_from_log(log) is None
+
+    def test_none_samples(self):
+        log = _make_log(None)
+        assert _extract_risk_from_log(log) is None
+
+    def test_y_true_encoding(self):
+        """Verify y_true = 1.0 when target matches first option_probs key."""
+        samples = [
+            _make_sample(0.9, "A", {"A": 0.9, "B": 0.1}),  # positive
+            _make_sample(0.3, "B", {"A": 0.3, "B": 0.7}),  # negative
+        ]
+        log = _make_log(samples)
+        result = _extract_risk_from_log(log)
+        assert result.y_true == [1.0, 0.0]
+
+
+# =============================================================================
+# extract_per_sample_risk_data (integration-level, mocks read_eval_log)
+# =============================================================================
+
+class TestExtractPerSampleRiskData:
+
+    @patch("cruijff_kit.tools.inspect.viz_helpers.read_eval_log")
+    def test_reads_multiple_files(self, mock_read):
+        log1 = _make_log(_make_binary_samples(20, seed=1), model="model_a")
+        log2 = _make_log(_make_binary_samples(20, seed=2), model="model_b")
+        mock_read.side_effect = [log1, log2]
+
+        results = extract_per_sample_risk_data(["f1.eval", "f2.eval"])
+        assert len(results) == 2
+        assert results[0].model_name == "model_a"
+        assert results[1].model_name == "model_b"
+
+    @patch("cruijff_kit.tools.inspect.viz_helpers.read_eval_log")
+    def test_skips_unreadable_files(self, mock_read):
+        mock_read.side_effect = Exception("corrupt")
+        results = extract_per_sample_risk_data(["bad.eval"])
+        assert results == []
+
+    @patch("cruijff_kit.tools.inspect.viz_helpers.read_eval_log")
+    def test_skips_unusable_models(self, mock_read):
+        """Single-class model is skipped but good model is kept."""
+        good_log = _make_log(_make_binary_samples(20), model="good")
+        bad_log = _make_log(
+            [_make_sample(0.9, "0", {"0": 0.9, "1": 0.1}) for _ in range(10)],
+            model="bad",
+        )
+        mock_read.side_effect = [good_log, bad_log]
+        results = extract_per_sample_risk_data(["good.eval", "bad.eval"])
+        assert len(results) == 1
+        assert results[0].model_name == "good"
+
+
+# =============================================================================
+# has_risk_scorer property
+# =============================================================================
+
+class TestHasRiskScorer:
+
+    def test_true_when_auc_present(self):
+        dm = DetectedMetrics(
+            accuracy=["match"],
+            supplementary=["risk_scorer_cruijff_kit/auc_score", "risk_scorer_cruijff_kit/ece"],
+        )
+        assert dm.has_risk_scorer is True
+
+    def test_false_when_no_auc(self):
+        dm = DetectedMetrics(accuracy=["match"], supplementary=["risk_scorer_cruijff_kit/ece"])
+        assert dm.has_risk_scorer is False
+
+    def test_false_when_empty(self):
+        dm = DetectedMetrics()
+        assert dm.has_risk_scorer is False
+
+
+# =============================================================================
+# generate_roc_overlay
+# =============================================================================
+
+class TestGenerateRocOverlay:
+
+    def test_produces_png(self, tmp_path):
+        rd = PerSampleRiskData("model_a", [1.0]*50 + [0.0]*50,
+                               [0.9]*50 + [0.1]*50, 100, 100)
+        out = generate_roc_overlay([rd], tmp_path / "roc.png")
+        assert out is not None
+        assert out.exists()
+        assert out.stat().st_size > 0
+
+    def test_multiple_models(self, tmp_path):
+        rd1 = PerSampleRiskData("a", [1.0]*50 + [0.0]*50, [0.9]*50 + [0.1]*50, 100, 100)
+        rd2 = PerSampleRiskData("b", [1.0]*50 + [0.0]*50, [0.7]*50 + [0.3]*50, 100, 100)
+        out = generate_roc_overlay([rd1, rd2], tmp_path / "roc.png")
+        assert out is not None
+        assert out.exists()
+
+    def test_empty_data_returns_none(self, tmp_path):
+        assert generate_roc_overlay([], tmp_path / "roc.png") is None
+
+
+# =============================================================================
+# generate_calibration_overlay
+# =============================================================================
+
+class TestGenerateCalibrationOverlay:
+
+    def test_produces_png(self, tmp_path):
+        rd = PerSampleRiskData("model_a", [1.0]*50 + [0.0]*50,
+                               [0.9]*50 + [0.1]*50, 100, 100)
+        out = generate_calibration_overlay([rd], tmp_path / "cal.png")
+        assert out is not None
+        assert out.exists()
+        assert out.stat().st_size > 0
+
+    def test_multiple_models(self, tmp_path):
+        rd1 = PerSampleRiskData("a", [1.0]*50 + [0.0]*50, [0.9]*50 + [0.1]*50, 100, 100)
+        rd2 = PerSampleRiskData("b", [1.0]*50 + [0.0]*50, [0.7]*50 + [0.3]*50, 100, 100)
+        out = generate_calibration_overlay([rd1, rd2], tmp_path / "cal.png")
+        assert out is not None
+        assert out.exists()
+
+    def test_empty_data_returns_none(self, tmp_path):
+        assert generate_calibration_overlay([], tmp_path / "cal.png") is None
+
+
+# =============================================================================
+# generate_prediction_histogram
+# =============================================================================
+
+class TestGeneratePredictionHistogram:
+
+    def test_produces_png(self, tmp_path):
+        rd = PerSampleRiskData("model_a", [1.0]*50 + [0.0]*50,
+                               [0.9]*50 + [0.1]*50, 100, 100)
+        out = generate_prediction_histogram([rd], tmp_path / "hist.png")
+        assert out is not None
+        assert out.exists()
+        assert out.stat().st_size > 0
+
+    def test_multiple_models(self, tmp_path):
+        rd1 = PerSampleRiskData("a", [1.0]*50 + [0.0]*50, [0.9]*50 + [0.1]*50, 100, 100)
+        rd2 = PerSampleRiskData("b", [1.0]*50 + [0.0]*50, [0.7]*50 + [0.3]*50, 100, 100)
+        out = generate_prediction_histogram([rd1, rd2], tmp_path / "hist.png")
+        assert out is not None
+        assert out.exists()
+
+    def test_empty_data_returns_none(self, tmp_path):
+        assert generate_prediction_histogram([], tmp_path / "hist.png") is None

--- a/tools/inspect/viz_helpers.py
+++ b/tools/inspect/viz_helpers.py
@@ -16,8 +16,10 @@ Example usage:
 """
 
 import json
+import logging
 import os
 from dataclasses import dataclass, field
+from pathlib import Path
 
 import pandas as pd
 from inspect_ai.log import read_eval_log
@@ -29,6 +31,8 @@ from inspect_ai.analysis import (
     EvalInfo,
     EvalTask,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def deduplicate_eval_files(eval_files: list[str]) -> tuple[list[str], list[str]]:
@@ -182,6 +186,11 @@ class DetectedMetrics:
     accuracy: list[str] = field(default_factory=list)
     supplementary: list[str] = field(default_factory=list)
 
+    @property
+    def has_risk_scorer(self) -> bool:
+        """True when the evaluation used risk_scorer (has AUC metric)."""
+        return any("auc_score" in m for m in self.supplementary)
+
 
 def detect_metrics(logs_df: pd.DataFrame) -> DetectedMetrics:
     """
@@ -269,3 +278,244 @@ def evals_df_prep(logs: list[str]) -> pd.DataFrame:
         columns=(EvalInfo + EvalTask + EvalModel + EvalResults + EvalScores)
     )
     return logs_df
+
+
+# =============================================================================
+# Per-sample risk data extraction and plotting
+# =============================================================================
+
+@dataclass
+class PerSampleRiskData:
+    """Per-sample binary prediction data extracted from a single eval log.
+
+    Attributes:
+        model_name: Display label for this model (from vis_label or model id).
+        y_true: Binary ground-truth labels (1.0 = positive class, 0.0 = negative).
+        y_score: Predicted probability of the positive class (risk_score).
+        n_total: Total samples in the eval log (including those without risk data).
+        n_valid: Samples with usable risk data.
+    """
+
+    model_name: str
+    y_true: list[float]
+    y_score: list[float]
+    n_total: int
+    n_valid: int
+
+
+def _extract_risk_from_log(log) -> PerSampleRiskData | None:
+    """Extract per-sample (y_true, y_score) from a single eval log.
+
+    This is the inner loop factored out for testability. Returns None when the
+    log has fewer than 2 valid samples or only one class present.
+    """
+    # Determine display name
+    task_args = {}
+    if hasattr(log.eval, 'task_args') and log.eval.task_args:
+        task_args = log.eval.task_args
+    model_name = task_args.get('vis_label', log.eval.model)
+
+    y_true: list[float] = []
+    y_score: list[float] = []
+    n_total = len(log.samples) if log.samples else 0
+
+    for sample in (log.samples or []):
+        scores = sample.scores or {}
+        risk_score_obj = scores.get('risk_scorer')
+        if risk_score_obj is None:
+            continue
+        meta = risk_score_obj.metadata or {}
+        risk = meta.get('risk_score')
+        target = meta.get('target')
+        option_probs = meta.get('option_probs')
+        if risk is None or target is None or option_probs is None:
+            continue
+
+        positive_token = next(iter(option_probs))
+        y_true.append(1.0 if target == positive_token else 0.0)
+        y_score.append(risk)
+
+    n_valid = len(y_true)
+    if n_valid < 2 or len(set(y_true)) < 2:
+        logger.info(
+            "Skipping %s: %d valid samples, %d classes",
+            model_name, n_valid, len(set(y_true)),
+        )
+        return None
+
+    return PerSampleRiskData(
+        model_name=model_name,
+        y_true=y_true,
+        y_score=y_score,
+        n_total=n_total,
+        n_valid=n_valid,
+    )
+
+
+def extract_per_sample_risk_data(eval_files: list[str]) -> list[PerSampleRiskData]:
+    """Read eval files and return per-sample risk data for each model.
+
+    Models with <2 valid samples or only one class are silently skipped.
+
+    Args:
+        eval_files: Paths to .eval log files.
+
+    Returns:
+        List of PerSampleRiskData (one per model with usable data).
+    """
+    results: list[PerSampleRiskData] = []
+    for filepath in eval_files:
+        try:
+            log = read_eval_log(filepath)
+        except Exception as e:
+            logger.warning("Could not read %s: %s", filepath, e)
+            continue
+        data = _extract_risk_from_log(log)
+        if data is not None:
+            results.append(data)
+    return results
+
+
+def generate_roc_overlay(
+    risk_data: list[PerSampleRiskData],
+    output_path: str | Path,
+) -> Path | None:
+    """Generate a single ROC-curve figure overlaying all models.
+
+    Args:
+        risk_data: Per-sample data for each model (from extract_per_sample_risk_data).
+        output_path: Where to save the PNG.
+
+    Returns:
+        Path to the saved PNG, or None if risk_data is empty.
+    """
+    if not risk_data:
+        return None
+
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from sklearn.metrics import roc_curve, auc
+
+    fig, ax = plt.subplots(figsize=(7, 6))
+    for rd in risk_data:
+        fpr, tpr, _ = roc_curve(rd.y_true, rd.y_score)
+        roc_auc = auc(fpr, tpr)
+        ax.plot(fpr, tpr, linewidth=2, label=f"{rd.model_name} (AUC = {roc_auc:.3f})")
+
+    ax.plot([0, 1], [0, 1], "k--", linewidth=1, label="Chance")
+    ax.set_xlabel("False Positive Rate")
+    ax.set_ylabel("True Positive Rate")
+    ax.set_title("ROC Curves")
+    ax.legend(loc="lower right", fontsize="small")
+    ax.set_xlim([0, 1])
+    ax.set_ylim([0, 1.05])
+    fig.tight_layout()
+
+    out = Path(output_path)
+    fig.savefig(out, dpi=150)
+    plt.close(fig)
+    return out
+
+
+def generate_prediction_histogram(
+    risk_data: list[PerSampleRiskData],
+    output_path: str | Path,
+    n_bins: int = 30,
+) -> Path | None:
+    """Generate prediction histograms split by true class, one subplot per model.
+
+    Each subplot shows overlapping histograms of risk_score for the positive
+    and negative classes, revealing how well the model separates them.
+
+    Args:
+        risk_data: Per-sample data for each model.
+        output_path: Where to save the PNG.
+        n_bins: Number of histogram bins.
+
+    Returns:
+        Path to the saved PNG, or None if risk_data is empty.
+    """
+    if not risk_data:
+        return None
+
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    n_models = len(risk_data)
+    fig, axes = plt.subplots(n_models, 1, figsize=(7, 3.5 * n_models), squeeze=False)
+
+    for i, rd in enumerate(risk_data):
+        ax = axes[i, 0]
+        y_true = np.array(rd.y_true)
+        y_score = np.array(rd.y_score)
+
+        neg_scores = y_score[y_true == 0.0]
+        pos_scores = y_score[y_true == 1.0]
+        base_rate = len(pos_scores) / len(y_score)
+
+        bins = np.linspace(0, 1, n_bins + 1)
+        ax.hist(neg_scores, bins=bins, alpha=0.5, label=f"Negative (n={len(neg_scores)})", color="tab:blue")
+        ax.hist(pos_scores, bins=bins, alpha=0.5, label=f"Positive (n={len(pos_scores)})", color="tab:orange")
+        ax.set_xlabel("Predicted P(positive)")
+        ax.set_ylabel("Count")
+        ax.set_title(f"{rd.model_name}  (base rate = {base_rate:.1%})")
+        ax.legend(fontsize="small")
+        ax.set_xlim([0, 1])
+
+    fig.suptitle("Prediction Distributions by True Class", fontsize=13, y=1.01)
+    fig.tight_layout()
+
+    out = Path(output_path)
+    fig.savefig(out, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    return out
+
+def generate_calibration_overlay(
+    risk_data: list[PerSampleRiskData],
+    output_path: str | Path,
+    n_bins: int = 10,
+) -> Path | None:
+    """Generate a single calibration-curve figure overlaying all models.
+
+    Args:
+        risk_data: Per-sample data for each model.
+        output_path: Where to save the PNG.
+        n_bins: Number of calibration bins.
+
+    Returns:
+        Path to the saved PNG, or None if risk_data is empty.
+    """
+    if not risk_data:
+        return None
+
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from sklearn.calibration import calibration_curve
+
+    fig, ax = plt.subplots(figsize=(7, 6))
+    for rd in risk_data:
+        fraction_pos, mean_predicted = calibration_curve(
+            rd.y_true, rd.y_score, n_bins=n_bins, strategy="uniform",
+        )
+        ax.plot(
+            mean_predicted, fraction_pos, "s-", linewidth=2,
+            label=f"{rd.model_name} (n={rd.n_valid})",
+        )
+
+    ax.plot([0, 1], [0, 1], "k--", linewidth=1, label="Perfectly calibrated")
+    ax.set_xlabel("Mean Predicted Probability")
+    ax.set_ylabel("Fraction of Positives")
+    ax.set_title("Calibration Curves")
+    ax.legend(loc="best", fontsize="small")
+    ax.set_xlim([0, 1])
+    ax.set_ylim([0, 1.05])
+    fig.tight_layout()
+
+    out = Path(output_path)
+    fig.savefig(out, dpi=150)
+    plt.close(fig)
+    return out


### PR DESCRIPTION
Closes #299

## Description

Adds per-sample ROC curves, calibration curves, and prediction histograms to the analyze-experiment skill. Instead of relying on stored aggregate metrics (which are affected by #305), this extracts raw `(y_true, y_score)` pairs from eval log samples and generates matplotlib overlay PNGs.

New functions in `viz_helpers.py`:
- `extract_per_sample_risk_data()` — reads eval logs and extracts per-sample risk data
- `generate_roc_overlay()` — overlaid ROC curves with AUC values
- `generate_calibration_overlay()` — overlaid calibration curves
- `generate_prediction_histogram()` — per-model histograms split by true class
- `DetectedMetrics.has_risk_scorer` — property to gate plot generation

Models with <2 valid samples or only one class (e.g., zeroshot base models) are automatically skipped.

## New Dependencies

- `scikit-learn` (for `roc_curve`, `auc`, `calibration_curve`) — already in the conda env
- `matplotlib` — already in the conda env

## Testing Instructions

- Unit tests: `pytest tests/unit/test_risk_plots.py`
- Integration: run `analyze-experiment` on an experiment that used `risk_scorer` (e.g., ACS income) and verify ROC/calibration/histogram PNGs appear in the output directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)