### PR TITLE
Fix inspect-ai 0.3.180 offline bug with HF_HUB_OFFLINE=1

### DIFF
--- a/tools/inspect/templates/eval_template.slurm
+++ b/tools/inspect/templates/eval_template.slurm
@@ -25,6 +25,9 @@ nvidia-smi --query-gpu=timestamp,utilization.gpu,utilization.memory,memory.used,
     --format=csv -l 30 > "${GPU_METRICS_DIR}/gpu_metrics.csv" 2>/dev/null &
 GPU_MONITOR_PID=$!
 
+# Prevent HF Hub lookups on offline compute nodes (inspect-ai >= 0.3.180)
+export HF_HUB_OFFLINE=1
+
 # Run inspect-ai evaluation
 cd <EVAL_DIR>
 


### PR DESCRIPTION
Closes #347 (alternative to #347's approach)

## Description

inspect-ai 0.3.180 added `get_model_info()` for cost tracking, which tries to instantiate a new HF provider on every `generate()` call. On offline compute nodes (Della), this causes repeated DNS failures with exponential backoff.

**Fix:** Add `export HF_HUB_OFFLINE=1` to the eval SLURM template. This makes the Hub lookup fail immediately, and the cost tracking code handles `None` gracefully (line 1872 in `_model.py`).

### Why this over #347

PR #347 fixes the same bug by passing model paths directly as `--model hf//path/to/model`, eliminating `-M model_path`. This works but:
- Touches 20+ files (docs, tests, skills, task scripts, report generator, viz helpers)
- Changes `log.eval.model` from clean names (`hf/1B_instruct_base`) to raw filesystem paths
- Requires `report_generator.py` and `viz_helpers.py` to group by `task_name` instead of `model`

This PR is a one-line change that preserves the existing model naming convention.

### Next steps

This is a quick unblock so we can upgrade inspect-ai without breaking evals. Longer-term, @sarahepedersen and I should discuss whether we want to evolve the display name strategy — e.g., pulling human-readable names from `--metadata` for plots and reports instead of relying on `log.eval.model`. Some of the ideas in #347 could inform that, but we can take our time designing it rather than rushing a 20-file refactor to fix an offline bug.

### Test result

Job 5594933 on Della with inspect-ai 0.3.180, old-style `--model hf/1B_instruct_base -M model_path=...`:

| | Result |
|---|---|
| **Status** | success (exit 0) |
| **Time** | 1:45 |
| **`log.eval.model`** | `hf/1B_instruct_base` (clean name preserved) |

## New Dependencies

None.

## Testing Instructions

Already tested via SLURM job 5594933. To reproduce:
1. Ensure inspect-ai >= 0.3.180
2. Run any eval with old-style `--model hf/name -M model_path=...` on an offline node
3. Confirm job completes without Hub retry errors

—MxC