### PR TITLE
Generalize shuffle_acs_variables.py to any variable count

### DIFF
--- a/experiments/folktexts/per_sample_shuffle_acs_variables.py
+++ b/experiments/folktexts/per_sample_shuffle_acs_variables.py
@@ -1,4 +1,4 @@
-"""Shuffle the order of bullet-point variables independently per training sample.
+"""Shuffle the order of survey variables independently per training sample.
 
 Unlike shuffle_acs_variables.py (which applies one fixed permutation to all
 rows), this script gives each training sample its own random permutation.
@@ -41,13 +41,13 @@ def main():
         if split == "train":
             shuffled_samples = []
             for sample in samples:
-                header, bullets, question = parse_input(sample["input"])
-                perm = list(range(len(bullets)))
+                header, variables, question = parse_input(sample["input"])
+                perm = list(range(len(variables)))
                 rng.shuffle(perm)
-                shuffled_bullets = [bullets[i] for i in perm]
+                shuffled_variables = [variables[i] for i in perm]
                 shuffled_samples.append(
                     {
-                        "input": reassemble(header, shuffled_bullets, question),
+                        "input": reassemble(header, shuffled_variables, question),
                         "output": sample["output"],
                     }
                 )

--- a/experiments/folktexts/shuffle_acs_variables.py
+++ b/experiments/folktexts/shuffle_acs_variables.py
@@ -1,9 +1,10 @@
-"""Shuffle the order of bullet-point variables in ACS Income prompts.
+"""Shuffle the order of bullet-point variables in ACS prompts.
 
-Produces a new dataset where the 10 survey-variable bullets appear in a
+Produces a new dataset where the survey-variable bullets appear in a
 random (but consistent across all rows) order.  Everything else — the
 header paragraph, the closing question, and the output label — stays
-identical.
+identical.  Works with any ACS task (Income, PublicCoverage, etc.)
+regardless of the number of variables.
 
 Usage:
     python experiments/folktexts/shuffle_acs_variables.py \
@@ -22,10 +23,10 @@ def parse_input(text: str) -> tuple[str, list[str], str]:
     """Split a prompt into (header, bullet_lines, question)."""
     lines = text.split("\n")
 
-    bullet_indices = [i for i, line in enumerate(lines) if line.startswith("- The ")]
-    if len(bullet_indices) != 10:
+    bullet_indices = [i for i, line in enumerate(lines) if line.startswith("- ")]
+    if len(bullet_indices) < 2:
         raise ValueError(
-            f"Expected 10 bullet lines, found {len(bullet_indices)}:\n{text[:200]}"
+            f"Expected at least 2 bullet lines, found {len(bullet_indices)}:\n{text[:200]}"
         )
 
     first_bullet = bullet_indices[0]
@@ -55,7 +56,7 @@ def shuffle_sample(sample: dict, permutation: list[int]) -> dict:
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Shuffle variable order in ACS Income prompts."
+        description="Shuffle variable order in ACS prompts."
     )
     parser.add_argument("--input", required=True, help="Path to source JSON")
     parser.add_argument("--output", required=True, help="Path to write shuffled JSON")
@@ -67,21 +68,28 @@ def main():
     with open(args.input) as f:
         data = json.load(f)
 
+    # Detect number of variables from first sample
+    first_sample = data[next(iter(data))][0]
+    _, original_bullets, _ = parse_input(first_sample["input"])
+    n_vars = len(original_bullets)
+    print(f"Detected {n_vars} variables")
+
     # Generate a derangement (no element stays in its original position)
     rng = random.Random(args.seed)
-    permutation = list(range(10))
+    permutation = list(range(n_vars))
     attempts = 0
     while True:
         rng.shuffle(permutation)
         attempts += 1
-        if all(permutation[i] != i for i in range(10)):
+        if all(permutation[i] != i for i in range(n_vars)):
             break
     print(f"Found derangement after {attempts} attempt(s)")
 
-    # Log the resulting order by extracting variable names from the first sample
-    first_sample = data[next(iter(data))][0]
-    _, original_bullets, _ = parse_input(first_sample["input"])
-    var_names = [re.match(r"- The (.+?) is:", b).group(1) for b in original_bullets]
+    # Log the resulting order
+    var_names = []
+    for b in original_bullets:
+        m = re.match(r"- The (.+?) is:", b)
+        var_names.append(m.group(1) if m else b[:60])
 
     print(f"Seed: {args.seed}")
     print(f"Permutation: {permutation}")

--- a/experiments/folktexts/shuffle_acs_variables.py
+++ b/experiments/folktexts/shuffle_acs_variables.py
@@ -1,6 +1,6 @@
-"""Shuffle the order of bullet-point variables in ACS prompts.
+"""Shuffle the order of survey variables in ACS prompts.
 
