### PR TITLE
Widen extract_loss regex to capture scientific-notation losses

### DIFF
--- a/src/tools/torchtune/extract_loss.py
+++ b/src/tools/torchtune/extract_loss.py
@@ -6,7 +6,7 @@ from custom torchtune recipe stdout (epoch|step|Loss: value format).
 
 import re
 
-LOSS_PATTERN = re.compile(r"(\d+)\|(\d+)\|Loss: ([0-9.]+)")
+LOSS_PATTERN = re.compile(r"(\d+)\|(\d+)\|Loss: ([0-9.eE+-]+)")
 
 
 def extract_losses(text: str) -> list[tuple[int, int, float]]:

--- a/tests/unit/test_summarize_fixtures.py
+++ b/tests/unit/test_summarize_fixtures.py
@@ -112,6 +112,32 @@ class TestLossExtraction:
                     f"pad_token_id line should not match: {line}"
                 )
 
+    def test_extracts_scientific_notation_loss(self):
+        """Converged-model logs emit losses in sci-notation; the regex must capture them."""
+        line = "3|750|Loss: 6.0498432503663935e-06: 100%|##########| 250/250 [12:05<00:00,  2.90s/it]"
+        losses = extract_losses(line)
+        assert len(losses) == 1
+        assert losses[0][2] == pytest.approx(6.0498e-6, rel=1e-4)
+
+    def test_extracts_positive_exponent_loss(self):
+        """Edge case: very large losses (early training, divergence) may use e+ notation."""
+        line = "1|1|Loss: 2.5e+02: starting"
+        losses = extract_losses(line)
+        assert len(losses) == 1
+        assert losses[0][2] == pytest.approx(250.0)
+
+    def test_mixed_decimal_and_sci_notation(self):
+        """A realistic converging-then-converged log mixes both formats."""
+        text = (
+            "1|10|Loss: 1.234: ...\n2|20|Loss: 5.6e-05: ...\n3|30|Loss: 7.89e-08: ...\n"
+        )
+        losses = extract_losses(text)
+        assert [step for _, step, _ in losses] == [10, 20, 30]
+        assert losses[0][2] == pytest.approx(1.234)
+        assert losses[1][2] == pytest.approx(5.6e-5)
+        assert losses[2][2] == pytest.approx(7.89e-8)
+        assert final_loss(text)[2] == pytest.approx(7.89e-8)
+
 
 class TestEvalResultParsing:
     def test_status_is_success(self, eval_result):


### PR DESCRIPTION
Closes #448

# Description

The torchtune custom recipe formats losses with Python's default `repr()`, which switches to scientific notation when |value| < 1e-4. The previous regex `(\d+)\|(\d+)\|Loss: ([0-9.]+)` captured digits-and-dots only, so a converged loss of `6.05e-06` silently parsed as `6.05` — `summary.md` would report a saturated run as "loss is high, training failed."

**Source change** (`src/tools/torchtune/extract_loss.py`): widen the third capture group from `[0-9.]+` to `[0-9.eE+-]+`. `float()` already accepts scientific notation natively, so no parsing change is needed in `extract_losses` — only the regex needs widening. The `[0-9.eE+-]+` character class is intentionally permissive; any malformed match would raise `ValueError` from `float()` (a healthy fail-loud, since malformed input means something is wrong upstream).

**Test change** (`tests/unit/test_summarize_fixtures.py`): three new tests appended to `TestLossExtraction` covering `e-06`, `e+02`, and a log that mixes both decimal and sci-notation losses. The existing `slurm_training_output.txt` fixture has zero scientific-notation losses — confirmed via `grep -E "Loss: [0-9.]+e[+-][0-9]+"` — which is why the bug shipped.

## New Dependencies

None.

# Testing Instructions

All commands run from the repo root with the `cruijff` conda env active.

**1. Unit tests — 23 passed in 0.07s:**

```bash
pytest tests/unit/test_summarize_fixtures.py -v
```

```
tests/unit/test_summarize_fixtures.py::TestLossExtraction::test_extracts_scientific_notation_loss PASSED
tests/unit/test_summarize_fixtures.py::TestLossExtraction::test_extracts_positive_exponent_loss  PASSED
tests/unit/test_summarize_fixtures.py::TestLossExtraction::test_mixed_decimal_and_sci_notation   PASSED
... (20 pre-existing tests also passed)
============================== 23 passed in 0.07s ==============================
```

**2. Existing fixture parses identically (no behavioral regression for decimal-format losses):**

```bash
python -c "
from pathlib import Path
from cruijff_kit.tools.torchtune.extract_loss import final_loss, extract_losses
text = Path('tests/fixtures/summarize/slurm_training_output.txt').read_text()
print('count:', len(extract_losses(text)), '(expected 18)')
print('final:', final_loss(text), '(expected (epoch, 500, ~0.26427))')
"
```

```
count: 18 (expected 18)
final: (2, 500, 0.26427456736564636) (expected (epoch, 500, ~0.26427))
```

**3. Lint — clean:**

```bash
ruff check src/tools/torchtune/extract_loss.py tests/unit/test_summarize_fixtures.py
ruff format --check src/tools/torchtune/extract_loss.py tests/unit/test_summarize_fixtures.py
```

```
All checks passed!
2 files already formatted
```

**Note on the issue's real-log replay step:** the suggested before/after replay against `/scratch/gpfs/MSALGANIK/mjs3/ck-experiments/consistency_curve_pilot_nth14_k20/.../slurm-7604383.out` was skipped — that file is `mjs3`-owned and not group-readable from `niznik`. The exact loss string from that log (`6.0498432503663935e-06`) is covered verbatim by `test_extracts_scientific_notation_loss`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)