### PR TITLE
Add 'split' to TASK_ARG_KEYS in setup_inspect.py

### DIFF
--- a/tests/unit/test_setup_inspect.py
+++ b/tests/unit/test_setup_inspect.py
@@ -75,6 +75,7 @@ FULL_EVAL_CONFIG = textwrap.dedent("""\
     data_path: /data/acs_income.json
     vis_label: 1B_ft
     use_chat_template: "true"
+    split: validation
     epoch: 0
     finetuned: true
     source_model: Llama-3.2-1B-Instruct
@@ -199,18 +200,26 @@ class TestBuildTaskArgs:
         assert build_task_args(config) == ""
 
     def test_all_task_args(self):
-        """All four task params produce -T lines."""
+        """All five task params produce -T lines."""
         config = make_config(
             data_path="/data/test.json",
             config_path="/config/eval.yaml",
             vis_label="1B_ft",
             use_chat_template="true",
+            split="validation",
         )
         result = build_task_args(config)
         assert '-T data_path="/data/test.json"' in result
         assert '-T config_path="/config/eval.yaml"' in result
         assert '-T vis_label="1B_ft"' in result
         assert '-T use_chat_template="true"' in result
+        assert '-T split="validation"' in result
+
+    def test_split_task_arg(self):
+        """split param produces a -T line when present."""
+        config = make_config(split="test")
+        result = build_task_args(config)
+        assert '-T split="test"' in result
 
     def test_partial_task_args(self):
         """Only specified params appear."""

--- a/tools/inspect/setup_inspect.py
+++ b/tools/inspect/setup_inspect.py
@@ -24,7 +24,7 @@ from cruijff_kit.tools.torchtune.model_configs import MODEL_CONFIGS
 TEMPLATE_PATH = Path(__file__).parent / "templates" / "eval_template.slurm"
 
 # Keys in eval_config.yaml that become -T (task) args in the inspect command
-TASK_ARG_KEYS = ["data_path", "config_path", "vis_label", "use_chat_template"]
+TASK_ARG_KEYS = ["data_path", "config_path", "vis_label", "use_chat_template", "split"]
 
 # Keys in eval_config.yaml that become --metadata args in the inspect command
 METADATA_ARG_KEYS = ["epoch", "finetuned", "source_model"]


### PR DESCRIPTION
Closes #419

## Description

The `split` parameter was missing from `TASK_ARG_KEYS` in `setup_inspect.py`, so when an eval config specified a `split` field it was silently dropped and never passed as a `-T` arg to the inspect command.

One-line fix + test updates:
- Added `"split"` to `TASK_ARG_KEYS`
- Updated `test_all_task_args` to cover all five keys
- Added `test_split_task_arg` for isolated coverage
- Added `split` to `FULL_EVAL_CONFIG` fixture

## New Dependencies

None

## Testing Instructions

```bash
python -m pytest tests/unit/test_setup_inspect.py -v
```

All 58 tests pass.

—MxC