### PR TITLE
Default scaffold-torchtune to _single_device_nightly recipe

### DIFF
--- a/.claude/agents/scaffold-torchtune.md
+++ b/.claude/agents/scaffold-torchtune.md
@@ -269,10 +269,18 @@ system_prompt: {from controls.system_prompt, often empty string ""}
 prompt: {from controls.prompt, e.g., "Capitalize the given word: {input}\n"}
 
 # Custom Recipe (REQUIRED)
-# Select based on model size:
-#   - Llama 1B, 3B, 8B models (1 GPU): lora_finetune_single_device_stable
-#   - Llama 70B models (multi-GPU): lora_finetune_distributed_stable
-custom_recipe: cruijff_kit.tools.torchtune.custom_recipes.lora_finetune_{single_device|distributed}_stable
+# Select based on GPU count:
+#   - Single-GPU runs (1B / 3B / 8B): lora_finetune_single_device_nightly
+#       The `_nightly` recipe supports `run_val_every_n_steps` / `dataset_val`.
+#       The `make install` and `make install-dev` targets force torchtune nightly,
+#       so this is the supported baseline for new experiments.
+#   - Multi-GPU runs (70B): lora_finetune_distributed_stable
+#       No `_distributed_nightly` exists yet (tracked in #474). If
+#       `controls.validation_during_training: true` is set for a multi-GPU run,
+#       you MUST emit a loud warning at scaffold time AND in the run log
+#       (see "Multi-GPU validation warning" below) — validation will be silently
+#       skipped because the distributed recipe has no val loop.
+custom_recipe: cruijff_kit.tools.torchtune.custom_recipes.lora_finetune_single_device_nightly  # or lora_finetune_distributed_stable for multi-GPU
 ```
 
 4. **Write file** to `{experiment_dir}/{run_directory_name}/setup_finetune.yaml`
@@ -385,6 +393,26 @@ For each run directory:
 **If model or dataset paths don't exist:**
 - Warn user but proceed (paths might be correct on compute nodes)
 - Note in log which paths couldn't be verified
+
+### Multi-GPU validation warning
+
+If a run has `gpus > 1` (i.e., uses the `_distributed_stable` recipe) AND
+`controls.validation_during_training: true` is set in `experiment_summary.yaml`,
+the distributed recipe has no validation loop and val will be silently skipped.
+
+You MUST:
+
+1. Emit a clearly visible warning to the user when reporting scaffold results, e.g.:
+   ```
+   ⚠️  WARNING: Run '{run_name}' requested validation_during_training=true but
+   uses the distributed (multi-GPU) recipe, which does not yet support
+   mid-training validation. Validation will be SKIPPED for this run.
+   Tracked in https://github.com/niznik-dev/cruijff_kit/issues/474.
+   ```
+2. Log the same warning to `logs/scaffold-torchtune.log` for that run.
+3. Do NOT silently strip `validation_during_training` from the config — leave the
+   experiment_summary.yaml as-is so the audit trail still shows what was requested.
+4. Continue scaffolding the run (treat as a non-fatal warning, not an error).
 
 ## Logging
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ All notable changes to cruijff_kit will be documented in this file.
 ### Changed
 
 - `scaffold-torchtune` defaults single-GPU runs to `_single_device_nightly` so `validation_during_training` is no longer silently dropped (#471)
+- `setup_finetune.py` now picks a GPU-aware default for `--custom_recipe` (single-GPU → `_single_device_nightly`, multi-GPU → `_distributed_stable`), anchoring the recipe choice in code rather than agent prose (#471)
 
 ### Fixed
 
 - `setup_finetune.py` now errors at scaffold time when the GPU-count auto-switch resolves to a non-existent recipe (e.g. `_distributed_nightly`), instead of failing late at SLURM runtime. Multi-GPU val support tracked in #474. (#471)
+- `setup_finetune.py` now warns when `validation_during_training` is requested for a multi-GPU run, in addition to the agent-side warning (#471)
 
 ## [0.3.0] - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to cruijff_kit will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- `scaffold-torchtune` defaults single-GPU runs to `_single_device_nightly` so `validation_during_training` is no longer silently dropped (#471)
+
+### Fixed
+
+- `setup_finetune.py` now errors at scaffold time when the GPU-count auto-switch resolves to a non-existent recipe (e.g. `_distributed_nightly`), instead of failing late at SLURM runtime. Multi-GPU val support tracked in #474. (#471)
+
 ## [0.3.0] - 2026-05-07
 
 ### Added

--- a/blueprints/capitalization/README.md
+++ b/blueprints/capitalization/README.md
@@ -43,7 +43,7 @@ torchtune_model_name: Llama-3.2-1B-Instruct
 prompt: "Capitalize the given word: {input}\n"
 batch_size: 1
 epochs: 1
-custom_recipe: cruijff_kit.tools.torchtune.custom_recipes.lora_finetune_single_device_stable
+custom_recipe: cruijff_kit.tools.torchtune.custom_recipes.lora_finetune_single_device_nightly
 ```
 
 Use a colon separator (not a newline) between instruction and input for best results. Then run:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -110,9 +110,9 @@ setup_finetune.yaml → setup_finetune.py → finetune.yaml + finetune.slurm
 - `src/tools/torchtune/templates/finetune_template.yaml` - Base template for torchtune configs
 
 - `src/tools/torchtune/custom_recipes/` - Modified torchtune recipes
