### PR TITLE
Add per-sample variant of shuffle_acs_variables.py

### DIFF
--- a/experiments/folktexts/per_sample_shuffle_acs_variables.py
+++ b/experiments/folktexts/per_sample_shuffle_acs_variables.py
@@ -1,0 +1,69 @@
+"""Shuffle the order of bullet-point variables independently per training sample.
+
+Unlike shuffle_acs_variables.py (which applies one fixed permutation to all
+rows), this script gives each training sample its own random permutation.
+Validation and test splits are left in original order so that evaluation
+comparisons remain clean.  Works with any ACS task (Income, PublicCoverage,
+etc.) regardless of the number of variables.
+
+Usage:
+    python experiments/folktexts/per_sample_shuffle_acs_variables.py \
+        --input  data/green/acs/acs_income_verbose_50000_80P.json \
+        --output data/green/acs/acs_income_verbose_50000_80P_per_sample_shuffle.json \
+        --seed 42
+"""
+
+import argparse
+import json
+import random
+
+from shuffle_acs_variables import parse_input, reassemble
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Per-sample shuffle of variable order in ACS prompts."
+    )
+    parser.add_argument("--input", required=True, help="Path to source JSON")
+    parser.add_argument("--output", required=True, help="Path to write shuffled JSON")
+    parser.add_argument(
+        "--seed", type=int, default=42, help="Random seed (default: 42)"
+    )
+    args = parser.parse_args()
+
+    with open(args.input) as f:
+        data = json.load(f)
+
+    rng = random.Random(args.seed)
+
+    result = {}
+    for split, samples in data.items():
+        if split == "train":
+            shuffled_samples = []
+            for sample in samples:
+                header, bullets, question = parse_input(sample["input"])
+                perm = list(range(len(bullets)))
+                rng.shuffle(perm)
+                shuffled_bullets = [bullets[i] for i in perm]
+                shuffled_samples.append(
+                    {
+                        "input": reassemble(header, shuffled_bullets, question),
+                        "output": sample["output"],
+                    }
+                )
+            result[split] = shuffled_samples
+            print(f"  {split}: {len(shuffled_samples)} samples (per-sample shuffled)")
+        else:
+            # Keep val/test in original order
+            result[split] = samples
+            print(f"  {split}: {len(samples)} samples (original order)")
+
+    with open(args.output, "w") as f:
+        json.dump(result, f, indent=2)
+
+    print(f"\nSeed: {args.seed}")
+    print(f"Written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #424

# Description

Adds `experiments/folktexts/per_sample_shuffle_acs_variables.py`, a sibling to the existing `shuffle_acs_variables.py`. Where the existing script applies one fixed permutation of bullet-point variables to all rows, this one gives each training sample its own independent random permutation. Validation and test splits are left in original order so evaluation comparisons remain clean.

The script reuses `parse_input` / `reassemble` from `shuffle_acs_variables.py` and is task-agnostic (works with any ACS task regardless of variable count).

A future refactor could fold both variants into a single script with a `--per-sample` flag — out of scope here.

## New Dependencies

None.

# Testing Instructions

```bash
python experiments/folktexts/per_sample_shuffle_acs_variables.py \
    --input  data/green/acs/acs_income_verbose_50000_80P.json \
    --output /tmp/per_sample_test.json \
    --seed 42
```

Verify that:
- Each training sample has a different ordering of bullet lines
- Validation / test splits match the input splits byte-for-byte

—MxC