### PR TITLE
Add contributors and acknowledgments to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ We thank the following people for helpful conversations that shaped this project
 
 - [Stephan Rabanser](https://github.com/steverab)
 - [Colin Swaney](https://github.com/cswaney)
-- [Emnet Sisay](https://github.com/esisay)
+- [Emnet Sisay](https://github.com/EmnetSy)
 
 ## How to Cite
 


### PR DESCRIPTION
Closes #375

## Description

Adds two new sections to the README before "How to Cite":

- **Contributors** — code contributors listed by date of first commit, with GitHub profile links
- **Acknowledgments** — people who provided helpful conversations that shaped the project

## New Dependencies

None.

## Testing Instructions

Visual review only — README content change.

—MxC