### PR TITLE
Add GPU smoke test workflow

### DIFF
--- a/.github/workflows/gpu-smoke-test.yml
+++ b/.github/workflows/gpu-smoke-test.yml
@@ -1,0 +1,30 @@
+name: GPU Smoke Test
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  gpu-test:
+    runs-on: [self-hosted, della-cruijff-gpu]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Select GPU
+        run: |
+          source ~/scripts/select_gpu.sh
+          echo "CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES" >> "$GITHUB_ENV"
+
+      - name: Check GPU visibility
+        run: |
+          module load anaconda3/2025.12
+          conda activate cruijff
+          python -c "
+          import torch
+          print('CUDA available:', torch.cuda.is_available())
+          print('Device count:', torch.cuda.device_count())
+          print('Device name:', torch.cuda.get_device_name(0))
+          "


### PR DESCRIPTION
Closes no issue — infrastructure addition.

## Description

Adds a GitHub Actions workflow (`gpu-smoke-test.yml`) for the self-hosted della-cruijff-gpu runner that:
- Runs nightly at 1:30 AM UTC via cron
- Can be triggered manually via `workflow_dispatch`
- Selects the least-busy GPU via `select_gpu.sh`
- Persists `CUDA_VISIBLE_DEVICES` across steps via `$GITHUB_ENV`
- Verifies PyTorch can see the GPU

## New Dependencies

None.

## Testing Instructions

- Merge to main, then trigger manually from the Actions tab
- Verify the "Check GPU visibility" step shows CUDA available with a device name

—MxC

🤖 Generated with [Claude Code](https://claude.com/claude-code)