### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,32 @@ All notable changes to cruijff_kit will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-07
+
 ### Added
 
-- `setup` skill — interactive first-time walkthrough of `claude.local.md.template`, or validate-mode health check for an existing `claude.local.md` (placeholder scan, required-field check, lightweight env probes). (#365)
-- `create-quiz` skill — turn one or two completed experiments into a self-contained, self-grading HTML quiz that tests a recipient's intuition about the results. (#453)
+#### Skills & Workflows
+- `/setup` skill — interactive first-time walkthrough of `claude.local.md.template`, or health check for an existing config (#458)
+- `create-quiz` skill — turn one or two completed experiments into a self-grading HTML quiz that tests a recipient's intuition (#454, @msalganik)
+- Compute estimates in `design-experiment` based on previous runs (#349, @sarahepedersen)
 
 ### Changed
 
-- `design-experiment` no longer inlines the `claude.local.md` prerequisite check; defers to `/setup` for greenfield walkthrough or validation. (#365)
-- `python-markdown` added as a runtime dependency (used by the quiz renderer for intro / prompt / explanation / write-up markdown).
-- **Breaking:** `model_organism` inspect task replaces the bundled `calibration` flag with two primitives: `logprobs: bool | None` (capability switch) and `top_logprobs: int` (previously hardcoded at 20). Logprobs auto-enable when a configured scorer declares `requires_logprobs = True` (currently only `risk_scorer`). Existing experiment configs using `-T calibration=true` must migrate to placing `risk_scorer` in the YAML `scorer:` list (calibration workflow) or `-T logprobs=true` (raw logprobs only). (#461)
+- **Breaking:** Folder reorganization — flat `src/` layout, `projects/` → `blueprints/`, all artifacts unified under `ck-projects/{project}/{experiment_name}/`. The `experiments/`, `data/`, and `synthetic_twins/` directories are retired; input data is now user-provisioned via `{ck_data_dir}`. `experiment_summary.yaml` schema gains `experiment.project` and drops `type`. (#441)
+- **Breaking:** `model_organism` inspect task replaces `calibration` flag with `logprobs` (capability switch) and `top_logprobs`. Logprobs auto-enable when a configured scorer declares `requires_logprobs`. Existing `-T calibration=true` configs must migrate to placing `risk_scorer` in `scorer:` (for calibration metrics) or `-T logprobs=true` (raw logprobs only). (#463, @msalganik)
+- `design-experiment` defers `claude.local.md` validation to `/setup` (#458)
+- Workflow test specs converted from YAML to plaintext briefs (#445)
+- `python-markdown` added as a runtime dependency (used by `create-quiz` for markdown rendering)
+
+### Fixed
+
+- `extract_loss` regex now captures scientific-notation losses (#456)
+- `--experiment_name` passed in GPU smoke test scaffolding (#469)
+
+### Removed
+
+- Parquet support in fine-tune/eval workflow, subsumed by folder reorg (#441)
+- Duplicative `workflows/` directory in run-experiment skill (#468)
 
 ## [0.2.2] - 2026-04-23
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cruijff_kit"
-version = "0.2.2"
+version = "0.3.0"
 description = "A toolkit for research with social data and LLMs"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

Cuts cruijff_kit v0.3.0 — the vision release.

Three breaking changes drive the minor bump:

1. **Folder reorganization** (#441): flat `src/` layout, `projects/` → `blueprints/`, all artifacts unified under `ck-projects/{project}/{experiment_name}/`. Retires `experiments/`, `data/`, `synthetic_twins/`, and parquet support. `experiment_summary.yaml` schema gains `experiment.project` and drops `type`.
2. **`calibration` flag → `logprobs` capability switch** (#463): existing `-T calibration=true` configs must migrate to placing `risk_scorer` in `scorer:` (calibration metrics) or `-T logprobs=true` (raw logprobs only).
3. **`blueprints/model_organism/` → `blueprints/model_organisms/`** (#462): renamed for symmetry with `src/tools/model_organisms/`. Existing `experiment_summary.yaml` files with `experiment.project: model_organism` must update to `model_organisms`.

Plus additions: `/setup` skill (#458), `create-quiz` skill (#454), compute estimates in `design-experiment` (#349), `weighted_sum`/`weighted_sum_binary` rules + `Rule.prepare` hook + `Rule.supports_ood` flag (#462), and a sweep of legacy "synthetic"/"sanity check" framing across model-organisms docs and the `design-experiment` skill (#462).

See `CHANGELOG.md` for the full entry.

## New Dependencies

- `python-markdown` runtime dep added (used by `create-quiz`).

## Testing Instructions

- [ ] CI passes on this PR
- [ ] CHANGELOG.md entry matches merged PRs since v0.2.2
- [ ] `pyproject.toml` version reads `0.3.0`

After merge: pull `main`, tag `v0.3.0` on the merge commit, push tag, create GitHub Release with the changelog entry as notes.

—MxC