### PR TITLE
Add validation field fallback in prebuild_cache.py

### DIFF
--- a/tests/test_prebuild_cache.py
+++ b/tests/test_prebuild_cache.py
@@ -122,6 +122,50 @@ def test_no_dataset_key_in_tasks(mock_load, tmp_path):
     assert mock_load.call_count == 0
 
 
+@patch("cruijff_kit.tools.inspect.prebuild_cache.load_dataset")
+def test_fallback_to_validation_field(mock_load, tmp_path):
+    """When field='test' fails, falls back to field='validation'."""
+    d1 = _make_dataset(tmp_path, "val_only.json")
+    summary = _write_summary(
+        tmp_path,
+        [{"name": "task1", "dataset": d1}],
+    )
+
+    # First call (field="test") fails, second call (field="validation") succeeds
+    mock_load.side_effect = [ValueError("no 'test' field"), None]
+
+    result = prebuild_cache(summary)
+
+    assert result["status"] == "success"
+    assert result["datasets_cached"] == 1
+    assert result["datasets_failed"] == 0
+    assert mock_load.call_count == 2
+    # Verify the fallback call used field="validation"
+    second_call = mock_load.call_args_list[1]
+    assert (
+        second_call.kwargs.get("field") or second_call[1].get("field") == "validation"
+    )
+
+
+@patch("cruijff_kit.tools.inspect.prebuild_cache.load_dataset")
+def test_both_fields_fail(mock_load, tmp_path):
+    """When both field='test' and field='validation' fail, reports failure."""
+    d1 = _make_dataset(tmp_path, "bad.json")
+    summary = _write_summary(
+        tmp_path,
+        [{"name": "task1", "dataset": d1}],
+    )
+
+    mock_load.side_effect = [ValueError("no 'test'"), ValueError("no 'validation'")]
+
+    result = prebuild_cache(summary)
+
+    assert result["status"] == "success"
+    assert result["datasets_cached"] == 0
+    assert result["datasets_failed"] == 1
+    assert mock_load.call_count == 2
+
+
 @patch("cruijff_kit.tools.inspect.prebuild_cache.load_dataset", None)
 def test_missing_datasets_package(tmp_path):
     """Missing datasets package → returns friendly error."""

--- a/tools/inspect/prebuild_cache.py
+++ b/tools/inspect/prebuild_cache.py
@@ -109,6 +109,10 @@ def prebuild_cache(summary_path: str) -> dict:
                     "json", data_files=dataset_path, field="validation", split="train"
                 )
                 print(f"CACHE_BUILT: {dataset_path} (field=validation)")
+                print(
+                    f"WARNING: {dataset_path} has no 'test' field — "
+                    f"fell back to 'validation'. Verify this is the intended eval split."
+                )
                 paths_cached.append(dataset_path)
             except Exception as e:
                 print(

--- a/tools/inspect/prebuild_cache.py
+++ b/tools/inspect/prebuild_cache.py
@@ -101,11 +101,21 @@ def prebuild_cache(summary_path: str) -> dict:
 
         try:
             load_dataset("json", data_files=dataset_path, field="test", split="train")
-            print(f"CACHE_BUILT: {dataset_path}")
+            print(f"CACHE_BUILT: {dataset_path} (field=test)")
             paths_cached.append(dataset_path)
-        except Exception as e:
-            print(f"CACHE_FAILED: {dataset_path} ({e})")
-            paths_failed.append(dataset_path)
+        except Exception:
+            try:
+                load_dataset(
+                    "json", data_files=dataset_path, field="validation", split="train"
+                )
+                print(f"CACHE_BUILT: {dataset_path} (field=validation)")
+                paths_cached.append(dataset_path)
+            except Exception as e:
+                print(
+                    f"CACHE_FAILED: {dataset_path} "
+                    f"(tried field=test and field=validation, both failed: {e})"
+                )
+                paths_failed.append(dataset_path)
 
     print(f"CACHE_PREBUILD_COMPLETE: {len(paths_cached)} datasets cached")
 


### PR DESCRIPTION
Closes #421

## Description

`prebuild_cache.py` hardcoded `field="test"` when preloading datasets into the HuggingFace cache. Datasets that use a `"validation"` split instead of `"test"` would fail the cache prebuild even though the dataset is valid.

This is a niche situation — most experiment datasets use a `"test"` field. It came up during sanity check experiments that used validation splits for evaluation, and may not arise in typical usage.

The fix tries `field="test"` first, falls back to `field="validation"`, and logs which field succeeded.

## New Dependencies

None

## Testing Instructions

```bash
python -m pytest tests/test_prebuild_cache.py -v
```

All 9 tests pass (2 new: `test_fallback_to_validation_field`, `test_both_fields_fail`).

—MxC