### PR TITLE
Bump to v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to cruijff_kit will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-04-03
+
+### Added
+
+#### Skills & Workflows
+- `archive-experiment` skill and CLI tool (#400)
+- `check-release` skill for weekly release workflow (#404)
+
+#### Observability & Testing
+- GPU smoke test workflow for self-hosted della runner (#383)
+- Nightly torchtune integration smoke test (#393)
+- Nightly inspect-ai eval smoke test (#394)
+- Extended GPU smoke test with model loading and scaffolding verification (#392)
+- Tracked test fixtures for nightly GPU smoke tests (#396)
+- Skill output checkpoint fixtures and tests (#377)
+
+#### Documentation & Data
+- Contributors and acknowledgments sections in README (#376)
+- Maintainer contact information in README (#381)
+
+### Changed
+
+- SHA-pin and upgrade all GitHub Actions (#405, #411)
+- Add Dependabot for GitHub Actions (#405)
+- Bump actions/checkout 4→6 (#406), schneegans/dynamic-badges-action 1.7.0→1.8.0 (#409)
+- Rewrite `spot_check` to use inspect-ai-style HF model loading (#397)
+- Remove orphaned files and references (#397)
+
+### Fixed
+
+- Route SLURM output logs into experiment directories, fix double-slash in output path (#361)
+- Include `vis_label` in dedup key to prevent cross-evaluation collapse (#390)
+- `header_only=True` in `deduplicate_eval_files()` for ~300x speedup (#403)
+
 ## [0.2.0] - 2026-03-11
 
 ### Added

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,17 +1,3 @@
 # Known Issues
 
-Current limitations in cruijff_kit with workarounds.
-
-## get_embeddings() Attention Mask Bug
-
-**Issue**: [#234](https://github.com/niznik-dev/cruijff_kit/issues/234)
-
-The `get_embeddings()` function has incorrect attention mask handling when processing batches with different sequence lengths.
-
-**Workaround**: Use consistent batch sizes or process sequences of similar lengths together.
-
-## Claude Code Agents Fail to Load
-
-Sometimes Claude Code doesn't properly load the scaffold or run agents on startup.
-
-**Workaround**: Restart Claude Code (`/quit` then relaunch).
+No known issues at this time. See [CHANGELOG.md](CHANGELOG.md) for recent fixes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cruijff_kit"
-version = "0.2.0"
+version = "0.2.1"
 description = "A toolkit for research with social data and LLMs"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Closes no issue — release PR.

## Description

Release v0.2.1. Changes:
- Update CHANGELOG.md with all changes since v0.2.0
- Bump version in pyproject.toml to 0.2.1
- Clean up KNOWN_ISSUES.md (remove resolved #234 and stale Claude Code entry)

See CHANGELOG.md for full release notes.

—MxC