### PR TITLE
Add numeric risk scoring and fix inverted probabilities

### DIFF
--- a/.claude/skills/design-experiment/references/scorers.md
+++ b/.claude/skills/design-experiment/references/scorers.md
@@ -77,6 +77,44 @@ Extracts risk scores from logprobs of the first generated token. Computes normal
 
 Note: For multiclass tasks, `risk_score` will be `null` — use `option_probs` instead.
 
+### numeric_risk_scorer
+
+Parses a numeric probability from the model's text output (e.g., "0.73"). For tasks where the model directly outputs a risk score as text rather than via logprobs.
+
+**Source:** `tools/inspect/scorers/numeric_risk_scorer.py`
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `labels` | `("0", "1")` | The ground-truth target values in the dataset: (negative, positive). Used to determine correctness and compute calibration metrics. |
+
+**How it works:**
+1. Parses the model's text output as a float in [0, 1] — this is the `risk_score` (probability of the positive class)
+2. Builds synthetic `option_probs`: `{negative_label: 1-risk, positive_label: risk}`
+3. Thresholds at 0.5 to determine correctness: if risk >= 0.5, the predicted label is `labels[-1]` (positive); this is compared to `target.text`
+
+**Metrics produced:**
+- `risk_score`: The parsed probability value
+- `option_probs`: Synthetic distribution over the two ground-truth labels
+- `CORRECT`/`INCORRECT` based on thresholding at 0.5
+
+**Requirements:**
+- Model must output a single float in [0, 1]
+- Does NOT require logprobs (works with any model, including API models)
+- PYTHONPATH must include cruijff_kit repo root (handled by scaffold-inspect)
+
+**Typical usage:** Binary prediction tasks where the prompt asks for a numeric probability.
+
+```yaml
+- name: "numeric_risk_scorer"
+  params:
+    labels: ["0", "1"]
+```
+
+**When to use `numeric_risk_scorer` vs `risk_scorer`:**
+- Use `risk_scorer` when you want probabilities derived from logprobs (first token)
+- Use `numeric_risk_scorer` when the model outputs a probability as text
+- Both produce compatible metadata, so all calibration metrics (ECE, Brier, AUC) and visualization code work with either
+
 ## Design-Time Considerations
 
 When a user selects scorers during experiment design, follow these guidelines:
@@ -84,6 +122,7 @@ When a user selects scorers during experiment design, follow these guidelines:
 - **Multiple scorers can be combined** — each runs independently and all results are stored in the eval log.
 - **Scorer parameters** (e.g., `option_tokens`) are specified in experiment_summary.yaml and flow through to eval_config.yaml at scaffold time. Task files read them at runtime.
 - **If `risk_scorer` is selected:** Ask which tokens represent the answer classes (default: `["0", "1"]` for binary). The task file will automatically request logprobs when `risk_scorer` is in the scorer list.
+- **If `numeric_risk_scorer` is selected:** Ask what the ground-truth target values are in the dataset (default: `["0", "1"]` for binary). The model should be prompted to output a single probability as text.
 - **If `match` is selected:** Ask whether matching should be exact, case-sensitive, etc. Defaults (`location: "exact"`, `ignore_case: false`) work well for constrained-output tasks.
 
 ## Common Scorer Combinations

