### PR TITLE
Update check-release skill with v0.2.1 lessons

### DIFF
--- a/.claude/skills/check-release/SKILL.md
+++ b/.claude/skills/check-release/SKILL.md
@@ -42,33 +42,44 @@ Walk through the release process incrementally, with decision points at each sta
    module load anaconda3/2025.6 && conda activate cruijff && gh pr list --repo niznik-dev/cruijff_kit --state merged --search "merged:>=$(git log -1 --format=%ai <latest_tag> | cut -d' ' -f1)" --json number,title,mergedAt --limit 50
    ```
 
-4. Check for anything already in `[Unreleased]` in `CHANGELOG.md`.
+4. List open PRs and present them for review — each should be merged, deferred, or closed before release:
+   ```bash
+   module load anaconda3/2025.6 && conda activate cruijff && gh pr list --repo niznik-dev/cruijff_kit --state open --json number,title
+   ```
 
-5. Present a summary to the user:
+5. Check for anything already in `[Unreleased]` in `CHANGELOG.md`.
+
+6. Check KNOWN_ISSUES.md for stale entries (closed issues, resolved problems).
+
+7. Present a summary to the user:
    - Number of commits and PRs since last release
    - Brief description of changes (group by: features, fixes, docs, cleanup)
    - Any breaking changes (flag explicitly)
+   - Open PR disposition (merge/defer/close)
+   - Any stale KNOWN_ISSUES entries to clean up
 
-6. **Decision point**: Ask the user whether to proceed with a release or stop here.
+8. **Decision point**: Ask the user whether to proceed with a release or stop here.
 
 ### Step 2: Version bump
 
 1. Read the current version from `pyproject.toml` (line 7).
 
-2. Suggest a semver bump based on change scope:
-   - **Patch** (0.2.0 -> 0.2.1): Bug fixes, docs, minor cleanup
-   - **Minor** (0.2.0 -> 0.3.0): New features, new skills, notable enhancements
+2. Default to a **patch** bump. The project versioning policy:
+   - **Patch** (default): New skills, bug fixes, docs, CI, refactors — anything that doesn't break existing workflows
+   - **Minor**: Significant milestones worth announcing to collaborators — major new capabilities or architectural shifts
+   - **Major**: Breaking changes to user-facing interfaces. Not expected before 1.0.
+   
+   When in doubt, it's a patch.
 
 3. **Decision point**: Confirm the version number with the user.
 
 ### Step 3: Changelog
 
-1. Draft a changelog entry using the [Keep a Changelog](https://keepachangelog.com/) format already in `CHANGELOG.md`. Use the existing categories:
-   - **Added** (with sub-sections like "Skills & Workflows", "Evaluation & Metrics", etc. as needed)
-   - **Changed**
-   - **Fixed**
-   - **Deprecated**
-   - **Removed**
+1. Draft a changelog entry using the [Keep a Changelog](https://keepachangelog.com/) format already in `CHANGELOG.md`:
+   - **Added** — uses domain sub-headings: "Skills & Workflows", "Evaluation & Metrics", "Observability & Testing", "Documentation & Data". Omit any sub-heading with no entries.
+   - **Changed** — flat list, no sub-headings
+   - **Fixed** — flat list, no sub-headings
+   - **Deprecated** / **Removed** — flat list, include only if applicable
 
 2. Include PR numbers and contributor attribution (e.g., `@username`) where applicable.
 
@@ -79,14 +90,50 @@ Walk through the release process incrementally, with decision points at each sta
 5. Once approved:
    - Move items from `[Unreleased]` (if any) into the new version section
    - Add the new version entry below `[Unreleased]` in `CHANGELOG.md`
+   - Update version in `pyproject.toml`
+   - Clean up KNOWN_ISSUES.md if needed
 
-### Step 4: Execute the release checklist
+### Step 4: Branch, PR, and merge
 
-Walk through the remaining items on the wiki checklist (loaded in Step 0) one at a time. For each item, execute it and confirm with the user before moving to the next.
+1. Create a release branch:
+   ```bash
+   git checkout -b release-<VERSION>
+   ```
 
-**Decision point**: Pause before any irreversible action (push, tag, GitHub release) and confirm with the user.
+2. Commit changelog + version bump + any KNOWN_ISSUES changes.
 
-After the final step, confirm success by printing the release URL.
+3. Push branch and open PR:
+   ```bash
+   git push -u origin release-<VERSION>
+   ```
+
+4. **Decision point**: Confirm PR is ready. Wait for CI to pass.
+
+5. User merges the PR using **merge commit** (not squash or rebase).
+
+### Step 5: Tag and release
+
+1. Pull the merge commit:
+   ```bash
+   git checkout main && git pull
+   ```
+
+2. Create annotated tag on the merge commit with a minimal message:
+   ```bash
+   git tag -a v<VERSION> -m "v<VERSION>"
+   ```
+
+3. Push tag:
+   ```bash
+   git push origin v<VERSION>
+   ```
+
+4. Create GitHub Release with the changelog entry as release notes:
+   ```bash
+   gh release create v<VERSION> --title "v<VERSION>" --notes "<changelog entry>"
+   ```
+
+5. Confirm success by printing the release URL.
 
 ## Important Notes
 
@@ -94,3 +141,5 @@ After the final step, confirm success by printing the release URL.
 - Do NOT skip decision points or auto-proceed
 - The wiki [Release Process](https://github.com/niznik-dev/cruijff_kit/wiki/Release-Process) page is the canonical checklist — do not duplicate its steps here
 - Keep changelog entries concise — one line per change, PR number, contributor if not Mattie/Claude
+- Tag messages are minimal (`"vX.Y.Z"` only) — GitHub Releases carry the full notes
+- Always tag **after** merging so the tag points at the merge commit on `main`


### PR DESCRIPTION
## Description

Updates the check-release skill based on lessons learned during the v0.2.1 release process. Wiki release process page was also updated (separate commit to wiki repo).

Key changes:
- Step 1 now includes open PR review and KNOWN_ISSUES staleness check
- Versioning policy documented (patch-default, minor for milestones)
- Changelog sub-heading rules clarified (domain sub-heads under Added only)
- Replaced vague "execute checklist" step with explicit branch → PR → merge → tag flow
- Minimal tag messages (`"vX.Y.Z"` only), GitHub Releases carry full notes

—MxC