### PR TITLE
Source modules.sh for self-hosted runner

### DIFF
--- a/.github/workflows/gpu-smoke-test.yml
+++ b/.github/workflows/gpu-smoke-test.yml
@@ -20,6 +20,7 @@ jobs:
 
       - name: Check GPU visibility
         run: |
+          source /etc/profile.d/modules.sh
           module load anaconda3/2025.12
           conda activate cruijff
           python -c "


### PR DESCRIPTION
Follow-up to #383 — the self-hosted runner doesn't get a login shell, so `module` isn't available by default.

## Description

Adds `source /etc/profile.d/modules.sh` before `module load` in the GPU smoke test workflow.

## New Dependencies

None.

## Testing Instructions

- Merge to main, trigger the workflow manually from the Actions tab
- Verify the "Check GPU visibility" step successfully loads the module and reports GPU info

—MxC

🤖 Generated with [Claude Code](https://claude.com/claude-code)