--- a/tests/unit/scorers/test_numeric_risk_scorer.py
+++ b/tests/unit/scorers/test_numeric_risk_scorer.py
@@ -1,0 +1,376 @@
+"""Unit tests for tools/inspect/scorers/numeric_risk_scorer.py
+
+Tests the numeric risk scorer that parses probabilities from model text output:
+- Parsing: valid decimals, whitespace, out-of-range, non-numeric
+- Binary scoring: risk_score, option_probs structure, correctness thresholding
+- Custom labels
+- Edge cases: empty/malformed completions
+- Metric compatibility: synthetic option_probs work with calibration metrics
+"""
+
+import math
+import asyncio
+import pytest
+from unittest.mock import MagicMock
+
+from inspect_ai.model._model_output import ChatCompletionChoice, ModelOutput
+from inspect_ai.model._chat_message import ChatMessageAssistant
+from inspect_ai.scorer import Score, CORRECT, INCORRECT, Target
+
+from cruijff_kit.tools.inspect.scorers.numeric_risk_scorer import (
+    numeric_risk_scorer,
+    _parse_risk_score,
+)
+from cruijff_kit.tools.inspect.scorers.calibration_metrics import (
+    expected_calibration_error,
+    risk_calibration_error,
+    brier_score,
+    auc_score,
+)
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+def _make_state(completion: str):
+    """Build a mock TaskState with the given text completion (no logprobs needed)."""
+    message = ChatMessageAssistant(content=completion)
+    choice = ChatCompletionChoice(message=message, logprobs=None)
+    output = ModelOutput(choices=[choice], completion=completion)
+
+    state = MagicMock()
+    state.output = output
+    return state
+
+
+def _make_target(text: str) -> Target:
+    """Build a Target with the given text."""
+    return Target([text])
+
+
+def _run(coro):
+    """Run an async coroutine synchronously."""
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+# =============================================================================
+# _parse_risk_score tests
+# =============================================================================
+
+class TestParseRiskScore:
+    """Tests for the _parse_risk_score helper function."""
+
+    def test_valid_decimal(self):
+        assert _parse_risk_score("0.73") == pytest.approx(0.73)
+
+    def test_zero(self):
+        assert _parse_risk_score("0.0") == pytest.approx(0.0)
+
+    def test_one(self):
+        assert _parse_risk_score("1.0") == pytest.approx(1.0)
+
+    def test_integer_zero(self):
+        assert _parse_risk_score("0") == pytest.approx(0.0)
+
+    def test_integer_one(self):
+        assert _parse_risk_score("1") == pytest.approx(1.0)
+
+    def test_leading_trailing_whitespace(self):
+        assert _parse_risk_score("  0.42  \n") == pytest.approx(0.42)
+
+    def test_negative_returns_none(self):
+        assert _parse_risk_score("-0.1") is None
+
+    def test_above_one_returns_none(self):
+        assert _parse_risk_score("1.01") is None
+
+    def test_non_numeric_returns_none(self):
+        assert _parse_risk_score("hello") is None
+
+    def test_empty_string_returns_none(self):
+        assert _parse_risk_score("") is None
+
+    def test_none_input_returns_none(self):
+        assert _parse_risk_score(None) is None
+
+
+# =============================================================================
+# Binary scoring tests
+# =============================================================================
+
+class TestBinaryScoring:
+    """Tests for binary classification with default labels ("0", "1")."""
+
+    def test_high_risk_correct(self):
+        """Model outputs 0.8, target is "1" (positive class) -> CORRECT."""
+        state = _make_state("0.8")
+        target = _make_target("1")
+
+        score_fn = numeric_risk_scorer()
+        result: Score = _run(score_fn(state, target))
+
+        assert result.value == CORRECT
+        assert result.metadata["risk_score"] == pytest.approx(0.8)
+        assert result.metadata["option_probs"]["0"] == pytest.approx(0.2)
+        assert result.metadata["option_probs"]["1"] == pytest.approx(0.8)
+        assert result.metadata["target"] == "1"
+
+    def test_low_risk_correct(self):
+        """Model outputs 0.2, target is "0" (negative class) -> CORRECT."""
+        state = _make_state("0.2")
+        target = _make_target("0")
+
+        score_fn = numeric_risk_scorer()
+        result: Score = _run(score_fn(state, target))
+
+        assert result.value == CORRECT
+        assert result.metadata["risk_score"] == pytest.approx(0.2)
+
+    def test_high_risk_incorrect(self):
+        """Model outputs 0.8, target is "0" -> INCORRECT."""
+        state = _make_state("0.8")
+        target = _make_target("0")
+
+        score_fn = numeric_risk_scorer()
+        result: Score = _run(score_fn(state, target))
+
+        assert result.value == INCORRECT
+
+    def test_low_risk_incorrect(self):
+        """Model outputs 0.2, target is "1" -> INCORRECT."""
+        state = _make_state("0.2")
+        target = _make_target("1")
+
+        score_fn = numeric_risk_scorer()
+        result: Score = _run(score_fn(state, target))
+
+        assert result.value == INCORRECT
+
+    def test_exactly_0_5_predicts_positive(self):
+        """At threshold 0.5 exactly, predicted label is positive (last label)."""
+        state = _make_state("0.5")
+        target = _make_target("1")
+
+        score_fn = numeric_risk_scorer()
+        result: Score = _run(score_fn(state, target))
+
+        assert result.value == CORRECT
+        assert result.metadata["risk_score"] == pytest.approx(0.5)
+
+    def test_answer_is_string_risk_score(self):
+        """Score.answer should be the string representation of the parsed risk score."""
+        state = _make_state("  0.73  ")
+        target = _make_target("1")
+
+        score_fn = numeric_risk_scorer()
+        result: Score = _run(score_fn(state, target))
+
+        assert result.answer == "0.73"
+
+    def test_option_probs_sum_to_one(self):
+        """Synthetic option_probs should always sum to 1."""
+        state = _make_state("0.37")
+        target = _make_target("0")
+
+        score_fn = numeric_risk_scorer()
+        result: Score = _run(score_fn(state, target))
+
+        total = sum(result.metadata["option_probs"].values())
+        assert total == pytest.approx(1.0, abs=1e-10)
+
+    def test_risk_zero(self):
+        """Risk score of 0.0 -> all probability on negative class."""
+        state = _make_state("0.0")
+        target = _make_target("0")
+
+        score_fn = numeric_risk_scorer()
+        result: Score = _run(score_fn(state, target))
+
+        assert result.value == CORRECT
+        assert result.metadata["risk_score"] == pytest.approx(0.0)
+        assert result.metadata["option_probs"]["0"] == pytest.approx(1.0)
+        assert result.metadata["option_probs"]["1"] == pytest.approx(0.0)
+
+    def test_risk_one(self):
+        """Risk score of 1.0 -> all probability on positive class."""
+        state = _make_state("1.0")
+        target = _make_target("1")
+
+        score_fn = numeric_risk_scorer()
+        result: Score = _run(score_fn(state, target))
+
+        assert result.value == CORRECT
+        assert result.metadata["risk_score"] == pytest.approx(1.0)
+        assert result.metadata["option_probs"]["0"] == pytest.approx(0.0)
+        assert result.metadata["option_probs"]["1"] == pytest.approx(1.0)
+
+
+# =============================================================================
+# Custom labels tests
+# =============================================================================
+
+class TestCustomLabels:
+    """Tests with non-default label names."""
+
+    def test_custom_labels(self):
+        """Labels ("A", "B") should work correctly."""
+        state = _make_state("0.6")
+        target = _make_target("B")
+
+        score_fn = numeric_risk_scorer(labels=("A", "B"))
+        result: Score = _run(score_fn(state, target))
+
+        assert result.value == CORRECT
+        assert result.metadata["option_probs"]["A"] == pytest.approx(0.4)
+        assert result.metadata["option_probs"]["B"] == pytest.approx(0.6)
+
+    def test_custom_labels_negative_correct(self):
+        """Low risk with custom labels, target is negative class."""
+        state = _make_state("0.3")
+        target = _make_target("A")
+
+        score_fn = numeric_risk_scorer(labels=("A", "B"))
+        result: Score = _run(score_fn(state, target))
+
+        assert result.value == CORRECT
+        assert result.metadata["risk_score"] == pytest.approx(0.3)
+
+
+# =============================================================================
+# Edge cases
+# =============================================================================
+
+class TestEdgeCases:
+    """Tests for error handling and malformed input."""
+
+    def test_non_numeric_completion(self):
+        """Non-numeric text -> INCORRECT with risk_score=None."""
+        state = _make_state("I think the answer is about 0.5")
+        target = _make_target("1")
+
+        score_fn = numeric_risk_scorer()
+        result: Score = _run(score_fn(state, target))
+
+        assert result.value == INCORRECT
+        assert result.metadata["risk_score"] is None
+        assert result.metadata["option_probs"] is None
+        assert result.metadata["target"] == "1"
+
+    def test_empty_completion(self):
+        """Empty string -> INCORRECT with risk_score=None."""
+        state = _make_state("")
+        target = _make_target("0")
+
+        score_fn = numeric_risk_scorer()
+        result: Score = _run(score_fn(state, target))
+
+        assert result.value == INCORRECT
+        assert result.metadata["risk_score"] is None
+
+    def test_out_of_range_completion(self):
+        """Value > 1 -> INCORRECT with risk_score=None."""
+        state = _make_state("1.5")
+        target = _make_target("1")
+
+        score_fn = numeric_risk_scorer()
+        result: Score = _run(score_fn(state, target))
+
+        assert result.value == INCORRECT
+        assert result.metadata["risk_score"] is None
+
+    def test_negative_completion(self):
+        """Negative value -> INCORRECT with risk_score=None."""
+        state = _make_state("-0.3")
+        target = _make_target("0")
+
+        score_fn = numeric_risk_scorer()
+        result: Score = _run(score_fn(state, target))
+
+        assert result.value == INCORRECT
+        assert result.metadata["risk_score"] is None
+
+    def test_whitespace_only(self):
+        """Whitespace-only completion -> INCORRECT."""
+        state = _make_state("   \n  ")
+        target = _make_target("1")
+
+        score_fn = numeric_risk_scorer()
+        result: Score = _run(score_fn(state, target))
+
+        assert result.value == INCORRECT
+        assert result.metadata["risk_score"] is None
+
+
+# =============================================================================
+# Metric compatibility tests
+# =============================================================================
+
+class TestMetricCompatibility:
+    """Verify synthetic option_probs work with all calibration metrics."""
+
+    def _make_scores(self) -> list[Score]:
+        """Build a set of Score objects matching numeric_risk_scorer output format."""
+        return [
+            Score(value=CORRECT, metadata={
+                "risk_score": 0.8,
+                "option_probs": {"0": 0.2, "1": 0.8},
+                "target": "1",
+            }),
+            Score(value=CORRECT, metadata={
+                "risk_score": 0.3,
+                "option_probs": {"0": 0.7, "1": 0.3},
+                "target": "0",
+            }),
+            Score(value=INCORRECT, metadata={
+                "risk_score": 0.6,
+                "option_probs": {"0": 0.4, "1": 0.6},
+                "target": "0",
+            }),
+            Score(value=CORRECT, metadata={
+                "risk_score": 0.9,
+                "option_probs": {"0": 0.1, "1": 0.9},
+                "target": "1",
+            }),
+        ]
+
+    def test_expected_calibration_error_works(self):
+        """ECE metric runs without error on synthetic option_probs."""
+        metric_fn = expected_calibration_error()
+        result = metric_fn(self._make_scores())
+        assert isinstance(result, float)
+        assert not math.isnan(result)
+
+    def test_risk_calibration_error_works(self):
+        """Risk ECE metric runs without error on synthetic option_probs."""
+        metric_fn = risk_calibration_error()
+        result = metric_fn(self._make_scores())
+        assert isinstance(result, float)
+        assert not math.isnan(result)
+
+    def test_brier_score_works(self):
+        """Brier score metric runs without error on synthetic option_probs."""
+        metric_fn = brier_score()
+        result = metric_fn(self._make_scores())
+        assert isinstance(result, float)
+        assert not math.isnan(result)
+
+    def test_auc_score_works(self):
+        """AUC metric runs without error on synthetic option_probs."""
+        metric_fn = auc_score()
+        result = metric_fn(self._make_scores())
+        assert isinstance(result, float)
+        assert not math.isnan(result)
+
+    def test_scores_with_none_risk_handled(self):
+        """Metrics gracefully skip samples with risk_score=None."""
+        scores = self._make_scores()
+        scores.append(Score(value=INCORRECT, metadata={
+            "risk_score": None,
+            "option_probs": None,
+            "target": "1",
+        }))
+        metric_fn = brier_score()
+        result = metric_fn(scores)
+        assert isinstance(result, float)
+        assert not math.isnan(result)

