### PR TITLE
Warn when epochs_to_save will produce excessive checkpoints

### DIFF
--- a/tests/unit/test_setup_finetune.py
+++ b/tests/unit/test_setup_finetune.py
@@ -823,3 +823,17 @@ def test_warn_on_excessive_checkpoints_unknown_model_omits_size():
         msg = str(w[0].message)
         assert "50 checkpoints" in msg
         assert "GB total" not in msg
+        assert "checkpoint size unknown" in msg
+
+
+def test_warn_on_excessive_checkpoints_unparseable_model_name():
+    """Model name that doesn't match NB pattern (e.g. 'gemma4') should still warn
+    and name the model so the user can see why size couldn't be estimated."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        warn_on_excessive_checkpoints("all", epochs=50, model_name="gemma4")
+        assert len(w) == 1
+        msg = str(w[0].message)
+        assert "50 checkpoints" in msg
+        assert "GB total" not in msg
+        assert "checkpoint size unknown for 'gemma4'" in msg

--- a/tests/unit/test_setup_finetune.py
+++ b/tests/unit/test_setup_finetune.py
@@ -14,6 +14,9 @@ from cruijff_kit.tools.torchtune.setup_finetune import (
     extract_flat_params,
     compute_training_steps,
     warn_on_low_steps,
+    warn_on_excessive_checkpoints,
+    _estimate_checkpoint_size_gb,
+    _suggest_checkpoint_subset,
     RECIPE_PARAM_MAPPING,
 )
 
@@ -729,3 +732,94 @@ def test_warn_on_low_steps_below_50_but_above_3x_warmup():
         warnings.simplefilter("always")
         warn_on_low_steps(step_info, num_warmup_steps=5)
         assert len(w) == 0
+
+
+# Tests for _estimate_checkpoint_size_gb()
+
+
+def test_estimate_checkpoint_size_gb_llama_1b():
+    """1B model should yield ~2.5 GB."""
+    assert _estimate_checkpoint_size_gb("Llama-3.2-1B-Instruct") == 2.5
+
+
+def test_estimate_checkpoint_size_gb_llama_8b():
+    """8B model should yield ~20 GB."""
+    assert _estimate_checkpoint_size_gb("Llama-3.1-8B-Instruct") == 20.0
+
+
+def test_estimate_checkpoint_size_gb_unknown_returns_none():
+    """Model name with no NB pattern should return None."""
+    assert _estimate_checkpoint_size_gb("some-unrecognized-model") is None
+
+
+def test_estimate_checkpoint_size_gb_none_input():
+    """None model name should return None."""
+    assert _estimate_checkpoint_size_gb(None) is None
+
+
+# Tests for _suggest_checkpoint_subset()
+
+
+def test_suggest_checkpoint_subset_100_epochs():
+    """100 epochs with default target_count=10 -> every 10th epoch."""
+    assert _suggest_checkpoint_subset(100) == "9,19,29,39,49,59,69,79,89,99"
+
+
+def test_suggest_checkpoint_subset_ends_on_last_epoch():
+    """Suggestion must always include the final epoch."""
+    result = _suggest_checkpoint_subset(53)
+    assert result.split(",")[-1] == "52"
+
+
+# Tests for warn_on_excessive_checkpoints()
+
+
+def test_warn_on_excessive_checkpoints_below_threshold():
+    """No warning when checkpoint count is at or below threshold."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        warn_on_excessive_checkpoints(
+            "all", epochs=10, model_name="Llama-3.2-1B-Instruct"
+        )
+        assert len(w) == 0
+
+
+def test_warn_on_excessive_checkpoints_all_over_threshold():
+    """'all' with epochs > threshold should warn."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        warn_on_excessive_checkpoints(
+            "all", epochs=100, model_name="Llama-3.2-1B-Instruct"
+        )
+        assert len(w) == 1
+        msg = str(w[0].message)
+        assert "100 checkpoints" in msg
+        assert "250 GB total" in msg  # 100 * 2.5
+
+
+def test_warn_on_excessive_checkpoints_explicit_list_over_threshold():
+    """An explicit list of >10 epochs should warn."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        warn_on_excessive_checkpoints(list(range(15)), epochs=50)
+        assert len(w) == 1
+        assert "15 checkpoints" in str(w[0].message)
+
+
+def test_warn_on_excessive_checkpoints_empty_list_no_warning():
+    """An empty list ('none') should not warn."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        warn_on_excessive_checkpoints([], epochs=100)
+        assert len(w) == 0
+
+
+def test_warn_on_excessive_checkpoints_unknown_model_omits_size():
+    """Warning should still fire but without a size estimate when model is unknown."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        warn_on_excessive_checkpoints("all", epochs=50, model_name=None)
+        assert len(w) == 1
+        msg = str(w[0].message)
+        assert "50 checkpoints" in msg
+        assert "GB total" not in msg

--- a/tools/torchtune/setup_finetune.py
+++ b/tools/torchtune/setup_finetune.py
@@ -166,8 +166,10 @@ def warn_on_excessive_checkpoints(
             f" (conservative estimate: ~{num_checkpoints * size_gb:.0f} GB total "
             f"at ~{size_gb:.1f} GB/checkpoint)"
         )
+    elif model_name:
+        size_note = f" (checkpoint size unknown for '{model_name}')"
     else:
-        size_note = ""
+        size_note = " (checkpoint size unknown)"
 
     suggestion = _suggest_checkpoint_subset(epochs)
 

--- a/tools/torchtune/setup_finetune.py
+++ b/tools/torchtune/setup_finetune.py
@@ -1,6 +1,7 @@
 import argparse
 import math
 import os
