### PR TITLE
Replace hardcoded paths in finetune_template.yaml

### DIFF
--- a/tools/torchtune/templates/finetune_template.yaml
+++ b/tools/torchtune/templates/finetune_template.yaml
@@ -11,9 +11,9 @@ input_formatting: ""
 
 dataset_label: ""
 
-output_dir: /scratch/gpfs/MSALGANIK/$USER/zyg_out_${my_wandb_run_name}/
-input_dir: /scratch/gpfs/MSALGANIK/$USER/zyg_in/${input_formatting}/
-models_dir: /scratch/gpfs/MSALGANIK/$USER/pretrained-llms/
+output_dir: ""  # Set by setup_finetune.py
+input_dir: ""  # Set by setup_finetune.py
+models_dir: ""  # Set by setup_finetune.py
 
 batch_size: 4
 


### PR DESCRIPTION
Closes #352

## Description

Lines 14-16 of `finetune_template.yaml` had hardcoded Della paths with legacy `zyg_` prefixes. These are always overwritten by `setup_finetune.py`, but were misleading if someone read the template directly. Replaced with empty strings and comments indicating they're set by the setup script.

## New Dependencies

None.

## Testing Instructions

No functional change — `setup_finetune.py` overwrites these fields at scaffold time.

—MxC