--- a/tests/unit/test_risk_plots.py
+++ b/tests/unit/test_risk_plots.py
@@ -133,14 +133,14 @@ class TestExtractRiskFromLog:
         assert _extract_risk_from_log(log) is None
 
     def test_y_true_encoding(self):
-        """Verify y_true = 1.0 when target matches first option_probs key."""
+        """Verify y_true = 1.0 when target matches last option_probs key."""
         samples = [
-            _make_sample(0.9, "A", {"A": 0.9, "B": 0.1}),  # positive
-            _make_sample(0.3, "B", {"A": 0.3, "B": 0.7}),  # negative
+            _make_sample(0.9, "A", {"A": 0.9, "B": 0.1}),  # negative (target≠B)
+            _make_sample(0.3, "B", {"A": 0.3, "B": 0.7}),  # positive (target=B)
         ]
         log = _make_log(samples)
         result = _extract_risk_from_log(log)
-        assert result.y_true == [1.0, 0.0]
+        assert result.y_true == [0.0, 1.0]
 
 
 # =============================================================================

--- a/tools/inspect/scorers/__init__.py
+++ b/tools/inspect/scorers/__init__.py
@@ -7,6 +7,7 @@
 
 from inspect_ai.scorer import match, includes
 from .risk_scorer import risk_scorer