+import re
 import warnings
 import yaml
 from pathlib import Path
@@ -106,6 +107,76 @@ def warn_on_low_steps(step_info, num_warmup_steps):
             f"Consider reducing batch size or gradient accumulation, or increasing epochs.",
             stacklevel=2,
         )
+
+
+def _estimate_checkpoint_size_gb(model_name):
+    """Estimate per-checkpoint disk size in GB from the parameter count in a model name.
+
+    Uses 2.5 GB/B as a conservative rule of thumb — empirically, torchtune LoRA
+    checkpoints land around 2.0-2.7 GB/B depending on model size. This errs high
+    for larger models so the warning leans toward over-warning rather than under.
+    Returns None if the parameter count can't be parsed from the name.
+    """
+    if not model_name:
+        return None
+    match = re.search(r"(\d+(?:\.\d+)?)B", model_name, re.IGNORECASE)
+    if not match:
+        return None
+    return float(match.group(1)) * 2.5
+
+
+def _suggest_checkpoint_subset(epochs, target_count=10):
+    """Suggest ~target_count evenly-spaced 0-indexed epochs ending at epochs - 1.
+
+    Example: epochs=100, target_count=10 -> "9,19,29,39,49,59,69,79,89,99"
+    """
+    if epochs <= target_count:
+        return ",".join(str(e) for e in range(epochs))
+    step = max(1, epochs // target_count)
+    epochs_list = list(range(step - 1, epochs, step))
+    if epochs_list[-1] != epochs - 1:
+        epochs_list.append(epochs - 1)
+    return ",".join(str(e) for e in epochs_list)
+
+
+def warn_on_excessive_checkpoints(
+    epochs_to_save, epochs, model_name=None, threshold=10
+):
+    """Warn if the configured checkpoint schedule will produce many checkpoints.
+
+    Args:
+        epochs_to_save: Output of parse_epochs() — "all", a list of ints, or [].
+        epochs: Total training epochs.
+        model_name: Optional torchtune model name; used to estimate total size.
+        threshold: Warn when the number of saved checkpoints exceeds this.
+    """
+    if epochs_to_save == "all":
+        num_checkpoints = epochs
+    elif isinstance(epochs_to_save, list):
+        num_checkpoints = len(epochs_to_save)
+    else:
+        return
+
+    if num_checkpoints <= threshold:
+        return
+
+    size_gb = _estimate_checkpoint_size_gb(model_name)
+    if size_gb is not None:
+        size_note = (
+            f" (conservative estimate: ~{num_checkpoints * size_gb:.0f} GB total "
+            f"at ~{size_gb:.1f} GB/checkpoint)"
+        )
+    else:
+        size_note = ""
+
+    suggestion = _suggest_checkpoint_subset(epochs)
+
+    warnings.warn(
+        f"epochs_to_save will produce {num_checkpoints} checkpoints{size_note}. "
+        f"This may use significant disk and I/O time. "
+        f"Consider setting epochs_to_save to a subset (e.g., '{suggestion}').",
+        stacklevel=2,
+    )
 
 
 # Used for epochs_to_save to allow for all/none options
@@ -628,6 +699,10 @@ def main():
             f"Supported models: {', '.join(MODEL_CONFIGS.keys())}"
         )
     model_config = MODEL_CONFIGS[args.torchtune_model_name]
+
+    warn_on_excessive_checkpoints(
+        args.epochs_to_save, args.epochs, args.torchtune_model_name
+    )
 
     # Default dataset_type from MODEL_CONFIGS if not explicitly set by user or config file
     # Priority: CLI arg > config file > MODEL_CONFIGS > argparse default


### PR DESCRIPTION
Closes #415

# Description

Adds `warn_on_excessive_checkpoints()` in `tools/torchtune/setup_finetune.py`, mirroring the existing `warn_on_low_steps` pattern. Fires when the resolved checkpoint count exceeds 10 (handling `"all"`, explicit lists, and `"none"`).

When the torchtune model name contains a recognizable parameter count (e.g., `Llama-3.2-1B-Instruct`), the warning includes a conservative disk-usage estimate and a suggested evenly-spaced subset of epochs.

**Example output** (1B, 100 epochs, `epochs_to_save: all`):
```
epochs_to_save will produce 100 checkpoints (conservative estimate: ~250 GB 
total at ~2.5 GB/checkpoint). This may use significant disk and I/O time. 
Consider setting epochs_to_save to a subset (e.g., '9,19,29,39,49,59,69,79,89,99').
```

## Implementation notes

Two small module-level helpers support the warning:
- `_estimate_checkpoint_size_gb(model_name)`: regex-based parse of the param count, multiplied by a conservative 2.5 GB/B rule of thumb. Empirical spot-checks of real torchtune LoRA checkpoints on this cluster: 1B → 2.7 GB/ckpt, 3B → 2.0, 8B → 2.0. The 2.5 factor overestimates modestly for 3B+ — intentional so we err toward over-warning.
- `_suggest_checkpoint_subset(epochs, target_count=10)`: emit ~10 evenly-spaced 0-indexed epochs, always including the final epoch.

## New Dependencies

None (new `re` import only).

# Testing Instructions

Run the unit tests:

```bash
python -m pytest tests/unit/test_setup_finetune.py -q
```

11 new tests cover: threshold boundary, `"all"` trigger, explicit list trigger, empty-list (no warn), unknown-model (no size estimate), and the subset helper's edge cases. All 83 tests in the file pass.

To see the warning fire end-to-end, scaffold any experiment with a high epoch count and `epochs_to_save: all`.

—MxC