### PR TITLE
Replace calibration flag with logprobs capability switch (#461)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to cruijff_kit will be documented in this file.
 ### Changed
 
 - `python-markdown` added as a runtime dependency (used by the quiz renderer for intro / prompt / explanation / write-up markdown).
+- **Breaking:** `model_organism` inspect task replaces the bundled `calibration` flag with two primitives: `logprobs: bool | None` (capability switch) and `top_logprobs: int` (previously hardcoded at 20). Logprobs auto-enable when a configured scorer declares `requires_logprobs = True` (currently only `risk_scorer`). Existing experiment configs using `-T calibration=true` must migrate to placing `risk_scorer` in the YAML `scorer:` list (calibration workflow) or `-T logprobs=true` (raw logprobs only). (#461)
 
 ## [0.2.2] - 2026-04-23
 

--- a/src/tools/inspect/scorers/__init__.py
+++ b/src/tools/inspect/scorers/__init__.py
@@ -14,6 +14,15 @@ from .calibration_metrics import (
     auc_score as auc_score,
 )
 
+# Underlying scorer factories keyed by registered name. Used for capability
+# introspection (e.g., `requires_logprobs`) before instantiation.
+SCORER_FACTORIES = {
+    "match": match,
+    "includes": includes,
+    "risk_scorer": risk_scorer,
+    "numeric_risk_scorer": numeric_risk_scorer,
+}
+
 # Registry of available scorers and their constructors.
 # Task files use build_scorers() to instantiate scorers from YAML config.
 SCORER_REGISTRY = {
@@ -28,6 +37,22 @@ SCORER_REGISTRY = {
         numeric_risk_scorer(**params) if params else numeric_risk_scorer()
     ),
 }
+
+
+def configured_scorers_require_logprobs(config: dict) -> bool:
+    """Return True if any scorer in the YAML config declares it needs logprobs.
+
+    Detection is attribute-based (not name-based): a scorer factory opts in by
+    setting ``requires_logprobs = True``. This avoids over-including scorers
+    whose names happen to match a heuristic but which read text completion
+    instead of logprobs (e.g., `numeric_risk_scorer`).
+    """
+    for entry in config.get("scorer", []) or []:
+        factory = SCORER_FACTORIES.get(entry.get("name"))
+        if factory is not None and getattr(factory, "requires_logprobs", False):
+            return True
+    return False
+
 
 # Default scorers when no config is provided
 DEFAULT_SCORERS = [

--- a/src/tools/inspect/scorers/risk_scorer.py
+++ b/src/tools/inspect/scorers/risk_scorer.py
@@ -46,7 +46,7 @@ def mean_risk_score() -> Metric:
 def risk_scorer(option_tokens: list[str] = ("0", "1")):
     """
     Scorer that extracts risk scores from logprobs of the first generated token.
-    - Requires GenerateConfig(logprobs=True, top_logprobs=20) on the Task.
+    - Requires GenerateConfig(logprobs=True, top_logprobs>=2) on the Task.
     - Supports any number of option tokens (binary or multiclass).
     - For binary tasks, returns a risk_score = P(last/positive option token).
     - For all tasks, returns normalized probabilities over all option tokens.
@@ -129,3 +129,10 @@ def risk_scorer(option_tokens: list[str] = ("0", "1")):
         )
 
     return score
+
+
+# Capability marker: the unified `model_organism` task auto-enables logprobs
+# capture when a configured scorer declares this attribute. Set on the factory
+# (not the inner score function) so the task can introspect by name lookup
+# without instantiating the scorer first. See src/tools/model_organisms/inspect_task.py.
+risk_scorer.requires_logprobs = True

--- a/src/tools/inspect/setup_inspect.py
+++ b/src/tools/inspect/setup_inspect.py
@@ -30,7 +30,8 @@ TASK_ARG_KEYS = [
     "vis_label",
     "use_chat_template",
     "split",
-    "calibration",
+    "logprobs",
+    "top_logprobs",
 ]
 
 # Keys in eval_config.yaml that become --metadata args in the inspect command

--- a/src/tools/model_organisms/inspect_task.py
+++ b/src/tools/model_organisms/inspect_task.py
@@ -12,10 +12,16 @@ Usage::
         -T data_path=/path/to/dataset.json \\
         -T config_path=/path/to/eval_config.yaml
 
-Calibration opt-in (enables logprobs + appends ``risk_scorer`` if not
-already configured via YAML)::
+Logprob capture is enabled in two ways:
 
-    ... -T calibration=true
+1. Implicitly — list a scorer in the YAML ``scorer:`` block whose factory sets
+   ``requires_logprobs = True`` (e.g., ``risk_scorer``). The task auto-enables
+   logprobs because the scorer needs them.
+2. Explicitly — pass ``-T logprobs=true`` to capture logprobs for downstream
+   analysis without configuring a logprob-consuming scorer.
+
+If a scorer requires logprobs but the user passes ``-T logprobs=false``, the
+task fails with a clear configuration error rather than silently overriding.
 """
 
 import yaml
@@ -24,7 +30,11 @@ from inspect_ai.dataset import Sample, hf_dataset
 from inspect_ai.model import GenerateConfig
 from inspect_ai.solver import chain, generate, system_message
 
-from cruijff_kit.tools.inspect.scorers import build_scorers, risk_scorer
+from cruijff_kit.tools.inspect.scorers import (
+    SCORER_FACTORIES,
+    build_scorers,
+    configured_scorers_require_logprobs,
+)
 
 
 @task
@@ -35,7 +45,8 @@ def model_organism(
     temperature: float = 1e-7,
     max_tokens: int = 5,
     use_chat_template: bool = True,
-    calibration: bool = False,
+    logprobs: bool | None = None,
+    top_logprobs: int = 20,
     vis_label: str = "",
 ) -> Task:
     """
@@ -48,8 +59,14 @@ def model_organism(
         temperature: Generation temperature.
         max_tokens: Max tokens to generate.
         use_chat_template: If True, prepend a system_message solver.
-        calibration: If True, enable logprobs and append risk_scorer to the
-            scorer list (unless already listed via YAML).
+        logprobs: Capture top logprobs for the generated tokens. ``None`` (the
+            default) means "auto" — enabled when a configured scorer declares
+            it needs logprobs, otherwise off. Pass ``True``/``False`` to force.
+            Passing ``False`` while configuring a scorer that requires
+            logprobs raises a ValueError.
+        top_logprobs: Number of top logprobs to capture per generated token
+            when logprobs are enabled. Default 20; multiclass / tokenization
+            variants may need more to keep all option tokens in the top-k.
         vis_label: Optional suffix for the task name (useful for multi-variant
             eval runs across a single experiment).
     """
@@ -91,11 +108,26 @@ def model_organism(
         )
 
     scorers = build_scorers(config)
-    if calibration:
-        configured_names = {entry["name"] for entry in config.get("scorer", [])}
-        if "risk_scorer" not in configured_names:
-            scorers.append(risk_scorer())
-        generate_config = GenerateConfig(logprobs=True, top_logprobs=20)
+    scorer_needs_logprobs = configured_scorers_require_logprobs(config)
+
+    if logprobs is False and scorer_needs_logprobs:
+        required = [
+            entry["name"]
+            for entry in config.get("scorer", []) or []
+            if getattr(
+                SCORER_FACTORIES.get(entry.get("name")), "requires_logprobs", False
+            )
+        ]
+        raise ValueError(
+            f"Scorer(s) {required} require logprobs, but logprobs=False was "
+            "explicitly set. Either remove the logprobs override or drop the "
+            "logprob-dependent scorer from the YAML config."
+        )
+
+    enable_logprobs = bool(logprobs) or (logprobs is None and scorer_needs_logprobs)
+
+    if enable_logprobs:
+        generate_config = GenerateConfig(logprobs=True, top_logprobs=top_logprobs)
     else:
         generate_config = GenerateConfig()
 

--- a/tests/unit/test_model_organism_inspect_task.py
+++ b/tests/unit/test_model_organism_inspect_task.py
@@ -39,12 +39,24 @@ def tiny_dataset(tmp_path):
     return str(path)
 
 
+def _write_config(tmp_path, *, scorers=None):
+    """Write a minimal eval_config.yaml. ``scorers`` is a list of name strings."""
+    config_path = tmp_path / "eval_config.yaml"
+    lines = ["prompt: '{input}'", "system_prompt: ''"]
+    if scorers is not None:
+        lines.append("scorer:")
+        for name in scorers:
+            lines.append(f"  - name: {name}")
+    config_path.write_text("\n".join(lines) + "\n")
+    return str(config_path)
+
+
 class TestDefaults:
     def test_returns_task(self, tiny_dataset):
         t = model_organism(data_path=tiny_dataset)
         assert t.name == "model_organism"
 
-    def test_no_calibration_no_logprobs(self, tiny_dataset):
+    def test_default_no_logprobs(self, tiny_dataset):
         t = model_organism(data_path=tiny_dataset)
         assert t.config.logprobs is None
         assert t.config.top_logprobs is None
@@ -55,37 +67,86 @@ class TestDefaults:
         assert names == ["inspect_ai/match", "inspect_ai/includes"]
 
 
-class TestCalibration:
-    def test_calibration_enables_logprobs(self, tiny_dataset):
-        t = model_organism(data_path=tiny_dataset, calibration=True)
+class TestLogprobs:
+    def test_explicit_true_enables_logprobs(self, tiny_dataset):
+        t = model_organism(data_path=tiny_dataset, logprobs=True)
         assert t.config.logprobs is True
         assert t.config.top_logprobs == 20
 
-    def test_calibration_appends_risk_scorer(self, tiny_dataset):
-        t = model_organism(data_path=tiny_dataset, calibration=True)
-        names = _scorer_names(t.scorer)
-        assert "risk_scorer" in names
-        assert "inspect_ai/match" in names
-        assert "inspect_ai/includes" in names
+    def test_top_logprobs_is_configurable(self, tiny_dataset):
+        t = model_organism(data_path=tiny_dataset, logprobs=True, top_logprobs=50)
+        assert t.config.logprobs is True
+        assert t.config.top_logprobs == 50
 
-    def test_calibration_does_not_duplicate_risk_scorer(self, tiny_dataset, tmp_path):
-        config_path = tmp_path / "eval_config.yaml"
-        config_path.write_text(
-            "prompt: '{input}'\n"
-            "system_prompt: ''\n"
-            "scorer:\n"
-            "  - name: match\n"
-            "    params:\n"
-            "      location: exact\n"
-            "  - name: risk_scorer\n"
-        )
-        t = model_organism(
-            data_path=tiny_dataset,
-            config_path=str(config_path),
-            calibration=True,
-        )
+    def test_top_logprobs_ignored_when_disabled(self, tiny_dataset):
+        t = model_organism(data_path=tiny_dataset, logprobs=False, top_logprobs=50)
+        assert t.config.logprobs is None
+        assert t.config.top_logprobs is None
+
+
+class TestScorerDrivenLogprobs:
+    def test_risk_scorer_auto_enables_logprobs(self, tiny_dataset, tmp_path):
+        config_path = _write_config(tmp_path, scorers=["risk_scorer"])
+        t = model_organism(data_path=tiny_dataset, config_path=config_path)
+        assert t.config.logprobs is True
+        assert t.config.top_logprobs == 20
+
+    def test_risk_scorer_present_no_duplicate(self, tiny_dataset, tmp_path):
+        config_path = _write_config(tmp_path, scorers=["match", "risk_scorer"])
+        t = model_organism(data_path=tiny_dataset, config_path=config_path)
         names = _scorer_names(t.scorer)
         assert names.count("risk_scorer") == 1
+
+    def test_match_only_does_not_enable_logprobs(self, tiny_dataset, tmp_path):
+        config_path = _write_config(tmp_path, scorers=["match"])
+        t = model_organism(data_path=tiny_dataset, config_path=config_path)
+        assert t.config.logprobs is None
+
+    def test_numeric_risk_scorer_does_not_enable_logprobs(self, tiny_dataset, tmp_path):
+        # numeric_risk_scorer parses a float from text completion — no logprobs
+        # needed. A name-based heuristic would over-include it; an attribute
+        # check correctly leaves it alone.
+        config_path = _write_config(tmp_path, scorers=["numeric_risk_scorer"])
+        t = model_organism(data_path=tiny_dataset, config_path=config_path)
+        assert t.config.logprobs is None
+
+
+class TestConflictSemantics:
+    def test_explicit_false_with_risk_scorer_raises(self, tiny_dataset, tmp_path):
+        config_path = _write_config(tmp_path, scorers=["risk_scorer"])
+        with pytest.raises(ValueError, match="risk_scorer.*logprobs=False"):
+            model_organism(
+                data_path=tiny_dataset,
+                config_path=config_path,
+                logprobs=False,
+            )
+
+    def test_explicit_true_with_risk_scorer_works(self, tiny_dataset, tmp_path):
+        config_path = _write_config(tmp_path, scorers=["risk_scorer"])
+        t = model_organism(
+            data_path=tiny_dataset,
+            config_path=config_path,
+            logprobs=True,
+        )
+        assert t.config.logprobs is True
+
+    def test_explicit_false_with_match_only_disables_logprobs(
+        self, tiny_dataset, tmp_path
+    ):
+        config_path = _write_config(tmp_path, scorers=["match"])
+        t = model_organism(
+            data_path=tiny_dataset,
+            config_path=config_path,
+            logprobs=False,
+        )
+        assert t.config.logprobs is None
+
+
+class TestRemovedCalibrationFlag:
+    def test_calibration_kwarg_rejected(self, tiny_dataset):
+        # The old `calibration` flag was removed; passing it must fail loud.
+        with pytest.raises(TypeError):
+            model_organism(data_path=tiny_dataset, calibration=True)
 
 
 class TestVisLabel:


### PR DESCRIPTION
Closes #461

# Description

The `model_organism` inspect task previously had a single `calibration: bool` flag that did two things: enabled logprob capture and auto-appended `risk_scorer`. The name described only the second behavior, leaving the underlying capability undiscoverable to anyone wanting logprobs for non-calibration analysis.

This PR replaces it with two primitives plus scorer-driven inference:

- `logprobs: bool | None = None` — capability switch. `None` means *auto*: enabled when a configured scorer declares it needs logprobs, otherwise off. `True`/`False` force.
- `top_logprobs: int = 20` — exposes the previously hardcoded value (multiclass / tokenization variants may need more).

Scorers opt in via a `requires_logprobs = True` attribute on the factory (set on `risk_scorer` only). Attribute-based detection — not name-matching — correctly skips `numeric_risk_scorer`, which reads text completion rather than logprobs.

**Conflict semantics:** `-T logprobs=false` while configuring a logprob-dependent scorer raises `ValueError` rather than silently overriding either choice.

**User experience:**
- Calibration workflow → list `risk_scorer` in YAML `scorer:`. Logprobs auto-enable.
- Raw logprobs only → `-T logprobs=true`.
- No `calibration` flag, no two ways to do the same thing.

This is a **breaking change** to the experiment-config surface: `-T calibration=true` is no longer recognized. Existing experiments must migrate. Repo is alpha; only test files used the flag.

## Files changed

- `src/tools/model_organisms/inspect_task.py` — replace `calibration` with `logprobs`/`top_logprobs`; scorer-driven auto-enable; conflict error.
- `src/tools/inspect/scorers/risk_scorer.py` — set `risk_scorer.requires_logprobs = True`.
- `src/tools/inspect/scorers/__init__.py` — add `SCORER_FACTORIES` map and `configured_scorers_require_logprobs()` helper.
- `src/tools/inspect/setup_inspect.py` — replace `calibration` in `TASK_ARG_KEYS` with `logprobs` + `top_logprobs`.
- `tests/unit/test_model_organism_inspect_task.py` — replace calibration tests with new coverage (auto-enable, explicit on/off, conflict, numeric_risk_scorer not over-included, calibration kwarg rejected).
- `CHANGELOG.md` — breaking-change entry under Unreleased.

## New Dependencies

None.

# Testing Instructions

```bash
pytest tests/unit/test_model_organism_inspect_task.py -v
pytest tests/unit -q
ruff check src/tools/model_organisms/inspect_task.py src/tools/inspect/scorers tests/unit/test_model_organism_inspect_task.py
```

## Acceptance criteria from #461

- [x] `tests/unit/test_model_organism_inspect_task.py` passes with the new flag names.
- [x] `risk_scorer` configured in YAML and no `-T logprobs` flag enables logprobs (`test_risk_scorer_auto_enables_logprobs`).
- [x] `-T logprobs=true` and no `risk_scorer` enables logprobs (`test_explicit_true_enables_logprobs`).
- [x] `-T logprobs=false` with `risk_scorer` raises a clear configuration error (`test_explicit_false_with_risk_scorer_raises`).
- [x] `calibration=...` is rejected (`test_calibration_kwarg_rejected`).

The third and fourth criteria specify behavior on a real eval run; here they are validated at the task-construction level (the surface the issue asked to fix). Logprob capture and the resulting metrics are exercised by existing scorer integration tests under `tests/unit/scorers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)