+from .numeric_risk_scorer import numeric_risk_scorer
 from .calibration_metrics import expected_calibration_error, brier_score, auc_score
 
 # Registry of available scorers and their constructors.
@@ -15,6 +16,7 @@ SCORER_REGISTRY = {
     "match": lambda params: match(**params) if params else match(location="exact", ignore_case=False),
     "includes": lambda params: includes(**params) if params else includes(ignore_case=False),
     "risk_scorer": lambda params: risk_scorer(**params) if params else risk_scorer(),
+    "numeric_risk_scorer": lambda params: numeric_risk_scorer(**params) if params else numeric_risk_scorer(),
 }
 
 # Default scorers when no config is provided

--- a/tools/inspect/scorers/numeric_risk_scorer.py
+++ b/tools/inspect/scorers/numeric_risk_scorer.py
@@ -1,0 +1,81 @@
+"""
+inspect-ai scorer that parses a numeric risk score from model text output.
+
+For tasks where the model outputs a probability directly as text (e.g., "0.73"),
+this scorer parses the value into a float and constructs synthetic option_probs
+so that downstream calibration metrics work identically to risk_scorer.
+
+Correctness is determined by thresholding at 0.5: if risk_score >= 0.5 the
+predicted label is the positive (last) label, otherwise the negative (first).
+"""
+from inspect_ai.scorer import scorer, Score, CORRECT, INCORRECT
+from inspect_ai.solver import TaskState
+from inspect_ai.scorer import Target
+from .risk_scorer import mean_risk_score
+from .calibration_metrics import expected_calibration_error, risk_calibration_error, brier_score, auc_score
+
+
+def _parse_risk_score(text: str) -> float | None:
+    """Parse a risk score from model output text.
+
+    Strips whitespace, attempts float conversion, and validates the value
+    is in [0, 1]. Returns None if parsing fails or value is out of range.
+    """
+    try:
+        value = float(text.strip())
+    except (ValueError, AttributeError):
+        return None
+    if value < 0.0 or value > 1.0:
+        return None
+    return value
+
+
+@scorer(metrics=[mean_risk_score(), expected_calibration_error(), risk_calibration_error(), brier_score(), auc_score()])
+def numeric_risk_scorer(labels: tuple[str, str] = ("0", "1")):
+    """
+    Scorer that parses a numeric probability from the model's text output.
+
+    The model is expected to output a single float in [0, 1] representing
+    P(positive class). The positive class is labels[-1] (default "1").
+
+    Constructs synthetic option_probs = {labels[0]: 1-risk, labels[-1]: risk}
+    so that all calibration metrics (ECE, Brier, AUC) work identically to
+    risk_scorer.
+
+    Args:
+        labels: Tuple of (negative_label, positive_label). Default ("0", "1").
+    """
+    async def score(state: TaskState, target: Target) -> Score:
+        completion = state.output.completion
+        risk_score = _parse_risk_score(completion)
+
+        if risk_score is None:
+            return Score(
+                value=INCORRECT,
+                answer=completion.strip() if completion else "",
+                explanation="Could not parse a numeric risk score from output",
+                metadata={
+                    "risk_score": None,
+                    "option_probs": None,
+                    "target": target.text,
+                }
+            )
+
+        # Build synthetic option_probs
+        option_probs = {labels[0]: 1.0 - risk_score, labels[-1]: risk_score}
+
+        # Threshold at 0.5 to determine predicted label
+        predicted_label = labels[-1] if risk_score >= 0.5 else labels[0]
+        correct = predicted_label == target.text
+
+        return Score(
+            value=CORRECT if correct else INCORRECT,
+            answer=str(risk_score),
+            metadata={
+                "risk_score": risk_score,
+                "option_probs": option_probs,
+                "target": target.text,
+            }
+        )
+
+    return score