-  - `lora_finetune_single_device_stable.py` - Single GPU with custom features
-  - `lora_finetune_distributed_stable.py` - Multi-GPU distributed training
-  - `lora_finetune_single_device_nightly.py` - With validation loss tracking
+  - `lora_finetune_single_device_nightly.py` - Default for single-GPU runs; supports `run_val_every_n_steps` / `dataset_val`
+  - `lora_finetune_distributed_stable.py` - Multi-GPU distributed training (no val support yet — see #474)
+  - `lora_finetune_single_device_stable.py` - Older single-GPU recipe without val loop; retained as escape hatch for non-nightly torchtune installs
   - `custom_recipe_utils.py` - Shared utilities for recipes
 
 **Custom features added to torchtune:**
@@ -302,9 +302,9 @@ python setup_finetune.py --custom_recipe cruijff_kit.tools.torchtune.custom_reci
 ```
 
 Available custom recipes:
-- `lora_finetune_single_device_stable.py` - Single GPU with selective epoch saving
-- `lora_finetune_distributed_stable.py` - Multi-GPU distributed training
-- `lora_finetune_single_device_nightly.py` - With validation loss tracking (requires torchtune nightly)
+- `lora_finetune_single_device_nightly.py` - Default for single-GPU; supports validation during training (requires torchtune nightly)
+- `lora_finetune_distributed_stable.py` - Multi-GPU distributed training (no val support yet — see #474)
+- `lora_finetune_single_device_stable.py` - Older single-GPU recipe; retained as escape hatch for non-nightly torchtune installs
 
 ## Key Abstractions
 

--- a/src/tools/torchtune/setup_finetune.py
+++ b/src/tools/torchtune/setup_finetune.py
@@ -976,6 +976,25 @@ def main():
         elif gpus == 1 and "distributed" in custom_recipe:
             custom_recipe = custom_recipe.replace("distributed", "single_device")
 
+        # Verify the (possibly auto-switched) recipe resolves to a real module on disk.
+        # Without this, e.g. a single-device _nightly recipe with gpus>1 silently rewrites to
+        # _distributed_nightly, which doesn't exist (see issue #474), and the SLURM job
+        # fails late at runtime instead of at scaffold time.
+        recipe_module_path = (
+            Path(__file__).parent
+            / "custom_recipes"
+            / f"{custom_recipe.rsplit('.', 1)[-1]}.py"
+        )
+        if not recipe_module_path.exists():
+            raise FileNotFoundError(
+                f"Resolved custom_recipe '{custom_recipe}' does not exist at "
+                f"{recipe_module_path}. This usually means the auto-switch between "
+                f"single_device and distributed produced a recipe variant that hasn't "
+                f"been implemented yet. If you requested validation_during_training=true "
+                f"on a multi-GPU run, that combination is tracked in "
+                f"https://github.com/niznik-dev/cruijff_kit/issues/474."
+            )
+
         if gpus == 1:
             slurm_script = slurm_script.replace(
                 "lora_finetune_single_device", custom_recipe + ".__main__"

--- a/src/tools/torchtune/setup_finetune.py
+++ b/src/tools/torchtune/setup_finetune.py
@@ -933,6 +933,30 @@ def main():
     model_gpus = slurm_config.get("gpus", 1)
     gpus = args.gpus if args.gpus != 1 else model_gpus
 
+    # Default custom_recipe based on GPU count when not explicitly set.
+    # This keeps the GPU-aware recipe choice anchored in code rather than
+    # relying on the scaffold-torchtune agent doc to pick the right one;
+    # the agent can still override by writing custom_recipe explicitly.
+    if args.custom_recipe is None:
+        if gpus == 1:
+            args.custom_recipe = "cruijff_kit.tools.torchtune.custom_recipes.lora_finetune_single_device_nightly"
+        else:
+            args.custom_recipe = "cruijff_kit.tools.torchtune.custom_recipes.lora_finetune_distributed_stable"
+
+    # Warn if validation was requested for a multi-GPU run. The distributed
+    # recipe has no val loop yet (issue #474), so val will be silently skipped
+    # at training time. The scaffold-torchtune agent is supposed to emit this
+    # warning too, but duplicating it here makes the failure loud even when
+    # setup_finetune.py is invoked outside the agent path.
+    if config.get("run_val_every_n_steps", 0) > 0 and gpus > 1:
+        warnings.warn(
+            "validation_during_training was requested for a multi-GPU run, but "
+            "the distributed recipe does not yet support mid-training validation. "
+            "Validation will be SKIPPED. Tracked in "
+            "https://github.com/niznik-dev/cruijff_kit/issues/474.",
+            stacklevel=2,
+        )
+
     # CPUs: use model config value
     cpus = slurm_config.get("cpus", 4)
 

--- a/tests/integration/gpu/smoke_test_torchtune.py
+++ b/tests/integration/gpu/smoke_test_torchtune.py
@@ -92,7 +92,7 @@ def main():
             [
                 "tune",
                 "run",
-                "cruijff_kit.tools.torchtune.custom_recipes.lora_finetune_single_device_stable.__main__",
+                "cruijff_kit.tools.torchtune.custom_recipes.lora_finetune_single_device_nightly.__main__",
                 "--config",
                 "finetune.yaml",
             ],

--- a/tests/unit/test_setup_finetune_main.py
+++ b/tests/unit/test_setup_finetune_main.py
@@ -5,6 +5,7 @@ test_setup_finetune.py doesn't cover (helper functions only).
 """
 
 import sys
+import warnings
 import yaml
 from unittest.mock import patch
 
@@ -263,6 +264,68 @@ class TestCustomRecipeGuard:
             extra_args=["--custom_recipe", self.STABLE_DIST, "--gpus", "4"]
         )
         assert "lora_finetune_distributed_stable" in slurm
+
+
+class TestCustomRecipeDefault:
+    """Tests for the GPU-aware --custom_recipe default added in #471.
+
+    Anchors the default recipe choice in code rather than the scaffold-torchtune
+    agent doc, so omitting --custom_recipe still produces a working recipe path.
+    """
+
+    def test_single_gpu_default_is_nightly(self, run_main):
+        """No --custom_recipe + 1 GPU → single_device_nightly (val-capable)."""
+        _, slurm = run_main()
+        assert "lora_finetune_single_device_nightly" in slurm
+
+    def test_multi_gpu_default_is_distributed_stable(self, run_main):
+        """No --custom_recipe + multi-GPU → distributed_stable (no val yet, see #474)."""
+        _, slurm = run_main(extra_args=["--gpus", "4"])
+        assert "lora_finetune_distributed_stable" in slurm
+
+    def test_explicit_custom_recipe_overrides_default(self, run_main):
+        """An explicit --custom_recipe still wins over the default."""
+        _, slurm = run_main(
+            extra_args=[
+                "--custom_recipe",
+                "cruijff_kit.tools.torchtune.custom_recipes.lora_finetune_single_device_stable",
+            ]
+        )
+        assert "lora_finetune_single_device_stable" in slurm
+        assert "lora_finetune_single_device_nightly" not in slurm
+
+
+class TestMultiGpuValWarning:
+    """Tests for the Python-side warning when val is requested for multi-GPU.
+
+    The scaffold-torchtune agent is supposed to flag this combination, but
+    setup_finetune.py duplicates the warning so it fires regardless of how
+    the script was invoked. Tracked in #474.
+    """
+
+    def _set_val(self, setup_yaml, n_steps):
+        with open(setup_yaml) as f:
+            cfg = yaml.safe_load(f)
+        cfg["run_val_every_n_steps"] = n_steps
+        with open(setup_yaml, "w") as f:
+            yaml.dump(cfg, f)
+
+    def test_warning_emitted_for_val_plus_multi_gpu(self, run_main, setup_yaml):
+        self._set_val(setup_yaml, 50)
+        with pytest.warns(UserWarning, match="474"):
+            run_main(extra_args=["--gpus", "4"])
+
+    def test_no_warning_for_val_plus_single_gpu(self, run_main, setup_yaml):
+        self._set_val(setup_yaml, 50)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # turn any warning into a test failure
+            run_main()
+
+    def test_no_warning_for_no_val_plus_multi_gpu(self, run_main, setup_yaml):
+        self._set_val(setup_yaml, 0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            run_main(extra_args=["--gpus", "4"])
 
 
 class TestMainConfigPrecedence:

--- a/tests/unit/test_setup_finetune_main.py
+++ b/tests/unit/test_setup_finetune_main.py
@@ -224,6 +224,47 @@ class TestMainSlurmGeneration:
         assert "--gres=gpu:4" in slurm
 
 
+class TestCustomRecipeGuard:
+    """Tests for the auto-switch guard added in #471.
+
+    Pre-#471, asking for a single-device recipe with gpus>1 silently rewrote it
+    to the distributed equivalent — including for `_nightly`, where no
+    distributed variant exists. Failures showed up at SLURM runtime instead of
+    scaffold time. The guard now hard-errors when the rewritten recipe doesn't
+    resolve to a real module on disk.
+    """
+
+    NIGHTLY = (
+        "cruijff_kit.tools.torchtune.custom_recipes.lora_finetune_single_device_nightly"
+    )
+    STABLE_SINGLE = (
+        "cruijff_kit.tools.torchtune.custom_recipes.lora_finetune_single_device_stable"
+    )
+    STABLE_DIST = (
+        "cruijff_kit.tools.torchtune.custom_recipes.lora_finetune_distributed_stable"
+    )
+
+    def test_single_device_nightly_with_one_gpu_resolves(self, run_main):
+        _, slurm = run_main(extra_args=["--custom_recipe", self.NIGHTLY])
+        assert "lora_finetune_single_device_nightly" in slurm
+
+    def test_single_device_nightly_with_multi_gpu_raises(self, run_main):
+        with pytest.raises(FileNotFoundError, match="474"):
+            run_main(extra_args=["--custom_recipe", self.NIGHTLY, "--gpus", "4"])
+
+    def test_single_device_stable_with_multi_gpu_auto_switches(self, run_main):
+        _, slurm = run_main(
+            extra_args=["--custom_recipe", self.STABLE_SINGLE, "--gpus", "4"]
+        )
+        assert "lora_finetune_distributed_stable" in slurm
+
+    def test_distributed_stable_with_multi_gpu_resolves(self, run_main):
+        _, slurm = run_main(
+            extra_args=["--custom_recipe", self.STABLE_DIST, "--gpus", "4"]
+        )
+        assert "lora_finetune_distributed_stable" in slurm
+
+
 class TestMainConfigPrecedence:
     """Tests for CLI > config_file > argparse_default precedence."""
 


### PR DESCRIPTION
Closes #471

# Description

Flips the `scaffold-torchtune` agent's default recipe for single-GPU runs from `lora_finetune_single_device_stable` to `lora_finetune_single_device_nightly` so that `validation_during_training: true` actually does what it says.

**Context.** The agent has been pointing every run at `_stable` since 2025-11-06. The `_stable` recipe has no validation loop, so `run_val_every_n_steps` and `dataset_val` were silently ignored at runtime. Meanwhile `make install` and `make install-dev` have force-installed torchtune nightly since 2025-11-17 — so the install path and the scaffold default have been out of sync for ~5.5 months.

**Changes.**
- `.claude/agents/scaffold-torchtune.md` — single-GPU default flipped to `_single_device_nightly`. Added a "Multi-GPU validation warning" subsection: if a multi-GPU run requests validation, the agent must emit a loud scaffold-time warning (the distributed recipe still has no val loop — see #474).
- `src/tools/torchtune/setup_finetune.py` — added a `FileNotFoundError` guard after the GPU-count auto-switch. Previously, requesting `_single_device_nightly` on a multi-GPU run would silently rewrite to `_distributed_nightly` (which doesn't exist) and fail late at SLURM runtime. Now it errors at scaffold time with a message pointing at #474.
- `tests/integration/gpu/smoke_test_torchtune.py` — flipped the hardcoded `tune run` invocation to `_single_device_nightly` so the GPU smoke test exercises the new default.
- `blueprints/capitalization/README.md` — example `setup_finetune.yaml` snippet updated.
- `docs/ARCHITECTURE.md` — recipe-list descriptions reordered so `_nightly` is presented as the default; `_distributed_stable` annotated with the #474 caveat; `_stable` reframed as an escape hatch.
- `CHANGELOG.md` — Unreleased entries.

**Out of scope (filed as #474).** Porting validation support to the distributed recipe so multi-GPU runs (currently any 70B fine-tune) can also use `run_val_every_n_steps`. Estimated ~2.5–4.5 days; needs careful token-weighted all-reduce and real multi-GPU verification. The #474 issue body and follow-up comment list every revert/update touchpoint from this PR so it's easy to clean up when distributed val lands.

## New Dependencies

None.

# Testing Instructions

- [ ] Run `make install` (or `install-dev`) on a fresh env and confirm `torchtune` resolves to a nightly build (`pip show torchtune`).
- [ ] Trigger a single-GPU workflow test (e.g. via `test the workflow` → "LoRA Comparison") and confirm:
  - generated `setup_finetune.yaml` files reference `..._single_device_nightly`
  - generated `finetune.yaml` retains `run_val_every_n_steps` and `dataset_val` (i.e. they're not silently dropped)
  - SLURM job runs to completion and `grep 'Validation loss' slurm-*.out` returns hits at the configured cadence
- [ ] Hand-test the new `setup_finetune.py` guard by pointing `--custom_recipe` at `..._single_device_nightly` and `--gpus 4`. Expected: scaffold-time `FileNotFoundError` referencing #474, not a late SLURM-time crash.
- [ ] Run the GPU smoke test (`tests/integration/gpu/smoke_test_torchtune.py`) and confirm the `_nightly` swap doesn't regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

—MxC