### PR TITLE
Pass --experiment_name in GPU smoke test scaffolding call

### DIFF
--- a/tests/integration/gpu/smoke_test_scaffolding.py
+++ b/tests/integration/gpu/smoke_test_scaffolding.py
@@ -35,6 +35,8 @@ def test_setup_finetune(work_dir: Path):
             "/fake/input/",
             "--output_dir_base",
             "/fake/output/",
+            "--experiment_name",
+            "smoke_test",
             "--models_dir",
             "/fake/models/",
             "--my_wandb_run_name",


### PR DESCRIPTION
# Description

Fixes the nightly GPU smoke test, which has been failing every morning with:

\`\`\`
ValueError: experiment_name is required
  File \"src/tools/torchtune/setup_finetune.py\", line 302, in construct_output_dir
\`\`\`

## Root cause

Commit \`41d4c85\` (\"Refactor: nest artifacts/ inside per-run directories\") flipped \`experiment_name\` from optional to required in \`construct_output_dir()\` as part of the folder reorg. The smoke test's argument list at \`tests/integration/gpu/smoke_test_scaffolding.py:42\` was written before that change and never updated.

The infra failure for \"Nightly Tests\" (CPU) the same morning is a separate issue — that one was \"job not acquired by Runner of type hosted\", a GitHub-side flake, not a code bug. Not addressed here.

## Fix

Add \`--experiment_name smoke_test\` to the args. The smoke test uses fake paths that aren't written to disk, so the value is purely there to satisfy the validation.

## New Dependencies

None.

# Testing Instructions

1. Locally (no GPU needed for the scaffolding portion):
   \`\`\`
   python tests/integration/gpu/smoke_test_scaffolding.py
   \`\`\`
   Should print:
   \`\`\`
   PASS: setup_finetune.py scaffolding
   PASS: setup_inspect.py scaffolding
   \`\`\`
2. After merge, the next \"GPU Smoke Test\" scheduled run (08:30 UTC) should turn green.

—MxC