--- a/tools/inspect/viz_helpers.py
+++ b/tools/inspect/viz_helpers.py
@@ -350,7 +350,8 @@ def _extract_risk_from_log(log) -> PerSampleRiskData | None:
         if risk is None or target is None or option_probs is None:
             continue
 
-        positive_token = next(iter(option_probs))
+        # Positive token is the last key (e.g., "1"), matching risk_score = P(last token)
+        positive_token = list(option_probs.keys())[-1]
         y_true.append(1.0 if target == positive_token else 0.0)
         y_score.append(risk)
 

--- a/tools/inspect/viz_helpers.py
+++ b/tools/inspect/viz_helpers.py
@@ -161,6 +161,11 @@ METRIC_DISPLAY_NAMES: dict[str, str] = {
     "risk_scorer_cruijff_kit/brier_score": "Brier Score",
     "risk_scorer_cruijff_kit/auc_score": "AUC",
     "risk_scorer_cruijff_kit/mean_risk_score": "Mean Risk Score",
+    "numeric_risk_scorer_cruijff_kit/expected_calibration_error": "C-ECE",
+    "numeric_risk_scorer_cruijff_kit/risk_calibration_error": "R-ECE",
+    "numeric_risk_scorer_cruijff_kit/brier_score": "Brier Score",
+    "numeric_risk_scorer_cruijff_kit/auc_score": "AUC",
+    "numeric_risk_scorer_cruijff_kit/mean_risk_score": "Mean Risk Score",
 }
 
 
@@ -340,7 +345,7 @@ def _extract_risk_from_log(log) -> PerSampleRiskData | None:
 
     for sample in (log.samples or []):
         scores = sample.scores or {}
-        risk_score_obj = scores.get('risk_scorer')
+        risk_score_obj = scores.get('risk_scorer') or scores.get('numeric_risk_scorer')
         if risk_score_obj is None:
             continue
         meta = risk_score_obj.metadata or {}


### PR DESCRIPTION
Closes #{311}

# Description

- Adds `numeric_risk_scorer` that will compute all downstream metrics (Accuracy, ECE, etc.) when the model is prompting for verbalized risk ("What is the probability of _____") instead of using the next-token logprobs 
- The risk scorer still requires the ground-truth positive and negative classes in the evaluation setup
- Fixes bug in which we were computing risk scores w.r.t. probability of 0 class instead of 1 (should always be with respect to positive class, so now we proxy that as the last option probability token) 

## New Dependencies

NA

# Testing Instructions

see `/scratch/gpfs/MSALGANIK/sarahep/ck-experiments/acs_income_numeric_risk_2026-02-23/Llama-3.1-8B-Instruct_base/eval/logs` in inspect for performance using numeric risk scores