-Produces a new dataset where the survey-variable bullets appear in a
+Produces a new dataset where the survey variables appear in a
 random (but consistent across all rows) order.  Everything else — the
 header paragraph, the closing question, and the output label — stays
 identical.  Works with any ACS task (Income, PublicCoverage, etc.)
@@ -20,36 +20,36 @@ import re
 
 
 def parse_input(text: str) -> tuple[str, list[str], str]:
-    """Split a prompt into (header, bullet_lines, question)."""
+    """Split a prompt into (header, variable_lines, question)."""
     lines = text.split("\n")
 
-    bullet_indices = [i for i, line in enumerate(lines) if line.startswith("- ")]
-    if len(bullet_indices) < 2:
+    variable_indices = [i for i, line in enumerate(lines) if line.startswith("- ")]
+    if len(variable_indices) < 2:
         raise ValueError(
-            f"Expected at least 2 bullet lines, found {len(bullet_indices)}:\n{text[:200]}"
+            f"Expected at least 2 variable lines, found {len(variable_indices)}:\n{text[:200]}"
         )
 
-    first_bullet = bullet_indices[0]
-    last_bullet = bullet_indices[-1]
+    first_variable = variable_indices[0]
+    last_variable = variable_indices[-1]
 
-    header = "\n".join(lines[:first_bullet])
-    bullets = [lines[i] for i in bullet_indices]
-    question = "\n".join(lines[last_bullet + 1 :])
+    header = "\n".join(lines[:first_variable])
+    variables = [lines[i] for i in variable_indices]
+    question = "\n".join(lines[last_variable + 1 :])
 
-    return header, bullets, question
+    return header, variables, question
 
 
-def reassemble(header: str, bullets: list[str], question: str) -> str:
+def reassemble(header: str, variables: list[str], question: str) -> str:
     """Reassemble the three parts into a single prompt string."""
-    return header + "\n" + "\n".join(bullets) + "\n" + question
+    return header + "\n" + "\n".join(variables) + "\n" + question
 
 
 def shuffle_sample(sample: dict, permutation: list[int]) -> dict:
-    """Return a copy of the sample with bullet lines reordered."""
-    header, bullets, question = parse_input(sample["input"])
-    shuffled_bullets = [bullets[i] for i in permutation]
+    """Return a copy of the sample with variable lines reordered."""
+    header, variables, question = parse_input(sample["input"])
+    shuffled_variables = [variables[i] for i in permutation]
     return {
-        "input": reassemble(header, shuffled_bullets, question),
+        "input": reassemble(header, shuffled_variables, question),
         "output": sample["output"],
     }
 
@@ -70,8 +70,8 @@ def main():
 
     # Detect number of variables from first sample
     first_sample = data[next(iter(data))][0]
-    _, original_bullets, _ = parse_input(first_sample["input"])
-    n_vars = len(original_bullets)
+    _, original_variables, _ = parse_input(first_sample["input"])
+    n_vars = len(original_variables)
     print(f"Detected {n_vars} variables")
 
     # Generate a derangement (no element stays in its original position)
@@ -87,9 +87,9 @@ def main():
 
     # Log the resulting order
     var_names = []
-    for b in original_bullets:
-        m = re.match(r"- The (.+?) is:", b)
-        var_names.append(m.group(1) if m else b[:60])
+    for v in original_variables:
+        m = re.match(r"- The (.+?) is:", v)
+        var_names.append(m.group(1) if m else v[:60])
 
     print(f"Seed: {args.seed}")
     print(f"Permutation: {permutation}")


### PR DESCRIPTION
Closes #430

## Description

\`parse_input\` in \`experiments/folktexts/shuffle_acs_variables.py\` was hardcoded to expect exactly 10 bullet lines (matching ACS Income). \`per_sample_shuffle_acs_variables.py\` imports \`parse_input\` from this module, so the per-sample shuffle script fails with \`ValueError: Expected 10 bullet lines\` when run on PublicCoverage (8 variables) or any other non-10-variable ACS task.

This PR relaxes the bullet-count check to \`>= 2\`, detects variable count dynamically from the first sample, and falls back to the bullet's first 60 characters when the \`- The <name> is:\` regex does not match (so variable-name logging still works for alternative bullet formats).

The fix has been sitting in a local \`git stash\` since 2026-04-01 — apologies for the delay in landing it.

## New Dependencies

None.

## Testing Instructions

- [ ] Run the existing CI lint (\`ruff check\` / \`ruff format --check\`) — passes locally.
- [ ] Manually run \`per_sample_shuffle_acs_variables.py\` on a PublicCoverage dataset (8 variables) and confirm it no longer raises \`ValueError\`.
- [ ] Manually run \`shuffle_acs_variables.py\` on an Income dataset (10 variables) to confirm the Income path is unchanged.

—MxC