### PR TITLE
Pin version floors for torch, torchtune, and torchao

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,9 @@ authors = [
     {name = "Donggyu Ban"},
 ]
 dependencies = [
-    "torch",
-    "torchtune",
-    "torchao",
+    "torch>=2.9.1",
+    "torchtune>=0.6.1",  # Makefile upgrades to nightly post-install
+    "torchao>=0.14.1",
     "torchvision",
     "wandb",
     "h5py",


### PR DESCRIPTION
Closes #337

# Description

Adds minimum version constraints for the three torch ecosystem packages, which are the only dependencies where version mismatches cause real breakage:

- `torch>=2.9.1` — current tested version
- `torchtune>=0.6.1` — latest stable (Makefile upgrades to nightly post-install)
- `torchao>=0.14.1` — tracks torch closely, mismatches break things

Other dependencies (tqdm, numpy, pandas, scipy, pyyaml) were investigated as potentially missing declarations, but all are reliably pulled in as transitive dependencies of torch, torchtune, datasets, and scikit-learn. A clean `conda create + make install` confirmed everything resolves correctly.

## New Dependencies

No new dependencies. Version floors added to three existing ones.

## Scope vs. Issue

The issue also proposed adding `tqdm` as a missing declaration — but torchtune already requires it directly, so it's always present. The remaining items (documenting torchtune-nightly, considering torchao ceiling) are addressed via an inline comment and a note on #302 respectively.

# Testing Instructions

1. Create a fresh conda env and run `make install`
2. Verify torch ecosystem packages install at or above the specified floors
3. Run `pytest` to confirm nothing broke

—MxC