### PR TITLE
Callable run-experiment submitters + detachable monitoring

### DIFF
--- a/.claude/skills/analyze-experiment/SKILL.md
+++ b/.claude/skills/analyze-experiment/SKILL.md
@@ -114,16 +114,13 @@ report = generate_report(
 
 ### 6b. Compute Utilization Report → `generation.md`
 
-If run logs exist (`logs/run-torchtune.log` and/or `logs/run-inspect.log`), generate a compute utilization section:
+Generate a compute utilization section. Always call `harvest_jids_from_run_logs(experiment_dir)` from `src/tools/slurm/compute_metrics.py` first — it returns `(jids_dict, warnings)`:
 
-1. Extract job IDs from logs (regex: `Result: Job ID (\d+)`)
-2. Run `seff` for each job and parse with `src/tools/slurm/compute_metrics.py`
-3. Read `gpu_metrics.csv` files and summarize with `summarize_gpu_metrics()`
-4. Generate compute table with `format_compute_table()`
-5. Save raw metrics to `analysis/compute_metrics.json` using `compute_summary.py` (see `generation.md`)
-6. Pass formatted table as `compute_section` to `generate_report()`
+1. Call `harvest_jids_from_run_logs(experiment_dir)`. It already prints `WARNING:` lines to stderr for any missing or malformed log files.
+2. **If `warnings` is non-empty**: append a visible "**Compute Utilization unavailable:** ..." note to the rendered report listing each warning, instead of silently skipping. Do NOT omit the section header. (Closes the silent-skip gap from issue #451.)
+3. **If JIDs are present**: for each, run `seff` and parse with helpers in `src/tools/slurm/compute_metrics.py`; read `gpu_metrics.csv` per run and summarize with `summarize_gpu_metrics()`; format with `format_compute_table()`; save raw metrics to `analysis/compute_metrics.json`; pass the formatted table as `compute_section` to `generate_report()`.
 
-**Skip silently** if no run logs exist (e.g., analyzing results without having run the experiment locally).
+**Loud-warn, do not silently skip.** When the logs are genuinely absent (e.g., analyzing a colleague's experiment without local logs), the warning text in `report.md` tells the operator how to recover (typically: re-run `run-experiment`, or re-create the canonical log via `src/tools/run/submit_*.py`).
 
 ### 7. Logging → `logging.md`
 

--- a/.claude/skills/analyze-experiment/generation.md
+++ b/.claude/skills/analyze-experiment/generation.md
@@ -379,14 +379,11 @@ Uses Wilson score intervals (preferred over normal approximation):
 
 ## Compute Utilization Analysis
 
-After generating visualizations and before the report, optionally add compute metrics. This requires run logs from `run-experiment`.
+After generating visualizations and before the report, add compute metrics. This requires run logs from `run-experiment` (or from `src/tools/run/submit_*.py` directly).
 
 **Workflow:**
 
-1. Extract job IDs from `run-torchtune.log` and `run-inspect.log`. The log format places `Job ID:` on its own line after the SUBMIT action (see `run-experiment/logging.md`). Use these regexes:
-   - Fine-tuning: `r'SUBMIT_JOB: ([\w.-]+)\n.*?\nJob ID: (\d+)'` → captures (run_name, job_id)
-   - Evaluation: `r'SUBMIT_EVAL: ([\w./-]+)\n.*?\nJob ID: (\d+)'` → captures (run/task/epoch, job_id)
-   - Both require `re.DOTALL` or explicit `\n` matching since the job ID is on a separate line from the action type.
+1. Call `harvest_jids_from_run_logs(experiment_dir)` from `src/tools/slurm/compute_metrics.py`. It returns `(jids_dict, warnings)` where `jids_dict` is `{"finetune": [(name, jid), ...], "eval": [(name, jid), ...]}`. The helper already prints `WARNING:` lines to stderr for any missing or malformed log file, mirroring the canonical regexes in `run-experiment/logging.md`. **If `warnings` is non-empty, do not silently skip the section** — append a "**Compute Utilization unavailable:** ..." note to `report.md` listing each warning so the absence is visible to the operator.
 2. Check if jobstats is available with `check_jobstats_available()`
 3. For each job:
    a. Run `seff {job_id}` and parse with `parse_seff_output()`. If `time_limit` is None (some clusters omit it), run `sacct -j {job_id} --format=Timelimit -P -n` and parse with `parse_sacct_time_limit()`.
@@ -425,7 +422,7 @@ After generating visualizations and before the report, optionally add compute me
 
 **Data sources:** nvidia-smi CSV for GPU memory/power and utilization range (min/max), jobstats for CPU metrics and GPU utilization average (Prometheus-sampled, more reliable than nvidia-smi's 30s polling), seff for job metadata + CPU fallback.
 
-**Error handling:** Missing seff → skip seff columns; missing gpu_metrics.csv → show `-` for GPU columns; jobstats unavailable or fails → fall back to seff for CPU data; missing run logs → skip compute analysis entirely; partial data → generate table with whatever is available.
+**Error handling:** Missing seff → skip seff columns; missing gpu_metrics.csv → show `-` for GPU columns; jobstats unavailable or fails → fall back to seff for CPU data; missing or malformed run logs → emit a loud `WARNING:` to stderr (handled inside `harvest_jids_from_run_logs()`) and surface a "*Compute Utilization unavailable: ...*" note in `report.md` (do not silently skip — see issue #451); partial data → generate table with whatever is available.
 
 ## Logging
 

--- a/.claude/skills/run-experiment/SKILL.md
+++ b/.claude/skills/run-experiment/SKILL.md
@@ -34,13 +34,15 @@ This ensures the entire experiment runs from training through evaluation with pr
 
 ### Tool Modules
 
-**Optimizer modules:** See [optimizers/](optimizers/) for tool-specific execution logic
-- Currently supported: torchtune (fine-tuning)
-- Future: DSPy (prompt optimization), custom trainers
+This skill invokes callable Python submitters that handle SLURM submission, drip-feed under the gpu-test QoS cap, monitoring to terminal state, and canonical log emission as a side-effect. The Python is the source of truth; the prose modules under `optimizers/` and `evaluators/` describe the schemas and flow for downstream readers.
 
-**Evaluator modules:** See [evaluators/](evaluators/) for tool-specific execution logic
-- Currently supported: inspect-ai
-- Future: custom evaluation frameworks
+**Optimizer modules:** See [optimizers/](optimizers/) for the schema description.
+- torchtune (fine-tuning) → `python -m cruijff_kit.tools.run.submit_torchtune <experiment_dir>` (writes `logs/run-torchtune.log` + `logs/run-torchtune.state.json`)
+
+**Evaluator modules:** See [evaluators/](evaluators/) for the schema description.
+- inspect-ai → `python -m cruijff_kit.tools.run.submit_inspect <experiment_dir>` (writes `logs/run-inspect.log` + `logs/run-inspect.state.json`)
+
+Both submitters are resume-safe: re-invoking after an interruption reads the JSON state file and skips already-submitted entries. Both emit canonical `SUBMIT_JOB:` / `SUBMIT_EVAL:` lines that `analyze-experiment`'s compute-utilization step harvests. Future tools (DSPy, custom trainers, custom evaluators) plug in here as additional submitters.
 
 ## Reading Tool Specifications
 
@@ -66,11 +68,9 @@ tools:
 **Why?** Evaluation jobs need optimized model checkpoints.
 
 **Implementation:**
-1. Execute optimizer module (torchtune fine-tuning)
-2. Monitor until ALL optimization jobs complete
-3. Only then execute evaluator module (inspect evaluation)
-4. Monitor until ALL evaluation jobs complete
-5. Report combined results
+1. Run `python -m cruijff_kit.tools.run.submit_torchtune <experiment_dir>` — submits, drip-feeds, monitors, writes `logs/run-torchtune.log` + `logs/run-torchtune.state.json`. Blocks until all jobs reach terminal state.
+2. Only after step 1 returns successfully, run `python -m cruijff_kit.tools.run.submit_inspect <experiment_dir>` — same pattern for evaluations, writes `logs/run-inspect.log` + `logs/run-inspect.state.json`. Blocks until terminal.
+3. Append a high-level summary to `logs/run-experiment.log` (the orchestration log). The detailed per-job records already live in the per-tool logs.
 
 ## Logging
 
@@ -217,11 +217,11 @@ After completing the experiment, offer to analyze the results:
 ## Important Notes
 
 **Orchestration principles:**
-- This skill orchestrates by loading tool modules into the main conversation context (no subagent delegation, unlike scaffold-experiment)
-- Each tool module maintains its own detailed log
-- Sequential execution is mandatory (evaluation requires optimization complete)
-- Partial success is acceptable (some runs succeed, others fail)
-- Tool modules can be executed independently if needed
+- This skill invokes callable Python submitters (`src/tools/run/submit_*.py`) that handle the operational work and emit canonical execution logs as a side-effect. No prose-by-prose recipe; the script is the contract.
+- Each submitter maintains its own detailed log (`logs/run-torchtune.log`, `logs/run-inspect.log`) AND a JSON resume state file alongside it.
+- Sequential execution is mandatory (evaluation requires optimization complete).
+- Partial success is acceptable (some runs succeed, others fail) — the state files capture which ones.
+- Each submitter can be invoked directly (CLI or `from cruijff_kit.tools.run import submit_torchtune; submit_torchtune.run(experiment_dir)`).
 
 **Relationship to other skills:**
 - **Before:** design-experiment, scaffold-experiment

--- a/.claude/skills/run-experiment/SKILL.md
+++ b/.claude/skills/run-experiment/SKILL.md
@@ -72,6 +72,29 @@ tools:
 2. Only after step 1 returns successfully, run `python -m cruijff_kit.tools.run.submit_inspect <experiment_dir>` — same pattern for evaluations, writes `logs/run-inspect.log` + `logs/run-inspect.state.json`. Blocks until terminal.
 3. Append a high-level summary to `logs/run-experiment.log` (the orchestration log). The detailed per-job records already live in the per-tool logs.
 
+## Long-Running / Detachable Monitoring
+
+The default flow above blocks until all jobs finish. For experiments that may run for hours, the submitters support **detach** so a watcher can stop without killing the jobs. Three trigger paths converge on a clean exit (flush state → emit canonical `MONITOR_DETACHED` block → return; jobs keep running):
+
+| Mechanism | Who uses it |
+|---|---|
+| `touch <experiment_dir>/logs/.detach` | Anyone — humans, agents, `/loop`, cron. Sentinel is sticky: remove it before re-attaching. |
+| `SIGINT` (Ctrl+C) | A human at the terminal where the submitter is running |
+| `SIGTERM` | A parent process killing the submitter subprocess |
+
+After a clean detach, **re-attaching** is one of:
+
+```
+# One-shot snapshot (read-only; refreshes state from squeue/sacct):
+python -m cruijff_kit.tools.run.status <experiment_dir>
+
+# Continuous re-monitor without resubmitting:
+python -m cruijff_kit.tools.run.submit_torchtune <experiment_dir> --resume-monitor
+python -m cruijff_kit.tools.run.submit_inspect   <experiment_dir> --resume-monitor
+```
+
+`status` is composable with `/loop` (e.g. periodic check-ins from an agent or cron job). It never submits anything and never writes `MONITOR_DETACHED`; it refreshes state, appends `STATE_CHANGE` blocks when SLURM has moved a job since the last refresh, and emits a per-tool `ALL_COMPLETE` block the first time refresh observes all-terminal — so a finished experiment closes its log cleanly without needing a follow-up `--resume-monitor`. `ALL_COMPLETE` is idempotent: at most one block per per-tool log, no matter how many `status` or submitter calls observe completion.
+
 ## Logging
 
 Execution is logged in three files (see logging.md for details).
@@ -136,9 +159,13 @@ After successful execution:
 - Optimization results still valid
 - Report partial success
 
-**If user cancels:**
+**If user cancels (Ctrl+C / SIGTERM / `touch logs/.detach`):**
+- Watcher exits cleanly, writes `MONITOR_DETACHED` to the per-tool log
 - SLURM jobs continue running independently
-- Can resume monitoring by re-running skill
+- To resume monitoring without resubmitting:
+  - `python -m cruijff_kit.tools.run.status <experiment_dir>` for a one-shot snapshot
+  - `python -m cruijff_kit.tools.run.submit_{torchtune,inspect} <experiment_dir> --resume-monitor` to watch until terminal
+- If detach was triggered by the sentinel file, `rm <experiment_dir>/logs/.detach` first (sticky)
 
 ## Validation Checklist
 

--- a/.claude/skills/run-experiment/evaluators/inspect/main.md
+++ b/.claude/skills/run-experiment/evaluators/inspect/main.md
@@ -1,29 +1,42 @@
 # Inspect Evaluator Execution Module
 
-Executes inspect-ai evaluation jobs for all runs in an experiment.
+Executes inspect-ai evaluation jobs for all runs in an experiment by invoking the canonical submitter:
 
-**CRITICAL:** Must run AFTER fine-tuning completes - evaluations require model checkpoints.
+```
+python -m cruijff_kit.tools.run.submit_inspect <experiment_dir>
+```
+
+**CRITICAL:** Must run AFTER fine-tuning completes — evaluations require model checkpoints.
+
+The submitter (`src/tools/run/submit_inspect.py`) handles every operational step in code:
+
+1. Globs `*/eval/*.slurm` under the experiment directory.
+2. Drip-feeds `sbatch`, capping concurrency at `MAX_SUBMIT` (default 25, override via env). The 5-second stagger applies on the eval side too — the HF datasets cache race hits whenever multiple jobs hit `datasets.load_dataset` at once, not just on fine-tunes.
+3. Polls SLURM (`squeue` first, `sacct` fallback) every 60 seconds until every job reaches a terminal state.
+4. Emits canonical 4-line `SUBMIT_EVAL:` / `Job ID:` / `Result:` blocks to `logs/run-inspect.log`. The eval-job identifier is `{run_name}/{task}/epoch{N}` (or `{run_name}/{task}` when no epoch suffix exists), matching the regex in `analyze-experiment`'s compute step.
+5. Persists `logs/run-inspect.state.json` keyed by `{run_name}/eval/{slurm_filename}` so distinct runs with the same eval slurm filename don't collide on a single state-file key (the bug from issue #451 comment #2).
 
 ## Prerequisites
 
-- experiment_summary.yaml exists
-- Evaluation scaffolding complete (eval/*.slurm files exist)
-- Fine-tuning complete (model checkpoints exist)
-- SLURM cluster access
+- `experiment_summary.yaml` exists.
+- Evaluation scaffolding complete (`*/eval/*.slurm` files exist).
+- Fine-tuning complete (model checkpoints exist).
+- SLURM cluster access.
 
-## Workflow
+## Outputs
 
-1. **[parsing.md](parsing.md)** - Parse experiment to identify evaluations
-2. **[dependency_checking.md](dependency_checking.md)** - Verify fine-tuning complete, checkpoints exist
-3. **[cache_prebuilding.md](cache_prebuilding.md)** - Pre-build HF datasets cache to prevent race conditions
-4. **[evaluation_selection.md](evaluation_selection.md)** - Select which evaluations need submission
-5. **[job_submission.md](job_submission.md)** - Submit SLURM jobs, capture IDs
-6. **[monitoring.md](monitoring.md)** - Poll squeue, track status, wait for completion
-7. **[validation.md](validation.md)** - Verify all jobs completed, evaluation logs exist
+- `logs/run-inspect.log` — canonical submission + state-change records.
+- `logs/run-inspect.state.json` — resume state file.
+- Evaluation logs in `{run_dir}/eval/logs/*.eval`.
 
-Every step is required. Execute steps in order — each step depends on the output of the previous one.
+## Schemas
 
-## Output
+The remaining files in this directory describe individual concerns for downstream readers. The submitter is the single source of truth for runtime behavior:
 
-- Creates logs/run-inspect.log with detailed execution history
-- Evaluation logs in `{run_dir}/eval/logs/*.eval`
+- [parsing.md](parsing.md) — how evaluations are identified.
+- [dependency_checking.md](dependency_checking.md) — checkpoint existence preconditions.
+- [cache_prebuilding.md](cache_prebuilding.md) — pre-building HF datasets cache.
+- [evaluation_selection.md](evaluation_selection.md) — which evals need submission.
+- [job_submission.md](job_submission.md) — canonical 4-line log block shape.
+- [monitoring.md](monitoring.md) — terminal-state polling.
+- [validation.md](validation.md) — eval log verification after completion.

--- a/.claude/skills/run-experiment/evaluators/inspect/main.md
+++ b/.claude/skills/run-experiment/evaluators/inspect/main.md
@@ -16,6 +16,16 @@ The submitter (`src/tools/run/submit_inspect.py`) handles every operational step
 4. Emits canonical 4-line `SUBMIT_EVAL:` / `Job ID:` / `Result:` blocks to `logs/run-inspect.log`. The eval-job identifier is `{run_name}/{task}/epoch{N}` (or `{run_name}/{task}` when no epoch suffix exists), matching the regex in `analyze-experiment`'s compute step.
 5. Persists `logs/run-inspect.state.json` keyed by `{run_name}/eval/{slurm_filename}` so distinct runs with the same eval slurm filename don't collide on a single state-file key (the bug from issue #451 comment #2).
 
+## Detach and resume
+
+The submitter exits cleanly on `SIGINT`, `SIGTERM`, or when `<experiment_dir>/logs/.detach` is present. State is flushed and a `MONITOR_DETACHED` block is appended to the log; SLURM jobs are untouched. To re-attach the monitor without resubmitting:
+
+```
+python -m cruijff_kit.tools.run.submit_inspect <experiment_dir> --resume-monitor
+```
+
+Or for a one-shot read across both submitters: `python -m cruijff_kit.tools.run.status <experiment_dir>`.
+
 ## Prerequisites
 
 - `experiment_summary.yaml` exists.

--- a/.claude/skills/run-experiment/logging.md
+++ b/.claude/skills/run-experiment/logging.md
@@ -32,6 +32,7 @@ Detailed sub-logs are created during job execution. The orchestration log record
 | `COMPUTE_METRICS` | Record seff compute metrics when job reaches terminal state |
 | `RESOURCE_STATUS` | Report GPU utilization from gpu_metrics.csv during monitoring |
 | `ALL_COMPLETE` | Mark all fine-tuning jobs finished |
+| `MONITOR_DETACHED` | Watcher exited via SIGINT / SIGTERM / sentinel; jobs continue running |
 
 ### Inspect-ai Actions
 
@@ -52,6 +53,7 @@ Detailed sub-logs are created during job execution. The orchestration log record
 | `COMPUTE_METRICS` | Record seff compute metrics when eval job reaches terminal state |
 | `RESOURCE_STATUS` | Report GPU utilization from gpu_metrics.csv during monitoring |
 | `ALL_COMPLETE` | Mark all evaluations finished |
+| `MONITOR_DETACHED` | Watcher exited via SIGINT / SIGTERM / sentinel; jobs continue running |
 
 ---
 

--- a/.claude/skills/run-experiment/optimizers/torchtune/main.md
+++ b/.claude/skills/run-experiment/optimizers/torchtune/main.md
@@ -15,6 +15,16 @@ The submitter (`src/tools/run/submit_torchtune.py`) handles every operational st
 5. Emits the canonical 4-line `SUBMIT_JOB:` / `Job ID:` / `Result:` blocks to `logs/run-torchtune.log` (consumed by `analyze-experiment`'s compute step via `harvest_jids_from_run_logs()` in `tools/slurm/compute_metrics.py`).
 6. Persists `logs/run-torchtune.state.json` for resume after interruption — keyed by `{relative_path}/finetune.slurm` so eval jobs in different runs don't collide.
 
+## Detach and resume
+
+The submitter exits cleanly on `SIGINT`, `SIGTERM`, or when `<experiment_dir>/logs/.detach` is present. State is flushed and a `MONITOR_DETACHED` block is appended to the log; SLURM jobs are untouched. To re-attach the monitor without resubmitting:
+
+```
+python -m cruijff_kit.tools.run.submit_torchtune <experiment_dir> --resume-monitor
+```
+
+Or for a one-shot read across both submitters: `python -m cruijff_kit.tools.run.status <experiment_dir>`.
+
 ## Prerequisites
 
 - `experiment_summary.yaml` exists.

--- a/.claude/skills/run-experiment/optimizers/torchtune/main.md
+++ b/.claude/skills/run-experiment/optimizers/torchtune/main.md
@@ -1,24 +1,38 @@
 # Torchtune Optimizer Execution Module
 
-Executes torchtune fine-tuning jobs for all runs in an experiment.
+Executes torchtune fine-tuning jobs for all fine-tuned runs in an experiment by invoking the canonical submitter:
+
+```
+python -m cruijff_kit.tools.run.submit_torchtune <experiment_dir>
+```
+
+The submitter (`src/tools/run/submit_torchtune.py`) handles every operational step in code:
+
+1. Parses `experiment_summary.yaml` and discovers fine-tuned runs (skips controls).
+2. Drip-feeds `sbatch` for each run's `finetune.slurm`, capping concurrency at the `MAX_SUBMIT` env var (default 25, the gpu-test QoS limit).
+3. Staggers 5 seconds between submissions to dodge the HF datasets cache race.
+4. Polls SLURM (`squeue` first, `sacct` fallback) every 60 seconds until every job reaches a terminal state.
+5. Emits the canonical 4-line `SUBMIT_JOB:` / `Job ID:` / `Result:` blocks to `logs/run-torchtune.log` (consumed by `analyze-experiment`'s compute step via `harvest_jids_from_run_logs()` in `tools/slurm/compute_metrics.py`).
+6. Persists `logs/run-torchtune.state.json` for resume after interruption — keyed by `{relative_path}/finetune.slurm` so eval jobs in different runs don't collide.
 
 ## Prerequisites
 
-- experiment_summary.yaml exists
-- Fine-tuning scaffolding complete (finetune.slurm files exist)
-- SLURM cluster access
+- `experiment_summary.yaml` exists.
+- Fine-tuning scaffolding complete (`finetune.slurm` files exist).
+- SLURM cluster access.
 
-## Workflow
+## Outputs
 
-1. **[parsing.md](parsing.md)** - Parse experiment to identify runs
-2. **[run_selection.md](run_selection.md)** - Select which runs need submission
-3. **[job_submission.md](job_submission.md)** - Submit jobs with 5-second stagger (prevents cache collision)
-4. **[monitoring.md](monitoring.md)** - Monitor with 60-second polling until all complete
-5. **[validation.md](validation.md)** - Validate checkpoints created successfully
+- `logs/run-torchtune.log` — canonical submission + state-change records.
+- `logs/run-torchtune.state.json` — resume state file.
+- Model checkpoints under `{output_dir_base}/{run_name}/artifacts/epoch_{N}/`.
 
-Every step is required. Execute steps in order — each step depends on the output of the previous one.
+## Schemas
 
-## Output
+The remaining files in this directory describe individual concerns for downstream readers. The submitter is the single source of truth for runtime behavior:
 
-- Creates logs/run-torchtune.log with detailed execution history
-- Model checkpoints in `{output_dir_base}/{run_name}/artifacts/epoch_{N}/`
+- [parsing.md](parsing.md) — how runs are identified from `experiment_summary.yaml`.
+- [run_selection.md](run_selection.md) — fine-tuned vs control filtering.
+- [job_submission.md](job_submission.md) — canonical 4-line log block shape (must match `harvest_jids_from_run_logs` regex).
+- [monitoring.md](monitoring.md) — terminal-state polling.
+- [validation.md](validation.md) — checkpoint verification after completion.

--- a/.claude/workflow_tests/workflow_test.md
+++ b/.claude/workflow_tests/workflow_test.md
@@ -50,6 +50,9 @@ Each of `Llama-3.2-1B-Instruct_rank4/` and `Llama-3.2-1B-Instruct_rank8/` should
 - `finetune.yaml` parameters match the run name
 - Training jobs complete successfully and produce `epoch_0/` checkpoint dirs
 - Evaluation jobs complete successfully and produce result logs
+- `logs/run-torchtune.log` exists and contains canonical `SUBMIT_JOB:` blocks (regex: `r'SUBMIT_JOB: ([\w.-]+)\n.*?\nJob ID: (\d+)'`)
+- `logs/run-inspect.log` exists and contains canonical `SUBMIT_EVAL:` blocks
+- After running `analyze-experiment`, `analysis/report.md` contains a `## Compute Utilization` header **and** `analysis/compute_metrics.json` exists with at least one entry per submitted job (closes #451 silent-skip gap)
 
 ## Estimated wall time
 

--- a/.claude/workflow_tests/workflow_test_base.md
+++ b/.claude/workflow_tests/workflow_test_base.md
@@ -57,6 +57,9 @@ Does fine-tuning improve capitalization accuracy over the base model? Again, the
 - Fine-tuning job completes successfully and produces `epoch_0/` checkpoint
 - Evaluation jobs complete successfully for **both** runs and produce result logs
 - The base run's evaluation `checkpoint_path` points to the HuggingFace model (not a local checkpoint)
+- `logs/run-torchtune.log` exists and contains at least one canonical `SUBMIT_JOB:` block followed by `Job ID:` (regex: `r'SUBMIT_JOB: ([\w.-]+)\n.*?\nJob ID: (\d+)'`)
+- `logs/run-inspect.log` exists and contains canonical `SUBMIT_EVAL:` blocks
+- After running `analyze-experiment`, `analysis/report.md` contains a `## Compute Utilization` header **and** `analysis/compute_metrics.json` exists with at least one entry per submitted job (closes #451 silent-skip gap)
 
 ## Estimated wall time
 

--- a/.claude/workflow_tests/workflow_test_recipe.md
+++ b/.claude/workflow_tests/workflow_test_recipe.md
@@ -76,6 +76,8 @@ Standard:
 - All run directories created
 - Training jobs complete successfully and produce `epoch_0/` checkpoint dirs
 - Evaluation jobs complete successfully and produce result logs
+- `logs/run-torchtune.log` and `logs/run-inspect.log` exist with canonical `SUBMIT_JOB:` / `SUBMIT_EVAL:` blocks
+- After running `analyze-experiment`, `analysis/report.md` contains a `## Compute Utilization` header and `analysis/compute_metrics.json` exists (closes #451)
 
 Recipe-specific:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,23 @@ All notable changes to cruijff_kit will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `src/tools/run/submit_torchtune.py` and `submit_inspect.py` — callable submitters for `run-experiment`. Drip-feed against the gpu-test QoS cap (default `MAX_SUBMIT=25`), 5-second stagger, resume-safe JSON state file, canonical `SUBMIT_JOB:` / `SUBMIT_EVAL:` log emission. Replaces the prose-only execution path the skill used to rely on. (#451)
+- `harvest_jids_from_run_logs()` in `src/tools/slurm/compute_metrics.py` — single helper that `analyze-experiment` calls to extract job IDs from `run-torchtune.log` / `run-inspect.log` and surface loud warnings when those logs are missing or malformed. (#451)
+
 ### Changed
 
 - `scaffold-torchtune` defaults single-GPU runs to `_single_device_nightly` so `validation_during_training` is no longer silently dropped (#471)
 - `setup_finetune.py` now picks a GPU-aware default for `--custom_recipe` (single-GPU → `_single_device_nightly`, multi-GPU → `_distributed_stable`), anchoring the recipe choice in code rather than agent prose (#471)
+- `run-experiment` skill now invokes the callable submitters instead of executing prose-by-prose recipes; the skill docs collapse to schema descriptions (#451)
+- `analyze-experiment` no longer silently skips the Compute Utilization section when run logs are missing; a `WARNING:` is printed to stderr and the absence is surfaced as a visible note in `report.md` (#451)
 
 ### Fixed
 
 - `setup_finetune.py` now errors at scaffold time when the GPU-count auto-switch resolves to a non-existent recipe (e.g. `_distributed_nightly`), instead of failing late at SLURM runtime. Multi-GPU val support tracked in #474. (#471)
 - `setup_finetune.py` now warns when `validation_during_training` is requested for a multi-GPU run, in addition to the agent-side warning (#471)
+- Eval-side submitter no longer collapses distinct runs onto a single state-file key when each run has the same eval slurm filename (the bug that bit the `lostmiddle_kxp_3B` experiment, issue #451 comment #2). State key now includes the relative path. (#451)
 
 ## [0.3.0] - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to cruijff_kit will be documented in this file.
 
 - `src/tools/run/submit_torchtune.py` and `submit_inspect.py` — callable submitters for `run-experiment`. Drip-feed against the gpu-test QoS cap (default `MAX_SUBMIT=25`), 5-second stagger, resume-safe JSON state file, canonical `SUBMIT_JOB:` / `SUBMIT_EVAL:` log emission. Replaces the prose-only execution path the skill used to rely on. (#451)
 - `harvest_jids_from_run_logs()` in `src/tools/slurm/compute_metrics.py` — single helper that `analyze-experiment` calls to extract job IDs from `run-torchtune.log` / `run-inspect.log` and surface loud warnings when those logs are missing or malformed. (#451)
+- Detach mechanisms for `run-experiment` submitters — SIGINT, SIGTERM, and a sticky `<exp_dir>/logs/.detach` sentinel file. Any path flushes state, emits a canonical `MONITOR_DETACHED` log block, prints a re-attach hint to stderr, and exits cleanly; SLURM jobs continue running. (#479)
+- `--resume-monitor` flag on `submit_torchtune` and `submit_inspect` — skips the submit phase and re-attaches a watcher to the existing state file. Idempotent; safe to invoke repeatedly. (#479)
+- `src/tools/run/status.py` — consolidated read-only snapshot command. Reads both state files, refreshes in-flight entries from `squeue`/`sacct`, prints a table (or `--json`). Emits a per-tool `ALL_COMPLETE` block when refresh first observes all-terminal so the pipeline log closes cleanly without a follow-up `--resume-monitor`. Composes with `/loop`, cron, or interactive use. (#479)
+- `log_all_complete()` is now idempotent — at most one `ALL_COMPLETE` block per per-tool log regardless of how many submitters or `status` calls emit it. (#479)
 
 ### Changed
 

--- a/docs/ARTIFACT_LOCATIONS.md
+++ b/docs/ARTIFACT_LOCATIONS.md
@@ -19,7 +19,10 @@ Each experiment lives in a single self-contained directory. The root contains th
 │   ├── scaffold-inspect.log
 │   ├── run-experiment.log
 │   ├── run-torchtune.log
+│   ├── run-torchtune.state.json # Submitter resume state (JSON)
 │   ├── run-inspect.log
+│   ├── run-inspect.state.json   # Submitter resume state (JSON)
+│   ├── .detach                  # Optional sentinel — touch to detach the watcher
 │   ├── summarize-experiment.log
 │   └── analyze-experiment.log
 ├── {run_name}/                  # Self-contained per-run directory (one per run)

--- a/src/tools/run/_submit_common.py
+++ b/src/tools/run/_submit_common.py
@@ -1,0 +1,420 @@
+"""Shared helpers for the run-experiment submitters.
+
+`submit_torchtune` and `submit_inspect` both:
+- discover slurm scripts under an experiment directory,
+- drip-feed sbatch them under the SLURM gpu-test QoS cap (default 25),
+- emit the canonical 4-line log block that analyze-experiment's regex consumes,
+- persist resume state as JSON keyed by relative path,
+- monitor the submitted jobs to terminal state.
+
+The shared logic lives here. The two submitters are thin wrappers that
+build the right todo list and hand it to `submit_and_monitor()`.
+
+Canonical log block shape (from .claude/skills/run-experiment/logging.md):
+
+    [YYYY-MM-DD HH:MM:SS] SUBMIT_JOB: <name>
+    Details: sbatch <slurm_name>
+    Job ID: <jid>
+    Result: success
+
+The regex in .claude/skills/analyze-experiment/generation.md is
+`SUBMIT_JOB: ([\\w.-]+)\\n.*?\\nJob ID: (\\d+)` (and SUBMIT_EVAL for evals).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+DEFAULT_MAX_SUBMIT = 25  # Della gpu-test QoS cap on MaxSubmitJobsPerUser
+DEFAULT_STAGGER_SEC = 5  # avoids HF datasets cache race when jobs land at once
+DEFAULT_POLL_SEC = 60
+
+TERMINAL_STATES = {
+    "COMPLETED",
+    "FAILED",
+    "CANCELLED",
+    "TIMEOUT",
+    "OUT_OF_MEMORY",
+    "NODE_FAIL",
+    "PREEMPTED",
+    "BOOT_FAIL",
+    "DEADLINE",
+}
+
+
+def _now() -> str:
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+# ---------------------------------------------------------------------------
+# State-file helpers
+# ---------------------------------------------------------------------------
+
+
+def state_key(work_dir: Path, slurm_name: str, experiment_dir: Path) -> str:
+    """Stable per-job key for the resume state file.
+
+    Using `work_dir.name` collapses all eval entries onto a single key
+    because every run's eval workdir is `<run_dir>/eval` (issue #451 comment).
+    Including the relative path keeps each entry unique.
+    """
+    rel = work_dir.relative_to(experiment_dir)
+    return f"{rel}/{slurm_name}"
+
+
+def read_state(state_path: Path) -> dict:
+    if not state_path.exists():
+        return {}
+    try:
+        return json.loads(state_path.read_text())
+    except json.JSONDecodeError:
+        # Corrupt mid-write — treat as empty so resume re-checks SLURM truth.
+        return {}
+
+
+def write_state_atomic(state_path: Path, state: dict) -> None:
+    """Write JSON atomically — write to .tmp, then rename.
+
+    Prevents a half-written file from breaking resume after an interruption.
+    """
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = state_path.with_suffix(state_path.suffix + ".tmp")
+    tmp.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n")
+    os.replace(tmp, state_path)
+
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+
+def append_log(log_path: Path, block: str) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a") as f:
+        f.write(block.rstrip("\n") + "\n\n")
+
+
+def log_submit(
+    log_path: Path,
+    action_type: str,
+    name: str,
+    slurm_name: str,
+    job_id: str | int,
+) -> None:
+    """Emit the canonical 4-line submission block.
+
+    `action_type` is "SUBMIT_JOB" (torchtune) or "SUBMIT_EVAL" (inspect).
+    `name` is whatever identifies the submission to a future log reader —
+    a run name for finetunes, a `run/task/epoch` triple for evals.
+    """
+    block = (
+        f"[{_now()}] {action_type}: {name}\n"
+        f"Details: sbatch {slurm_name}\n"
+        f"Job ID: {job_id}\n"
+        f"Result: success"
+    )
+    append_log(log_path, block)
+
+
+def log_submit_failure(
+    log_path: Path,
+    action_type: str,
+    name: str,
+    slurm_name: str,
+    error: str,
+) -> None:
+    block = (
+        f"[{_now()}] {action_type}: {name}\n"
+        f"Details: sbatch {slurm_name}\n"
+        f"Result: failure: {error}"
+    )
+    append_log(log_path, block)
+
+
+def log_state_change(
+    log_path: Path,
+    name: str,
+    job_id: str | int,
+    old_state: str,
+    new_state: str,
+) -> None:
+    block = (
+        f"[{_now()}] STATE_CHANGE: {name}\n"
+        f"Details: job {job_id}: {old_state} -> {new_state}\n"
+        f"Result: tracked"
+    )
+    append_log(log_path, block)
+
+
+def log_all_complete(log_path: Path, summary: dict) -> None:
+    parts = ", ".join(f"{k}={v}" for k, v in sorted(summary.items()))
+    block = (
+        f"[{_now()}] ALL_COMPLETE\n"
+        f"Details: terminal-state breakdown: {parts}\n"
+        f"Result: done"
+    )
+    append_log(log_path, block)
+
+
+# ---------------------------------------------------------------------------
+# SLURM interaction (mockable via subprocess.run)
+# ---------------------------------------------------------------------------
+
+
+def queue_depth(user: str) -> int:
+    """Number of jobs the user has in the SLURM queue."""
+    r = subprocess.run(
+        ["squeue", "-u", user, "-h"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return sum(1 for line in r.stdout.splitlines() if line.strip())
+
+
+def sbatch_submit(work_dir: Path, slurm_name: str) -> str:
+    """Submit one slurm script, return the job ID as a string.
+
+    Raises CalledProcessError on submission failure so the caller can log it.
+    """
+    r = subprocess.run(
+        ["sbatch", "--parsable", slurm_name],
+        cwd=str(work_dir),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return r.stdout.strip().split(";")[0]
+
+
+def squeue_state(jid: str) -> str | None:
+    """Return current state for an in-flight job, or None if not in squeue."""
+    r = subprocess.run(
+        ["squeue", "-j", jid, "-h", "-o", "%T"],
+        capture_output=True,
+        text=True,
+    )
+    line = r.stdout.strip()
+    return line or None
+
+
+def sacct_state(jid: str) -> str | None:
+    """Fall back to sacct for terminal state when squeue no longer lists the job."""
+    r = subprocess.run(
+        ["sacct", "-j", jid, "-X", "-n", "--format=State", "--parsable2"],
+        capture_output=True,
+        text=True,
+    )
+    line = r.stdout.strip().splitlines()
+    return line[0].strip() if line and line[0].strip() else None
+
+
+def current_state(jid: str) -> str | None:
+    """squeue first, sacct fallback. Returns None if neither knows the job."""
+    return squeue_state(jid) or sacct_state(jid)
+
+
+# ---------------------------------------------------------------------------
+# Drip-feed submit-and-monitor
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TodoItem:
+    work_dir: Path
+    slurm_name: str
+    name: str  # SUBMIT_JOB / SUBMIT_EVAL identifier (e.g. run name)
+
+
+@dataclass
+class _SubmitConfig:
+    log_path: Path
+    state_path: Path
+    action_type: str
+    user: str
+    experiment_dir: Path
+    max_submit: int = DEFAULT_MAX_SUBMIT
+    stagger_sec: float = DEFAULT_STAGGER_SEC
+    poll_sec: float = DEFAULT_POLL_SEC
+
+
+def submit_and_monitor(
+    todo: Iterable[TodoItem],
+    log_path: Path,
+    state_path: Path,
+    action_type: str,
+    user: str,
+    experiment_dir: Path,
+    max_submit: int = DEFAULT_MAX_SUBMIT,
+    stagger_sec: float = DEFAULT_STAGGER_SEC,
+    poll_sec: float = DEFAULT_POLL_SEC,
+) -> dict:
+    """Drip-feed-submit `todo` and poll until all jobs reach terminal state.
+
+    Returns a dict summarizing terminal-state counts (e.g. {"COMPLETED": 2}).
+    Resumable: existing entries in the state file with terminal state are skipped.
+
+    Honors:
+    - `max_submit` queue-depth cap (gpu-test default = 25; override via env or arg).
+    - `stagger_sec` between submissions (HF datasets cache race).
+    - `poll_sec` when waiting for queue room or for in-flight jobs.
+    """
+    cfg = _SubmitConfig(
+        log_path=log_path,
+        state_path=state_path,
+        action_type=action_type,
+        user=user,
+        experiment_dir=experiment_dir,
+        max_submit=max_submit,
+        stagger_sec=stagger_sec,
+        poll_sec=poll_sec,
+    )
+
+    state = read_state(state_path)
+    state = _refresh_in_flight_state(state, log_path)
+    write_state_atomic(state_path, state)
+
+    pending = _filter_pending(todo, state, experiment_dir)
+    state = _drip_feed_submit(pending, state, cfg)
+    state = _monitor_to_terminal(state, cfg)
+
+    summary = _summarize(state)
+    log_all_complete(log_path, summary)
+    return summary
+
+
+def _filter_pending(
+    todo: Iterable[TodoItem],
+    state: dict,
+    experiment_dir: Path,
+) -> list[TodoItem]:
+    """Drop items already submitted (by state-key match)."""
+    submitted = set(state.keys())
+    pending: list[TodoItem] = []
+    for item in todo:
+        key = state_key(item.work_dir, item.slurm_name, experiment_dir)
+        if key not in submitted:
+            pending.append(item)
+    return pending
+
+
+def _refresh_in_flight_state(state: dict, log_path: Path) -> dict:
+    """For non-terminal entries, re-check SLURM and update."""
+    for key, entry in state.items():
+        if entry.get("state") in TERMINAL_STATES:
+            continue
+        jid = entry.get("job_id")
+        if not jid:
+            continue
+        new_state = current_state(str(jid))
+        if new_state and new_state != entry.get("state"):
+            log_state_change(
+                log_path,
+                name=key,
+                job_id=jid,
+                old_state=entry.get("state", "?"),
+                new_state=new_state,
+            )
+            entry["state"] = new_state
+    return state
+
+
+def _drip_feed_submit(
+    pending: list[TodoItem],
+    state: dict,
+    cfg: _SubmitConfig,
+) -> dict:
+    todo = list(pending)
+    while todo:
+        depth = queue_depth(cfg.user)
+        room = cfg.max_submit - depth
+        if room <= 0:
+            time.sleep(cfg.poll_sec)
+            continue
+
+        batch = min(room, len(todo))
+        for i in range(batch):
+            item = todo.pop(0)
+            key = state_key(item.work_dir, item.slurm_name, cfg.experiment_dir)
+            try:
+                jid = sbatch_submit(item.work_dir, item.slurm_name)
+            except subprocess.CalledProcessError as e:
+                err = (e.stderr or "").strip() or f"exit {e.returncode}"
+                log_submit_failure(
+                    cfg.log_path, cfg.action_type, item.name, item.slurm_name, err
+                )
+                state[key] = {
+                    "job_id": None,
+                    "submitted_at": _now(),
+                    "state": "SUBMIT_FAILED",
+                    "error": err,
+                }
+                write_state_atomic(cfg.state_path, state)
+                continue
+
+            log_submit(cfg.log_path, cfg.action_type, item.name, item.slurm_name, jid)
+            state[key] = {
+                "job_id": jid,
+                "submitted_at": _now(),
+                "state": "PENDING",
+            }
+            write_state_atomic(cfg.state_path, state)
+
+            if todo or i < batch - 1:
+                time.sleep(cfg.stagger_sec)
+    return state
+
+
+def _monitor_to_terminal(state: dict, cfg: _SubmitConfig) -> dict:
+    while not _all_terminal(state):
+        time.sleep(cfg.poll_sec)
+        state = _refresh_in_flight_state(state, cfg.log_path)
+        write_state_atomic(cfg.state_path, state)
+    return state
+
+
+def _all_terminal(state: dict) -> bool:
+    return all(
+        entry.get("state") in TERMINAL_STATES or entry.get("state") == "SUBMIT_FAILED"
+        for entry in state.values()
+    )
+
+
+def _summarize(state: dict) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for entry in state.values():
+        s = entry.get("state", "UNKNOWN")
+        out[s] = out.get(s, 0) + 1
+    return out
+
+
+# ---------------------------------------------------------------------------
+# CLI helpers
+# ---------------------------------------------------------------------------
+
+
+def resolve_user(cli_user: str | None) -> str:
+    return cli_user or os.environ.get("USER") or ""
+
+
+def resolve_max_submit(cli_max: int | None) -> int:
+    if cli_max is not None:
+        return cli_max
+    env = os.environ.get("MAX_SUBMIT")
+    if env:
+        try:
+            return int(env)
+        except ValueError:
+            print(
+                f"WARNING: ignoring non-integer MAX_SUBMIT env var: {env!r}",
+                file=sys.stderr,
+            )
+    return DEFAULT_MAX_SUBMIT

--- a/src/tools/run/_submit_common.py
+++ b/src/tools/run/_submit_common.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import json
 import os
+import signal
 import subprocess
 import sys
 import time
@@ -52,6 +53,94 @@ TERMINAL_STATES = {
 
 def _now() -> str:
     return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+# ---------------------------------------------------------------------------
+# Detach (signal + sentinel)
+# ---------------------------------------------------------------------------
+#
+# Watching is detachable. Three trigger paths converge on the same exit:
+# flush state -> log MONITOR_DETACHED -> exit. Jobs keep running either way.
+#
+# - SIGINT  (Ctrl+C, human at a terminal)
+# - SIGTERM (parent process killing the subprocess)
+# - touch <exp_dir>/logs/.detach  (anyone, including agents that no longer
+#   hold the process handle; the sentinel persists across invocations so
+#   re-attach via --resume-monitor will also exit until removed)
+
+SENTINEL_NAME = ".detach"
+
+_detach_signal_received: str | None = None  # set by handler; "SIGINT" / "SIGTERM"
+
+
+def _on_detach_signal(signum, frame):  # noqa: ARG001 — signal handler signature
+    global _detach_signal_received
+    _detach_signal_received = "SIGINT" if signum == signal.SIGINT else "SIGTERM"
+
+
+def install_detach_handlers() -> None:
+    """Install SIGINT/SIGTERM handlers that flip the module-level flag."""
+    signal.signal(signal.SIGINT, _on_detach_signal)
+    signal.signal(signal.SIGTERM, _on_detach_signal)
+
+
+def _reset_detach_state() -> None:
+    """Reset the in-memory signal flag (does NOT touch the sentinel file)."""
+    global _detach_signal_received
+    _detach_signal_received = None
+
+
+def sentinel_path(log_path: Path) -> Path:
+    """The detach sentinel lives next to the per-tool log files."""
+    return log_path.parent / SENTINEL_NAME
+
+
+def detach_requested(log_path: Path) -> tuple[bool, str | None]:
+    """Return (True, reason) if anything has asked us to stop watching.
+
+    reason is one of: "SIGINT", "SIGTERM", "sentinel", or None.
+    """
+    if _detach_signal_received:
+        return True, _detach_signal_received
+    if sentinel_path(log_path).exists():
+        return True, "sentinel"
+    return False, None
+
+
+def _interruptible_sleep(
+    seconds: float, log_path: Path, check_interval: float = 1.0
+) -> bool:
+    """Sleep up to `seconds`, returning True if detach was requested mid-sleep.
+
+    Polls `detach_requested` every `check_interval` seconds. The 1s default
+    bounds the worst-case "how long after touch .detach does the monitor
+    notice" at 1 second, which is plenty responsive without spinning.
+    """
+    elapsed = 0.0
+    while elapsed < seconds:
+        chunk = min(check_interval, seconds - elapsed)
+        time.sleep(chunk)
+        elapsed += chunk
+        detached, _ = detach_requested(log_path)
+        if detached:
+            return True
+    return False
+
+
+def _reattach_hint(experiment_dir: Path, action_type: str, reason: str) -> str:
+    """Loud banner shown after detach so the agent re-reading later sees how to resume."""
+    submitter = "submit_torchtune" if action_type == "SUBMIT_JOB" else "submit_inspect"
+    sentinel_note = ""
+    if reason == "sentinel":
+        sentinel_note = (
+            f"\n   NOTE: sentinel is sticky — remove it before re-attaching:\n"
+            f"         rm {experiment_dir}/logs/{SENTINEL_NAME}"
+        )
+    return (
+        f"\n⏸  Monitor detached (reason={reason}). Jobs continue running.{sentinel_note}\n"
+        f"   Check status:  python -m cruijff_kit.tools.run.status {experiment_dir}\n"
+        f"   Re-attach:     python -m cruijff_kit.tools.run.{submitter} {experiment_dir} --resume-monitor\n"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -155,11 +244,38 @@ def log_state_change(
 
 
 def log_all_complete(log_path: Path, summary: dict) -> None:
+    """Write the ALL_COMPLETE closing block. Idempotent — skips if one is
+    already present in this log.
+
+    This lets `status` emit ALL_COMPLETE when it observes all-terminal without
+    risking duplicates from a later `--resume-monitor` invocation, and also
+    closes a latent issue where running `--resume-monitor` twice on a finished
+    experiment would have written two ALL_COMPLETE blocks.
+    """
+    if log_path.exists() and "ALL_COMPLETE" in log_path.read_text():
+        return
     parts = ", ".join(f"{k}={v}" for k, v in sorted(summary.items()))
     block = (
         f"[{_now()}] ALL_COMPLETE\n"
         f"Details: terminal-state breakdown: {parts}\n"
         f"Result: done"
+    )
+    append_log(log_path, block)
+
+
+def log_monitor_detached(log_path: Path, reason: str, summary: dict) -> None:
+    """Canonical 'monitor stopped watching' block.
+
+    Reason is one of "SIGINT", "SIGTERM", "sentinel". Jobs are unaffected;
+    this only records that the watcher exited. analyze-experiment's
+    SUBMIT_JOB/SUBMIT_EVAL/Job ID regex won't match this block, so the
+    harvest path is undisturbed.
+    """
+    parts = ", ".join(f"{k}={v}" for k, v in sorted(summary.items())) or "(no state)"
+    block = (
+        f"[{_now()}] MONITOR_DETACHED\n"
+        f"Details: reason={reason}; state breakdown: {parts}\n"
+        f"Result: monitoring paused; jobs continue"
     )
     append_log(log_path, block)
 
@@ -257,7 +373,11 @@ def submit_and_monitor(
     stagger_sec: float = DEFAULT_STAGGER_SEC,
     poll_sec: float = DEFAULT_POLL_SEC,
 ) -> dict:
-    """Drip-feed-submit `todo` and poll until all jobs reach terminal state.
+    """Default flow: submit drip-fed, then monitor to terminal.
+
+    Both phases honor detach (SIGINT/SIGTERM/sentinel). On detach, flushes
+    state, emits MONITOR_DETACHED, prints a re-attach hint to stderr, and
+    returns the partial summary. Jobs continue running.
 
     Returns a dict summarizing terminal-state counts (e.g. {"COMPLETED": 2}).
     Resumable: existing entries in the state file with terminal state are skipped.
@@ -277,6 +397,8 @@ def submit_and_monitor(
         stagger_sec=stagger_sec,
         poll_sec=poll_sec,
     )
+    _reset_detach_state()
+    install_detach_handlers()
 
     state = read_state(state_path)
     state = _refresh_in_flight_state(state, log_path)
@@ -284,11 +406,123 @@ def submit_and_monitor(
 
     pending = _filter_pending(todo, state, experiment_dir)
     state = _drip_feed_submit(pending, state, cfg)
+    if _finalize_if_detached(state, cfg) is not None:
+        return _summarize(state)
+
     state = _monitor_to_terminal(state, cfg)
+    if _finalize_if_detached(state, cfg) is not None:
+        return _summarize(state)
 
     summary = _summarize(state)
     log_all_complete(log_path, summary)
     return summary
+
+
+def submit_only(
+    todo: Iterable[TodoItem],
+    log_path: Path,
+    state_path: Path,
+    action_type: str,
+    user: str,
+    experiment_dir: Path,
+    max_submit: int = DEFAULT_MAX_SUBMIT,
+    stagger_sec: float = DEFAULT_STAGGER_SEC,
+    poll_sec: float = DEFAULT_POLL_SEC,
+) -> dict:
+    """Submit phase only — drip-feed-submits then returns without monitoring.
+
+    Honors detach: if requested mid-drip-feed, flushes state, emits
+    MONITOR_DETACHED, and returns early. Currently not wired to a CLI flag
+    (the default `submit_and_monitor` covers the dispatch+watch case); kept
+    available for tests and future composition.
+    """
+    cfg = _SubmitConfig(
+        log_path=log_path,
+        state_path=state_path,
+        action_type=action_type,
+        user=user,
+        experiment_dir=experiment_dir,
+        max_submit=max_submit,
+        stagger_sec=stagger_sec,
+        poll_sec=poll_sec,
+    )
+    _reset_detach_state()
+    install_detach_handlers()
+
+    state = read_state(state_path)
+    state = _refresh_in_flight_state(state, log_path)
+    write_state_atomic(state_path, state)
+
+    pending = _filter_pending(todo, state, experiment_dir)
+    state = _drip_feed_submit(pending, state, cfg)
+    _finalize_if_detached(state, cfg)
+    return _summarize(state)
+
+
+def monitor_only(
+    log_path: Path,
+    state_path: Path,
+    action_type: str,
+    user: str,
+    experiment_dir: Path,
+    max_submit: int = DEFAULT_MAX_SUBMIT,
+    stagger_sec: float = DEFAULT_STAGGER_SEC,
+    poll_sec: float = DEFAULT_POLL_SEC,
+) -> dict:
+    """Re-attach to an existing state file and watch to terminal — no new submissions.
+
+    Powers `--resume-monitor`. If the state file is missing or empty, warns
+    loudly to stderr and returns an empty summary rather than silently no-op.
+
+    Honors detach: emits MONITOR_DETACHED on signal/sentinel and returns early.
+    """
+    cfg = _SubmitConfig(
+        log_path=log_path,
+        state_path=state_path,
+        action_type=action_type,
+        user=user,
+        experiment_dir=experiment_dir,
+        max_submit=max_submit,
+        stagger_sec=stagger_sec,
+        poll_sec=poll_sec,
+    )
+    _reset_detach_state()
+    install_detach_handlers()
+
+    state = read_state(state_path)
+    if not state:
+        print(
+            f"WARNING: no state at {state_path}; nothing to monitor. "
+            f"Run the submitter without --resume-monitor first to dispatch jobs.",
+            file=sys.stderr,
+        )
+        return {}
+
+    state = _refresh_in_flight_state(state, log_path)
+    write_state_atomic(state_path, state)
+
+    state = _monitor_to_terminal(state, cfg)
+    if _finalize_if_detached(state, cfg) is not None:
+        return _summarize(state)
+
+    summary = _summarize(state)
+    log_all_complete(log_path, summary)
+    return summary
+
+
+def _finalize_if_detached(state: dict, cfg: _SubmitConfig) -> str | None:
+    """If a detach was requested, log MONITOR_DETACHED + print hint; else no-op.
+
+    Returns the detach reason (truthy) so the caller can decide whether to
+    short-circuit, or None if no detach.
+    """
+    detached, reason = detach_requested(cfg.log_path)
+    if not detached:
+        return None
+    summary = _summarize(state)
+    log_monitor_detached(cfg.log_path, reason, summary)
+    sys.stderr.write(_reattach_hint(cfg.experiment_dir, cfg.action_type, reason))
+    return reason
 
 
 def _filter_pending(
@@ -334,14 +568,25 @@ def _drip_feed_submit(
 ) -> dict:
     todo = list(pending)
     while todo:
+        # Detach check before any further submission work.
+        detached, _ = detach_requested(cfg.log_path)
+        if detached:
+            return state
+
         depth = queue_depth(cfg.user)
         room = cfg.max_submit - depth
         if room <= 0:
-            time.sleep(cfg.poll_sec)
+            if _interruptible_sleep(cfg.poll_sec, cfg.log_path):
+                return state
             continue
 
         batch = min(room, len(todo))
         for i in range(batch):
+            # Detach check between submissions inside a batch.
+            detached, _ = detach_requested(cfg.log_path)
+            if detached:
+                return state
+
             item = todo.pop(0)
             key = state_key(item.work_dir, item.slurm_name, cfg.experiment_dir)
             try:
@@ -369,13 +614,15 @@ def _drip_feed_submit(
             write_state_atomic(cfg.state_path, state)
 
             if todo or i < batch - 1:
-                time.sleep(cfg.stagger_sec)
+                if _interruptible_sleep(cfg.stagger_sec, cfg.log_path):
+                    return state
     return state
 
 
 def _monitor_to_terminal(state: dict, cfg: _SubmitConfig) -> dict:
     while not _all_terminal(state):
-        time.sleep(cfg.poll_sec)
+        if _interruptible_sleep(cfg.poll_sec, cfg.log_path):
+            return state
         state = _refresh_in_flight_state(state, cfg.log_path)
         write_state_atomic(cfg.state_path, state)
     return state

--- a/src/tools/run/status.py
+++ b/src/tools/run/status.py
@@ -1,0 +1,154 @@
+"""One-shot consolidated status snapshot across both run-experiment submitters.
+
+Reads `logs/run-torchtune.state.json` and `logs/run-inspect.state.json` if
+present, refreshes in-flight entries from `squeue`/`sacct`, prints a
+consolidated table, and exits. Side effects are bounded to:
+
+- writing back refreshed state files (idempotent)
+- emitting `STATE_CHANGE` log blocks when transitions are observed
+- emitting `ALL_COMPLETE` once per tool when refresh observes all-terminal
+  (idempotent via the guard inside `log_all_complete`)
+
+Does NOT submit anything and does not write `MONITOR_DETACHED` or
+`SUBMIT_*` blocks. Safe to call from `/loop`, cron, or interactively at
+any cadence — and the refresh keeps the run logs alive even when no
+monitor is currently attached.
+
+Usage:
+    python -m cruijff_kit.tools.run.status <experiment_dir>
+    python -m cruijff_kit.tools.run.status <experiment_dir> --json
+
+Reads:
+    {experiment_dir}/logs/run-torchtune.state.json
+    {experiment_dir}/logs/run-inspect.state.json
+
+Writes (refreshed, idempotent):
+    same paths, plus STATE_CHANGE entries appended to the matching .log
+    when SLURM has moved a job since the last refresh, plus a single
+    ALL_COMPLETE block when refresh first observes all-terminal.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+
+from cruijff_kit.tools.run._submit_common import (
+    TERMINAL_STATES,
+    _refresh_in_flight_state,
+    log_all_complete,
+    read_state,
+    write_state_atomic,
+)
+
+# (tool name, log filename, state filename) for every submitter we know about.
+# When a new submitter lands (DSPy etc.), add it here.
+TOOLS = [
+    ("torchtune", "run-torchtune.log", "run-torchtune.state.json"),
+    ("inspect", "run-inspect.log", "run-inspect.state.json"),
+]
+
+
+def snapshot(experiment_dir: Path) -> dict[str, dict]:
+    """Refresh state for every known tool. Returns {tool_name: state_dict}.
+
+    Skips tools whose state file is missing (i.e. that submitter was never
+    invoked for this experiment). Empty state dicts are kept so callers can
+    distinguish "tool ran but submitted nothing" from "tool never ran."
+    """
+    out: dict[str, dict] = {}
+    for tool_name, log_name, state_name in TOOLS:
+        state_path = experiment_dir / "logs" / state_name
+        log_path = experiment_dir / "logs" / log_name
+        if not state_path.exists():
+            continue
+        state = read_state(state_path)
+        state = _refresh_in_flight_state(state, log_path)
+        write_state_atomic(state_path, state)
+        # If status is the one that happens to observe all-terminal,
+        # emit ALL_COMPLETE so the pipeline log closes cleanly without
+        # needing a separate --resume-monitor invocation just for log hygiene.
+        # log_all_complete is idempotent — at most one block per log.
+        if state and all(e.get("state") in TERMINAL_STATES for e in state.values()):
+            summary = Counter(e.get("state", "UNKNOWN") for e in state.values())
+            log_all_complete(log_path, dict(summary))
+        out[tool_name] = state
+    return out
+
+
+def _format_age(submitted_at_str: str) -> str:
+    try:
+        submitted = datetime.strptime(submitted_at_str, "%Y-%m-%d %H:%M:%S")
+    except ValueError:
+        return "?"
+    total = int((datetime.now() - submitted).total_seconds())
+    if total < 60:
+        return f"{total}s"
+    if total < 3600:
+        return f"{total // 60}m"
+    return f"{total // 3600}h{(total % 3600) // 60}m"
+
+
+def format_table(snapshots: dict[str, dict]) -> str:
+    if not snapshots:
+        return "No state files found under logs/. Has run-experiment been invoked yet?"
+
+    # Width the key column to the widest entry across both tools so eval
+    # paths like `<run>/eval/<task>_epoch<N>.slurm` don't get truncated.
+    keys = [k for state in snapshots.values() for k in state]
+    maxw = max((len(k) for k in keys), default=20)
+
+    lines: list[str] = []
+    grand: Counter[str] = Counter()
+    for tool_name, state in snapshots.items():
+        lines.append(f"\n[{tool_name}]")
+        if not state:
+            lines.append("  (no submissions yet)")
+            continue
+        counter: Counter[str] = Counter()
+        for key, entry in sorted(state.items()):
+            jid = entry.get("job_id") or "-"
+            s = entry.get("state", "?")
+            submitted = entry.get("submitted_at", "")
+            age = _format_age(submitted) if submitted else "?"
+            counter[s] += 1
+            lines.append(f"  {key:<{maxw}}  jid {str(jid):>10}  {s:14}  ({age} ago)")
+        breakdown = ", ".join(f"{k}={v}" for k, v in sorted(counter.items()))
+        lines.append(f"  -- {sum(counter.values())} jobs: {breakdown}")
+        grand.update(counter)
+
+    if grand:
+        breakdown = ", ".join(f"{k}={v}" for k, v in sorted(grand.items()))
+        lines.append(
+            f"\nTotal: {sum(grand.values())} jobs across "
+            f"{len(snapshots)} tool(s): {breakdown}"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("experiment_dir", type=Path)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of the table.",
+    )
+    args = parser.parse_args(argv)
+
+    experiment_dir = args.experiment_dir.resolve()
+    snapshots = snapshot(experiment_dir)
+
+    if args.json:
+        print(json.dumps(snapshots, indent=2, sort_keys=True))
+    else:
+        print(format_table(snapshots))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/tools/run/submit_inspect.py
+++ b/src/tools/run/submit_inspect.py
@@ -1,0 +1,115 @@
+"""Submit-and-monitor entrypoint for inspect-ai evaluation runs.
+
+Drip-feeds every `<run>/eval/*.slurm` file under an experiment directory,
+emits canonical SUBMIT_EVAL log blocks, and persists resume state. See
+`_submit_common.py` for shared logic.
+
+Drip-feed (5-second stagger, 25-job queue cap) applies on this side too —
+the HF datasets cache race that hits fine-tunes also hits evals when many
+jobs land on `datasets.load_dataset` at once.
+
+Usage:
+    python -m cruijff_kit.tools.run.submit_inspect <experiment_dir>
+
+Reads:
+    {experiment_dir}/<run>/eval/*.slurm
+
+Writes:
+    {experiment_dir}/logs/run-inspect.log
+    {experiment_dir}/logs/run-inspect.state.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from cruijff_kit.tools.run._submit_common import (
+    TodoItem,
+    resolve_max_submit,
+    resolve_user,
+    submit_and_monitor,
+)
+
+LOG_NAME = "run-inspect.log"
+STATE_NAME = "run-inspect.state.json"
+
+
+def _eval_name(run_dir_name: str, slurm_name: str) -> str:
+    """Build a SUBMIT_EVAL identifier matching the analyze-experiment regex `[\\w./-]+`.
+
+    Examples:
+      ("Llama-3.2-1B-Instruct_base",  "capitalization.slurm")        -> "Llama-3.2-1B-Instruct_base/capitalization"
+      ("Llama-3.2-1B-Instruct_rank4", "capitalization_epoch0.slurm") -> "Llama-3.2-1B-Instruct_rank4/capitalization/epoch0"
+    """
+    base = slurm_name
+    if base.endswith(".slurm"):
+        base = base[: -len(".slurm")]
+    if "_epoch" in base:
+        task, epoch = base.split("_epoch", 1)
+        return f"{run_dir_name}/{task}/epoch{epoch}"
+    return f"{run_dir_name}/{base}"
+
+
+def _build_todo(experiment_dir: Path) -> list[TodoItem]:
+    """Return a TodoItem for each *.slurm under any */eval/ subdirectory."""
+    todo: list[TodoItem] = []
+    for slurm_path in sorted(experiment_dir.glob("*/eval/*.slurm")):
+        eval_dir = slurm_path.parent
+        run_dir = eval_dir.parent
+        todo.append(
+            TodoItem(
+                work_dir=eval_dir,
+                slurm_name=slurm_path.name,
+                name=_eval_name(run_dir.name, slurm_path.name),
+            )
+        )
+    return todo
+
+
+def run(
+    experiment_dir: Path,
+    user: str | None = None,
+    max_submit: int | None = None,
+) -> dict:
+    """Programmatic entrypoint (also used by tests)."""
+    experiment_dir = experiment_dir.resolve()
+    todo = _build_todo(experiment_dir)
+    log_path = experiment_dir / "logs" / LOG_NAME
+    state_path = experiment_dir / "logs" / STATE_NAME
+
+    return submit_and_monitor(
+        todo=todo,
+        log_path=log_path,
+        state_path=state_path,
+        action_type="SUBMIT_EVAL",
+        user=resolve_user(user),
+        experiment_dir=experiment_dir,
+        max_submit=resolve_max_submit(max_submit),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("experiment_dir", type=Path)
+    parser.add_argument(
+        "--user",
+        default=None,
+        help="SLURM username for queue-depth checks. Defaults to $USER.",
+    )
+    parser.add_argument(
+        "--max-submit",
+        type=int,
+        default=None,
+        help="Cap on concurrent submissions (default: 25, override via MAX_SUBMIT env).",
+    )
+    args = parser.parse_args(argv)
+
+    summary = run(args.experiment_dir, user=args.user, max_submit=args.max_submit)
+    print(f"Done. Terminal-state breakdown: {summary}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/tools/run/submit_inspect.py
+++ b/src/tools/run/submit_inspect.py
@@ -27,6 +27,7 @@ from pathlib import Path
 
 from cruijff_kit.tools.run._submit_common import (
     TodoItem,
+    monitor_only,
     resolve_max_submit,
     resolve_user,
     submit_and_monitor,
@@ -72,13 +73,29 @@ def run(
     experiment_dir: Path,
     user: str | None = None,
     max_submit: int | None = None,
+    resume_monitor: bool = False,
 ) -> dict:
-    """Programmatic entrypoint (also used by tests)."""
+    """Programmatic entrypoint (also used by tests).
+
+    `resume_monitor=True` skips the submission phase entirely and re-attaches
+    a watcher to the existing state file. Useful after a clean detach
+    (SIGINT / SIGTERM / sentinel) to pick up monitoring without resubmitting.
+    """
     experiment_dir = experiment_dir.resolve()
-    todo = _build_todo(experiment_dir)
     log_path = experiment_dir / "logs" / LOG_NAME
     state_path = experiment_dir / "logs" / STATE_NAME
 
+    if resume_monitor:
+        return monitor_only(
+            log_path=log_path,
+            state_path=state_path,
+            action_type="SUBMIT_EVAL",
+            user=resolve_user(user),
+            experiment_dir=experiment_dir,
+            max_submit=resolve_max_submit(max_submit),
+        )
+
+    todo = _build_todo(experiment_dir)
     return submit_and_monitor(
         todo=todo,
         log_path=log_path,
@@ -104,9 +121,20 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="Cap on concurrent submissions (default: 25, override via MAX_SUBMIT env).",
     )
+    parser.add_argument(
+        "--resume-monitor",
+        action="store_true",
+        help="Skip submission; re-attach a watcher to the existing state file. "
+        "Use after a clean detach to resume monitoring without resubmitting.",
+    )
     args = parser.parse_args(argv)
 
-    summary = run(args.experiment_dir, user=args.user, max_submit=args.max_submit)
+    summary = run(
+        args.experiment_dir,
+        user=args.user,
+        max_submit=args.max_submit,
+        resume_monitor=args.resume_monitor,
+    )
     print(f"Done. Terminal-state breakdown: {summary}")
     return 0
 

--- a/src/tools/run/submit_torchtune.py
+++ b/src/tools/run/submit_torchtune.py
@@ -1,0 +1,117 @@
+"""Submit-and-monitor entrypoint for torchtune fine-tuning runs.
+
+Drip-feeds `*/finetune.slurm` files for fine-tuned runs declared in
+`experiment_summary.yaml`, emits canonical SUBMIT_JOB log blocks, and
+persists resume state. See `_submit_common.py` for shared logic and
+the canonical log shape.
+
+Usage:
+    python -m cruijff_kit.tools.run.submit_torchtune <experiment_dir>
+
+Reads:
+    {experiment_dir}/experiment_summary.yaml
+    {experiment_dir}/<run>/finetune.slurm
+
+Writes:
+    {experiment_dir}/logs/run-torchtune.log
+    {experiment_dir}/logs/run-torchtune.state.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+from cruijff_kit.tools.run._submit_common import (
+    TodoItem,
+    resolve_max_submit,
+    resolve_user,
+    submit_and_monitor,
+)
+
+LOG_NAME = "run-torchtune.log"
+STATE_NAME = "run-torchtune.state.json"
+
+
+def _build_todo(experiment_dir: Path) -> list[TodoItem]:
+    """Return a TodoItem for each fine-tuned run that has a finetune.slurm."""
+    summary_path = experiment_dir / "experiment_summary.yaml"
+    if not summary_path.exists():
+        raise FileNotFoundError(
+            f"experiment_summary.yaml not found at {summary_path}. "
+            f"Run design-experiment first."
+        )
+
+    summary = yaml.safe_load(summary_path.read_text()) or {}
+    runs = summary.get("runs", []) or []
+
+    todo: list[TodoItem] = []
+    for run in runs:
+        if run.get("type") != "fine-tuned":
+            continue
+        run_name = run.get("name")
+        if not run_name:
+            continue
+        work_dir = experiment_dir / run_name
+        slurm = work_dir / "finetune.slurm"
+        if not slurm.exists():
+            print(
+                f"WARNING: skipping {run_name!r}: {slurm} not found "
+                f"(scaffold-experiment may not have run for this run)",
+                file=sys.stderr,
+            )
+            continue
+        todo.append(
+            TodoItem(work_dir=work_dir, slurm_name="finetune.slurm", name=run_name)
+        )
+    return todo
+
+
+def run(
+    experiment_dir: Path,
+    user: str | None = None,
+    max_submit: int | None = None,
+) -> dict:
+    """Programmatic entrypoint (also used by tests)."""
+    experiment_dir = experiment_dir.resolve()
+    todo = _build_todo(experiment_dir)
+    log_path = experiment_dir / "logs" / LOG_NAME
+    state_path = experiment_dir / "logs" / STATE_NAME
+
+    return submit_and_monitor(
+        todo=todo,
+        log_path=log_path,
+        state_path=state_path,
+        action_type="SUBMIT_JOB",
+        user=resolve_user(user),
+        experiment_dir=experiment_dir,
+        max_submit=resolve_max_submit(max_submit),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("experiment_dir", type=Path)
+    parser.add_argument(
+        "--user",
+        default=None,
+        help="SLURM username for queue-depth checks. Defaults to $USER.",
+    )
+    parser.add_argument(
+        "--max-submit",
+        type=int,
+        default=None,
+        help="Cap on concurrent submissions (default: 25, override via MAX_SUBMIT env).",
+    )
+    args = parser.parse_args(argv)
+
+    summary = run(args.experiment_dir, user=args.user, max_submit=args.max_submit)
+    print(f"Done. Terminal-state breakdown: {summary}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/tools/run/submit_torchtune.py
+++ b/src/tools/run/submit_torchtune.py
@@ -27,6 +27,7 @@ import yaml
 
 from cruijff_kit.tools.run._submit_common import (
     TodoItem,
+    monitor_only,
     resolve_max_submit,
     resolve_user,
     submit_and_monitor,
@@ -74,13 +75,29 @@ def run(
     experiment_dir: Path,
     user: str | None = None,
     max_submit: int | None = None,
+    resume_monitor: bool = False,
 ) -> dict:
-    """Programmatic entrypoint (also used by tests)."""
+    """Programmatic entrypoint (also used by tests).
+
+    `resume_monitor=True` skips the submission phase entirely and re-attaches
+    a watcher to the existing state file. Useful after a clean detach
+    (SIGINT / SIGTERM / sentinel) to pick up monitoring without resubmitting.
+    """
     experiment_dir = experiment_dir.resolve()
-    todo = _build_todo(experiment_dir)
     log_path = experiment_dir / "logs" / LOG_NAME
     state_path = experiment_dir / "logs" / STATE_NAME
 
+    if resume_monitor:
+        return monitor_only(
+            log_path=log_path,
+            state_path=state_path,
+            action_type="SUBMIT_JOB",
+            user=resolve_user(user),
+            experiment_dir=experiment_dir,
+            max_submit=resolve_max_submit(max_submit),
+        )
+
+    todo = _build_todo(experiment_dir)
     return submit_and_monitor(
         todo=todo,
         log_path=log_path,
@@ -106,9 +123,20 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="Cap on concurrent submissions (default: 25, override via MAX_SUBMIT env).",
     )
+    parser.add_argument(
+        "--resume-monitor",
+        action="store_true",
+        help="Skip submission; re-attach a watcher to the existing state file. "
+        "Use after a clean detach to resume monitoring without resubmitting.",
+    )
     args = parser.parse_args(argv)
 
-    summary = run(args.experiment_dir, user=args.user, max_submit=args.max_submit)
+    summary = run(
+        args.experiment_dir,
+        user=args.user,
+        max_submit=args.max_submit,
+        resume_monitor=args.resume_monitor,
+    )
     print(f"Done. Terminal-state breakdown: {summary}")
     return 0
 

--- a/src/tools/slurm/compute_metrics.py
+++ b/src/tools/slurm/compute_metrics.py
@@ -9,7 +9,15 @@ import json
 import re
 import shutil
 import subprocess
+import sys
 from pathlib import Path
+
+# Canonical run-experiment log shape lives at
+# .claude/skills/run-experiment/logging.md and is enforced by
+# src/tools/run/_submit_common.py. Both regexes mirror those in
+# .claude/skills/analyze-experiment/generation.md:387-388.
+SUBMIT_JOB_RE = re.compile(r"SUBMIT_JOB: ([\w.-]+)\n.*?\nJob ID: (\d+)", re.DOTALL)
+SUBMIT_EVAL_RE = re.compile(r"SUBMIT_EVAL: ([\w./-]+)\n.*?\nJob ID: (\d+)", re.DOTALL)
 
 
 def parse_seff_output(seff_text: str) -> dict:
@@ -582,3 +590,54 @@ def format_compute_table(
                 lines.append("")
 
     return "\n".join(lines)
+
+
+def harvest_jids_from_run_logs(
+    experiment_dir: Path,
+) -> tuple[dict[str, list[tuple[str, str]]], list[str]]:
+    """Parse run-experiment execution logs into job IDs.
+
+    Returns:
+        ({"finetune": [(name, jid), ...], "eval": [(name, jid), ...]}, warnings)
+
+    `warnings` is a list of human-readable strings explaining any missing or
+    malformed log files. When non-empty, callers should:
+      1. Emit each line to stderr (this function already does so).
+      2. Surface them in the rendered report (e.g., as a "*Compute Utilization
+         unavailable: ...*" note) instead of silently omitting the section.
+
+    Pre-#451, analyze-experiment's compute step "skipped silently if no run
+    logs exist." This helper makes the absence loud.
+    """
+    finetune_path = experiment_dir / "logs" / "run-torchtune.log"
+    eval_path = experiment_dir / "logs" / "run-inspect.log"
+
+    finetune_pairs, finetune_warns = _harvest_one(finetune_path, SUBMIT_JOB_RE)
+    eval_pairs, eval_warns = _harvest_one(eval_path, SUBMIT_EVAL_RE)
+
+    warnings = finetune_warns + eval_warns
+    for w in warnings:
+        print(f"WARNING: {w}", file=sys.stderr)
+
+    return {"finetune": finetune_pairs, "eval": eval_pairs}, warnings
+
+
+def _harvest_one(
+    log_path: Path, pattern: re.Pattern[str]
+) -> tuple[list[tuple[str, str]], list[str]]:
+    if not log_path.exists():
+        return [], [
+            f"{log_path} not found — compute utilization cannot be reported "
+            f"for the corresponding job class. Re-run run-experiment, or "
+            f"reconstruct the log from sacct."
+        ]
+    text = log_path.read_text()
+    pairs = pattern.findall(text)
+    if not pairs:
+        return [], [
+            f"{log_path} exists but contains no canonical SUBMIT_JOB / "
+            f"SUBMIT_EVAL entries. Compute utilization cannot be reported "
+            f"for this log. Check that submissions used the run-experiment "
+            f"skill or src/tools/run/submit_*.py."
+        ]
+    return list(pairs), []

--- a/tests/unit/test_compute_metrics.py
+++ b/tests/unit/test_compute_metrics.py
@@ -17,6 +17,7 @@ from cruijff_kit.tools.slurm.compute_metrics import (
     extract_jobstats_notes,
     format_compute_table,
     generate_gpu_recommendations,
+    harvest_jids_from_run_logs,
     parse_jobstats_json,
     parse_sacct_time_limit,
     parse_seff_output,
@@ -1020,3 +1021,97 @@ class TestGenerateGpuRecommendations:
         ]
         recs = generate_gpu_recommendations(jobs)
         assert recs == {}
+
+
+# =============================================================================
+# harvest_jids_from_run_logs()  — issue #451 loud-warn
+# =============================================================================
+
+
+class TestHarvestJidsFromRunLogs:
+    """Issue #451: replace silent skip with loud warnings when run-experiment
+    logs are missing or malformed."""
+
+    def _write_log(self, path, blocks):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("\n\n".join(blocks) + "\n")
+
+    def test_warns_on_missing_finetune_log(self, tmp_path, capsys):
+        # No logs at all
+        result, warnings = harvest_jids_from_run_logs(tmp_path)
+        assert result == {"finetune": [], "eval": []}
+        assert len(warnings) == 2  # both finetune AND eval missing
+        assert any("run-torchtune.log" in w for w in warnings)
+        assert any("run-inspect.log" in w for w in warnings)
+        # Loud-warn writes to stderr
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "run-torchtune.log" in captured.err
+
+    def test_warns_on_malformed_log(self, tmp_path, capsys):
+        log_path = tmp_path / "logs" / "run-torchtune.log"
+        log_path.parent.mkdir(parents=True)
+        log_path.write_text("blah blah no canonical entries here\n")
+        # Eval log also missing — both produce warnings
+        _, warnings = harvest_jids_from_run_logs(tmp_path)
+        assert any("no canonical SUBMIT_JOB" in w for w in warnings)
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+
+    def test_extracts_finetune_jids(self, tmp_path, capsys):
+        log_path = tmp_path / "logs" / "run-torchtune.log"
+        self._write_log(
+            log_path,
+            [
+                "[2026-05-08 14:32:01] SUBMIT_JOB: rank4\nDetails: sbatch finetune.slurm\nJob ID: 1234\nResult: success",
+                "[2026-05-08 14:32:06] SUBMIT_JOB: rank8\nDetails: sbatch finetune.slurm\nJob ID: 1235\nResult: success",
+            ],
+        )
+        # Eval log missing → still warns for that side
+        result, warnings = harvest_jids_from_run_logs(tmp_path)
+        assert result["finetune"] == [("rank4", "1234"), ("rank8", "1235")]
+        assert result["eval"] == []
+        assert any("run-inspect.log" in w for w in warnings)
+
+    def test_extracts_eval_jids_with_slash_names(self, tmp_path):
+        log_path = tmp_path / "logs" / "run-inspect.log"
+        # Also write a torchtune log so the finetune side doesn't warn.
+        self._write_log(
+            tmp_path / "logs" / "run-torchtune.log",
+            [
+                "[2026-05-08 14:32:01] SUBMIT_JOB: rank4\nDetails: sbatch finetune.slurm\nJob ID: 1234\nResult: success",
+            ],
+        )
+        self._write_log(
+            log_path,
+            [
+                "[2026-05-08 15:00:01] SUBMIT_EVAL: rank4/capitalization/epoch0\nDetails: sbatch capitalization_epoch0.slurm\nJob ID: 9999\nResult: success",
+                "[2026-05-08 15:00:06] SUBMIT_EVAL: rank4/capitalization/epoch1\nDetails: sbatch capitalization_epoch1.slurm\nJob ID: 10000\nResult: success",
+            ],
+        )
+        result, warnings = harvest_jids_from_run_logs(tmp_path)
+        assert result["eval"] == [
+            ("rank4/capitalization/epoch0", "9999"),
+            ("rank4/capitalization/epoch1", "10000"),
+        ]
+        assert warnings == []
+
+    def test_round_trips_with_canonical_submitter_output(self, tmp_path):
+        """End-to-end glue: _submit_common's log lines are parseable by this harvester."""
+        from cruijff_kit.tools.run import _submit_common
+
+        log_path = tmp_path / "logs" / "run-torchtune.log"
+        _submit_common.log_submit(
+            log_path, "SUBMIT_JOB", name="rank4", slurm_name="finetune.slurm", job_id=42
+        )
+        _submit_common.log_submit(
+            tmp_path / "logs" / "run-inspect.log",
+            "SUBMIT_EVAL",
+            name="rank4/capitalization/epoch0",
+            slurm_name="capitalization_epoch0.slurm",
+            job_id=99,
+        )
+        result, warnings = harvest_jids_from_run_logs(tmp_path)
+        assert result["finetune"] == [("rank4", "42")]
+        assert result["eval"] == [("rank4/capitalization/epoch0", "99")]
+        assert warnings == []

--- a/tests/unit/test_run_experiment_logs.py
+++ b/tests/unit/test_run_experiment_logs.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import re
+import signal
 import subprocess
 from pathlib import Path
 
@@ -23,6 +24,7 @@ import pytest
 import yaml
 
 from cruijff_kit.tools.run import _submit_common as common
+from cruijff_kit.tools.run import status as run_status
 from cruijff_kit.tools.run import submit_inspect, submit_torchtune
 
 
@@ -333,11 +335,13 @@ class TestDripFeed:
 
         submit_torchtune.run(tmp_path, user="testuser", max_submit=2)
 
-        # Both jobs eventually submitted, but at least one POLL_SEC sleep
-        # happened due to back-pressure.
+        # Both jobs eventually submitted, but at least one full back-pressure
+        # poll cycle (DEFAULT_POLL_SEC total) elapsed before the second sbatch.
+        # We assert on the SUM rather than an exact-value match because
+        # interruptible sleeps chunk into 1s slices for sentinel polling.
         assert len(fake_slurm.submissions) == 2
-        assert any(s == common.DEFAULT_POLL_SEC for s in fast_sleep), (
-            f"expected a {common.DEFAULT_POLL_SEC}s back-pressure sleep, "
+        assert sum(fast_sleep) >= common.DEFAULT_POLL_SEC, (
+            f"expected at least {common.DEFAULT_POLL_SEC}s of back-pressure sleep, "
             f"got sleeps {fast_sleep}"
         )
 
@@ -356,9 +360,11 @@ class TestDripFeed:
 
         submit_torchtune.run(tmp_path, user="testuser", max_submit=10)
 
-        stagger_sleeps = [s for s in fast_sleep if s == common.DEFAULT_STAGGER_SEC]
-        assert len(stagger_sleeps) >= 1, (
-            f"expected at least one {common.DEFAULT_STAGGER_SEC}s stagger sleep, "
+        # At least one stagger (DEFAULT_STAGGER_SEC total) happened between
+        # the two submissions. Sum-based rather than exact-match because
+        # interruptible sleeps chunk into 1s slices for sentinel polling.
+        assert sum(fast_sleep) >= common.DEFAULT_STAGGER_SEC, (
+            f"expected at least {common.DEFAULT_STAGGER_SEC}s of stagger sleep, "
             f"got {fast_sleep}"
         )
 
@@ -412,3 +418,416 @@ class TestEvalCollisionRegression:
         assert "run_a/eval/capitalization.slurm" in state
         assert "run_b/eval/capitalization.slurm" in state
         assert len(state) == 2
+
+
+# ---------------------------------------------------------------------------
+# (4) Detach mechanisms — sentinel + signal
+# ---------------------------------------------------------------------------
+
+
+class TestDetach:
+    """Detach exits cleanly, jobs continue, MONITOR_DETACHED is logged.
+
+    All three trigger paths (sentinel, SIGINT, SIGTERM) converge on the same
+    exit. Tests poke at the module-level signal flag directly to avoid
+    sending real signals to the test runner.
+    """
+
+    def test_sentinel_blocks_all_submissions_when_present_pre_run(
+        self, tmp_path, fake_slurm, fast_sleep
+    ):
+        """Sentinel created before submit_* runs → no sbatch happens."""
+        _write_finetune_experiment(tmp_path, ["rank4", "rank8"], include_control=False)
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        (logs_dir / common.SENTINEL_NAME).touch()
+
+        summary = submit_torchtune.run(tmp_path, user="testuser", max_submit=10)
+
+        assert fake_slurm.submissions == []
+        assert summary == {}  # nothing in state to summarize
+        log = (logs_dir / "run-torchtune.log").read_text()
+        assert "MONITOR_DETACHED" in log
+        assert "reason=sentinel" in log
+
+    def test_sentinel_mid_drip_feed_stops_further_submissions(
+        self, tmp_path, fake_slurm, fast_sleep
+    ):
+        """Sentinel appearing after the first submission halts the drip-feed."""
+        _write_finetune_experiment(
+            tmp_path, ["rank4", "rank8", "rank16"], include_control=False
+        )
+        original_sbatch = fake_slurm._sbatch
+        logs_dir = tmp_path / "logs"
+
+        def sbatch_then_sentinel(argv, kwargs):
+            r = original_sbatch(argv, kwargs)
+            # After the first submission, drop the sentinel.
+            if len(fake_slurm.submissions) == 1:
+                logs_dir.mkdir(parents=True, exist_ok=True)
+                (logs_dir / common.SENTINEL_NAME).touch()
+            return r
+
+        fake_slurm._sbatch = sbatch_then_sentinel
+
+        summary = submit_torchtune.run(tmp_path, user="testuser", max_submit=10)
+
+        # Exactly one job submitted — sentinel caught the stagger sleep.
+        assert len(fake_slurm.submissions) == 1
+        assert summary == {"PENDING": 1}
+        log = (logs_dir / "run-torchtune.log").read_text()
+        assert "MONITOR_DETACHED" in log
+
+    def test_sentinel_during_monitor_returns_without_terminal_states(
+        self, tmp_path, fake_slurm, fast_sleep
+    ):
+        """Sentinel during the monitor loop exits with jobs still RUNNING.
+
+        Uses resume_monitor=True with a pre-seeded RUNNING state — this is
+        the cleanest way to exercise the monitor-side detach path without
+        racing the drip-feed.
+        """
+        _write_finetune_experiment(tmp_path, ["rank4"], include_control=False)
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+
+        # Pre-seed state as if a previous submitter dispatched and exited.
+        fake_slurm.in_queue["1000"] = "RUNNING"
+        (logs_dir / "run-torchtune.state.json").write_text(
+            json.dumps(
+                {
+                    "rank4/finetune.slurm": {
+                        "job_id": "1000",
+                        "submitted_at": "2026-05-11 14:00:00",
+                        "state": "RUNNING",
+                    }
+                }
+            )
+        )
+        # Sentinel is present from the start — monitor bails on first sleep.
+        (logs_dir / common.SENTINEL_NAME).touch()
+
+        summary = submit_torchtune.run(
+            tmp_path, user="testuser", max_submit=10, resume_monitor=True
+        )
+
+        assert summary == {"RUNNING": 1}
+        log = (logs_dir / "run-torchtune.log").read_text()
+        assert "MONITOR_DETACHED" in log
+        assert "ALL_COMPLETE" not in log
+
+    def test_sigterm_during_drip_feed(self, tmp_path, fake_slurm, fast_sleep):
+        """Simulating SIGTERM mid-drip-feed halts further submissions."""
+        _write_finetune_experiment(
+            tmp_path, ["rank4", "rank8", "rank16"], include_control=False
+        )
+        original_sbatch = fake_slurm._sbatch
+
+        def sbatch_then_sigterm(argv, kwargs):
+            r = original_sbatch(argv, kwargs)
+            if len(fake_slurm.submissions) == 1:
+                # Simulate SIGTERM by calling the handler directly. Avoids
+                # actually signalling the test runner.
+                common._on_detach_signal(signal.SIGTERM, None)
+            return r
+
+        fake_slurm._sbatch = sbatch_then_sigterm
+
+        summary = submit_torchtune.run(tmp_path, user="testuser", max_submit=10)
+
+        assert len(fake_slurm.submissions) == 1
+        assert summary == {"PENDING": 1}
+        log = (tmp_path / "logs" / "run-torchtune.log").read_text()
+        assert "MONITOR_DETACHED" in log
+        assert "reason=SIGTERM" in log
+
+    def test_detach_state_resets_between_calls(self, tmp_path, fake_slurm, fast_sleep):
+        """A SIGTERM-flagged state from one call is cleared at the start of the next.
+
+        Without _reset_detach_state(), a subsequent submitter call in the
+        same process would detach immediately on entry — a real hazard for
+        tests and any in-process orchestrator.
+        """
+        common._on_detach_signal(signal.SIGTERM, None)
+        assert common._detach_signal_received == "SIGTERM"
+
+        _write_finetune_experiment(tmp_path, ["rank4"], include_control=False)
+        original_sbatch = fake_slurm._sbatch
+
+        def sbatch_then_finish(argv, kwargs):
+            r = original_sbatch(argv, kwargs)
+            fake_slurm.finish_all("COMPLETED")
+            return r
+
+        fake_slurm._sbatch = sbatch_then_finish
+
+        summary = submit_torchtune.run(tmp_path, user="testuser", max_submit=10)
+
+        # The pre-existing signal flag did NOT cause an early exit.
+        assert len(fake_slurm.submissions) == 1
+        assert summary == {"COMPLETED": 1}
+
+
+# ---------------------------------------------------------------------------
+# (5) --resume-monitor flag
+# ---------------------------------------------------------------------------
+
+
+class TestResumeMonitor:
+    def test_resume_monitor_skips_submit_phase(self, tmp_path, fake_slurm, fast_sleep):
+        """With existing state, --resume-monitor never calls sbatch."""
+        _write_finetune_experiment(tmp_path, ["rank4"], include_control=False)
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+
+        # Pre-seed a state file as if the run was already submitted.
+        fake_slurm.in_queue["1000"] = "RUNNING"
+        seeded_state = {
+            "rank4/finetune.slurm": {
+                "job_id": "1000",
+                "submitted_at": "2026-05-11 14:00:00",
+                "state": "RUNNING",
+            }
+        }
+        (logs_dir / "run-torchtune.state.json").write_text(json.dumps(seeded_state))
+
+        # When monitor refreshes, the job transitions to COMPLETED.
+        def transition_to_done():
+            fake_slurm.finish_all("COMPLETED")
+
+        original_sleep = common.time.sleep
+
+        def sleep_then_finish(s):
+            original_sleep(s)
+            transition_to_done()
+
+        # Mock the sleep so the first poll causes the transition.
+        common.time.sleep = sleep_then_finish
+        try:
+            summary = submit_torchtune.run(
+                tmp_path, user="testuser", max_submit=10, resume_monitor=True
+            )
+        finally:
+            common.time.sleep = original_sleep
+
+        assert fake_slurm.submissions == [], "resume-monitor must not call sbatch"
+        assert summary == {"COMPLETED": 1}
+        log = (logs_dir / "run-torchtune.log").read_text()
+        assert "ALL_COMPLETE" in log
+
+    def test_resume_monitor_with_no_state_warns_and_returns_empty(
+        self, tmp_path, fake_slurm, fast_sleep, capsys
+    ):
+        """No state file → loud stderr warning, no sbatch, empty summary."""
+        (tmp_path / "logs").mkdir()
+
+        summary = submit_inspect.run(
+            tmp_path, user="testuser", max_submit=10, resume_monitor=True
+        )
+
+        assert summary == {}
+        assert fake_slurm.submissions == []
+        captured = capsys.readouterr()
+        assert "no state" in captured.err.lower()
+
+
+# ---------------------------------------------------------------------------
+# (6) status command — read-only snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestStatus:
+    def test_snapshot_reads_both_state_files_when_present(
+        self, tmp_path, fake_slurm, fast_sleep
+    ):
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir()
+
+        (logs_dir / "run-torchtune.state.json").write_text(
+            json.dumps(
+                {
+                    "rank4/finetune.slurm": {
+                        "job_id": "1000",
+                        "submitted_at": "2026-05-11 14:00:00",
+                        "state": "COMPLETED",
+                    }
+                }
+            )
+        )
+        (logs_dir / "run-inspect.state.json").write_text(
+            json.dumps(
+                {
+                    "rank4/eval/cap.slurm": {
+                        "job_id": "1001",
+                        "submitted_at": "2026-05-11 14:30:00",
+                        "state": "RUNNING",
+                    }
+                }
+            )
+        )
+        fake_slurm.in_queue["1001"] = "RUNNING"
+
+        snapshots = run_status.snapshot(tmp_path)
+
+        assert set(snapshots.keys()) == {"torchtune", "inspect"}
+        assert snapshots["torchtune"]["rank4/finetune.slurm"]["state"] == "COMPLETED"
+        assert snapshots["inspect"]["rank4/eval/cap.slurm"]["state"] == "RUNNING"
+
+    def test_snapshot_skips_missing_state_files(self, tmp_path, fake_slurm):
+        (tmp_path / "logs").mkdir()
+        # Only torchtune state exists.
+        (tmp_path / "logs" / "run-torchtune.state.json").write_text(json.dumps({}))
+
+        snapshots = run_status.snapshot(tmp_path)
+
+        assert "torchtune" in snapshots
+        assert "inspect" not in snapshots
+
+    def test_snapshot_does_not_call_sbatch(self, tmp_path, fake_slurm):
+        """status reads + refreshes; it must never submit anything."""
+        (tmp_path / "logs").mkdir()
+        (tmp_path / "logs" / "run-torchtune.state.json").write_text(
+            json.dumps(
+                {
+                    "x/finetune.slurm": {
+                        "job_id": "1000",
+                        "submitted_at": "2026-05-11 14:00:00",
+                        "state": "COMPLETED",
+                    }
+                }
+            )
+        )
+
+        run_status.snapshot(tmp_path)
+        assert fake_slurm.submissions == []
+
+    def test_format_table_empty_returns_helpful_message(self):
+        out = run_status.format_table({})
+        assert "No state files" in out
+
+    def test_format_table_includes_sections_and_totals(self):
+        snapshots = {
+            "torchtune": {
+                "rank4/finetune.slurm": {
+                    "job_id": "1000",
+                    "submitted_at": "2026-05-11 14:00:00",
+                    "state": "COMPLETED",
+                }
+            },
+            "inspect": {
+                "rank4/eval/cap.slurm": {
+                    "job_id": "1001",
+                    "submitted_at": "2026-05-11 14:30:00",
+                    "state": "RUNNING",
+                }
+            },
+        }
+        out = run_status.format_table(snapshots)
+        assert "[torchtune]" in out
+        assert "[inspect]" in out
+        assert "COMPLETED" in out
+        assert "RUNNING" in out
+        assert "Total:" in out
+        assert "2 tool(s)" in out
+
+    def test_status_emits_all_complete_when_observing_all_terminal(
+        self, tmp_path, fake_slurm
+    ):
+        """When status refresh sees all entries terminal, ALL_COMPLETE lands."""
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir()
+        (logs_dir / "run-torchtune.state.json").write_text(
+            json.dumps(
+                {
+                    "rank4/finetune.slurm": {
+                        "job_id": "1000",
+                        "submitted_at": "2026-05-11 14:00:00",
+                        "state": "COMPLETED",
+                    }
+                }
+            )
+        )
+
+        run_status.snapshot(tmp_path)
+
+        log = (logs_dir / "run-torchtune.log").read_text()
+        assert "ALL_COMPLETE" in log
+        assert "COMPLETED=1" in log
+
+    def test_status_does_not_emit_all_complete_when_jobs_in_flight(
+        self, tmp_path, fake_slurm
+    ):
+        """Don't write ALL_COMPLETE while anything is still PENDING/RUNNING."""
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir()
+        fake_slurm.in_queue["1000"] = "RUNNING"
+        (logs_dir / "run-torchtune.state.json").write_text(
+            json.dumps(
+                {
+                    "rank4/finetune.slurm": {
+                        "job_id": "1000",
+                        "submitted_at": "2026-05-11 14:00:00",
+                        "state": "RUNNING",
+                    }
+                }
+            )
+        )
+
+        run_status.snapshot(tmp_path)
+
+        log_path = logs_dir / "run-torchtune.log"
+        # Log may not even exist if no STATE_CHANGE blocks were written.
+        if log_path.exists():
+            assert "ALL_COMPLETE" not in log_path.read_text()
+
+    def test_status_all_complete_emit_is_idempotent(self, tmp_path, fake_slurm):
+        """Repeated status calls on a finished experiment never duplicate ALL_COMPLETE."""
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir()
+        (logs_dir / "run-torchtune.state.json").write_text(
+            json.dumps(
+                {
+                    "rank4/finetune.slurm": {
+                        "job_id": "1000",
+                        "submitted_at": "2026-05-11 14:00:00",
+                        "state": "COMPLETED",
+                    }
+                }
+            )
+        )
+
+        run_status.snapshot(tmp_path)
+        run_status.snapshot(tmp_path)
+        run_status.snapshot(tmp_path)
+
+        log = (logs_dir / "run-torchtune.log").read_text()
+        assert log.count("ALL_COMPLETE") == 1
+
+    def test_resume_monitor_after_status_emitted_all_complete_no_duplicate(
+        self, tmp_path, fake_slurm, fast_sleep
+    ):
+        """The guard inside log_all_complete also protects --resume-monitor."""
+        _write_finetune_experiment(tmp_path, ["rank4"], include_control=False)
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        (logs_dir / "run-torchtune.state.json").write_text(
+            json.dumps(
+                {
+                    "rank4/finetune.slurm": {
+                        "job_id": "1000",
+                        "submitted_at": "2026-05-11 14:00:00",
+                        "state": "COMPLETED",
+                    }
+                }
+            )
+        )
+
+        # Status writes the first (only) ALL_COMPLETE block.
+        run_status.snapshot(tmp_path)
+        # --resume-monitor would try to emit on exit; guard must skip it.
+        submit_torchtune.run(
+            tmp_path, user="testuser", max_submit=10, resume_monitor=True
+        )
+
+        log = (logs_dir / "run-torchtune.log").read_text()
+        assert log.count("ALL_COMPLETE") == 1

--- a/tests/unit/test_run_experiment_logs.py
+++ b/tests/unit/test_run_experiment_logs.py
@@ -1,0 +1,414 @@
+"""Tests for the run-experiment submitters (#451).
+
+Three responsibilities are exercised:
+
+1. Canonical log shape — every submission writes a 4-line block whose
+   regex round-trips through the analyze-experiment regex anchors at
+   `.claude/skills/analyze-experiment/generation.md:387-388`.
+2. State-file shape and resume — the state key includes the relative path,
+   so eval entries don't collapse onto a single key (the issue #451 comment
+   #2 bug). Atomic write + resume skips already-submitted jobs.
+3. Drip-feed back-pressure — when squeue returns >= MAX_SUBMIT, no
+   submissions until depth drops; 5-second stagger between submissions.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from cruijff_kit.tools.run import _submit_common as common
+from cruijff_kit.tools.run import submit_inspect, submit_torchtune
+
+
+# ---------------------------------------------------------------------------
+# Regexes (must match analyze-experiment/generation.md exactly)
+# ---------------------------------------------------------------------------
+
+SUBMIT_JOB_RE = re.compile(r"SUBMIT_JOB: ([\w.-]+)\n.*?\nJob ID: (\d+)")
+SUBMIT_EVAL_RE = re.compile(r"SUBMIT_EVAL: ([\w./-]+)\n.*?\nJob ID: (\d+)")
+
+
+# ---------------------------------------------------------------------------
+# Mock SLURM
+# ---------------------------------------------------------------------------
+
+
+class FakeSlurm:
+    """Mock-friendly SLURM. sbatch hands out monotonic JIDs; squeue tracks
+    'queued' jobs that the test can advance to terminal state."""
+
+    def __init__(self, queue_depth: int = 0, sbatch_failures: list[str] | None = None):
+        self.next_jid = 1000
+        self.queue_depth = queue_depth
+        self.sbatch_failures = list(
+            sbatch_failures or []
+        )  # slurm names that should fail
+        self.submissions: list[tuple[str, str]] = []  # (cwd_str, slurm_name)
+        self.in_queue: dict[str, str] = {}  # jid -> state ("PENDING"/"RUNNING")
+        self.finished: dict[str, str] = {}  # jid -> terminal state
+
+    def __call__(self, cmd, *args, **kwargs):
+        argv = list(cmd)
+        head = argv[0]
+        if head == "sbatch":
+            return self._sbatch(argv, kwargs)
+        if head == "squeue":
+            return self._squeue(argv)
+        if head == "sacct":
+            return self._sacct(argv)
+        raise AssertionError(f"unexpected subprocess command: {argv}")
+
+    def _result(self, stdout: str = "", stderr: str = "", returncode: int = 0):
+        return subprocess.CompletedProcess(
+            args=[], returncode=returncode, stdout=stdout, stderr=stderr
+        )
+
+    def _sbatch(self, argv, kwargs):
+        slurm_name = argv[-1]
+        cwd = kwargs.get("cwd", "")
+        if slurm_name in self.sbatch_failures:
+            raise subprocess.CalledProcessError(
+                returncode=1,
+                cmd=argv,
+                output="",
+                stderr="Job violates accounting/QOS policy, job not submitted",
+            )
+        jid = str(self.next_jid)
+        self.next_jid += 1
+        self.submissions.append((str(cwd), slurm_name))
+        self.in_queue[jid] = "PENDING"
+        return self._result(stdout=f"{jid}\n")
+
+    def _squeue(self, argv):
+        # Two flavors: `squeue -u <user> -h` (queue depth) or `squeue -j <jid> -h -o %T`
+        if "-u" in argv:
+            return self._result(stdout="x\n" * self.queue_depth)
+        if "-j" in argv:
+            j_idx = argv.index("-j") + 1
+            jid = argv[j_idx]
+            state = self.in_queue.get(jid)
+            return self._result(stdout=(state + "\n") if state else "")
+        return self._result()
+
+    def _sacct(self, argv):
+        j_idx = argv.index("-j") + 1
+        jid = argv[j_idx]
+        state = self.finished.get(jid)
+        return self._result(stdout=(state + "\n") if state else "")
+
+    # Test helpers --------------------------------------------------------
+    def finish_all(self, terminal_state: str = "COMPLETED"):
+        for jid in list(self.in_queue.keys()):
+            self.finished[jid] = terminal_state
+            del self.in_queue[jid]
+
+
+@pytest.fixture
+def fake_slurm(monkeypatch):
+    fs = FakeSlurm(queue_depth=0)
+    monkeypatch.setattr(subprocess, "run", fs)
+    return fs
+
+
+@pytest.fixture
+def fast_sleep(monkeypatch):
+    """Replace time.sleep + the submitters' sleep with a no-op recorder."""
+    calls = []
+    monkeypatch.setattr(common.time, "sleep", lambda s: calls.append(s))
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# Experiment fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _write_finetune_experiment(
+    tmp_path: Path,
+    run_names: list[str],
+    include_control: bool = True,
+) -> Path:
+    summary_runs = []
+    for name in run_names:
+        summary_runs.append({"name": name, "type": "fine-tuned", "model": "x"})
+        run_dir = tmp_path / name
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "finetune.slurm").write_text("#!/bin/bash\n")
+    if include_control:
+        ctrl_name = run_names[0] + "_base"
+        summary_runs.append({"name": ctrl_name, "type": "control", "model": "x"})
+        (tmp_path / ctrl_name).mkdir(parents=True, exist_ok=True)
+        # No finetune.slurm — control runs don't train.
+
+    (tmp_path / "experiment_summary.yaml").write_text(yaml.dump({"runs": summary_runs}))
+    return tmp_path
+
+
+def _write_eval_experiment(
+    tmp_path: Path,
+    runs_with_evals: dict[str, list[str]],
+) -> Path:
+    """`runs_with_evals` maps run_dir name -> list of eval slurm filenames."""
+    for run_name, eval_files in runs_with_evals.items():
+        eval_dir = tmp_path / run_name / "eval"
+        eval_dir.mkdir(parents=True, exist_ok=True)
+        for ef in eval_files:
+            (eval_dir / ef).write_text("#!/bin/bash\n")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# (1) Canonical log shape — regex round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalLogShape:
+    def test_finetune_log_lines_match_analyze_experiment_regex(
+        self, tmp_path, fake_slurm, fast_sleep
+    ):
+        _write_finetune_experiment(tmp_path, ["rank4", "rank8"])
+
+        # Auto-finish jobs as they're submitted so monitor loop exits.
+        original_sbatch = fake_slurm._sbatch
+
+        def sbatch_then_finish(argv, kwargs):
+            r = original_sbatch(argv, kwargs)
+            fake_slurm.finish_all("COMPLETED")
+            return r
+
+        fake_slurm._sbatch = sbatch_then_finish
+
+        submit_torchtune.run(tmp_path, user="testuser", max_submit=10)
+
+        log = (tmp_path / "logs" / "run-torchtune.log").read_text()
+        matches = SUBMIT_JOB_RE.findall(log)
+        names = {m[0] for m in matches}
+        jids = [m[1] for m in matches]
+        assert names == {"rank4", "rank8"}
+        assert all(j.isdigit() for j in jids)
+        # ALL_COMPLETE is emitted at end
+        assert "ALL_COMPLETE" in log
+
+    def test_eval_log_lines_match_analyze_experiment_regex(
+        self, tmp_path, fake_slurm, fast_sleep
+    ):
+        _write_eval_experiment(
+            tmp_path,
+            {
+                "Llama_base": ["capitalization.slurm"],
+                "Llama_rank4": ["capitalization_epoch0.slurm"],
+            },
+        )
+
+        original_sbatch = fake_slurm._sbatch
+
+        def sbatch_then_finish(argv, kwargs):
+            r = original_sbatch(argv, kwargs)
+            fake_slurm.finish_all("COMPLETED")
+            return r
+
+        fake_slurm._sbatch = sbatch_then_finish
+
+        submit_inspect.run(tmp_path, user="testuser", max_submit=10)
+
+        log = (tmp_path / "logs" / "run-inspect.log").read_text()
+        matches = SUBMIT_EVAL_RE.findall(log)
+        names = {m[0] for m in matches}
+        # _eval_name() formatting:
+        assert names == {
+            "Llama_base/capitalization",
+            "Llama_rank4/capitalization/epoch0",
+        }
+
+
+# ---------------------------------------------------------------------------
+# (2) State-file shape and resume
+# ---------------------------------------------------------------------------
+
+
+class TestStateFileShape:
+    def test_state_key_distinguishes_eval_collisions(self, tmp_path):
+        """The bug from issue #451 comment #2: keying by work_dir.name
+        collapsed all eval entries onto 'eval'."""
+        run_a = tmp_path / "run_a" / "eval"
+        run_b = tmp_path / "run_b" / "eval"
+        run_a.mkdir(parents=True)
+        run_b.mkdir(parents=True)
+
+        key_a = common.state_key(run_a, "capitalization.slurm", tmp_path)
+        key_b = common.state_key(run_b, "capitalization.slurm", tmp_path)
+        assert key_a != key_b
+        assert key_a == "run_a/eval/capitalization.slurm"
+        assert key_b == "run_b/eval/capitalization.slurm"
+
+    def test_atomic_write_round_trips(self, tmp_path):
+        path = tmp_path / "state.json"
+        common.write_state_atomic(path, {"k": {"job_id": "1", "state": "RUNNING"}})
+        assert common.read_state(path) == {"k": {"job_id": "1", "state": "RUNNING"}}
+
+    def test_corrupt_state_file_resumes_as_empty(self, tmp_path):
+        path = tmp_path / "state.json"
+        path.write_text("{not valid json")
+        # Treat as empty so resume re-checks SLURM truth instead of crashing.
+        assert common.read_state(path) == {}
+
+    def test_resume_skips_already_submitted_jobs(
+        self, tmp_path, fake_slurm, fast_sleep
+    ):
+        """If state file already has an entry, the submitter must not re-sbatch."""
+        _write_finetune_experiment(tmp_path, ["rank4", "rank8"], include_control=False)
+
+        # Pre-populate state as if rank4 was submitted in a prior run.
+        state_path = tmp_path / "logs" / "run-torchtune.state.json"
+        common.write_state_atomic(
+            state_path,
+            {
+                "rank4/finetune.slurm": {
+                    "job_id": "999",
+                    "submitted_at": "2026-05-08 10:00:00",
+                    "state": "COMPLETED",
+                }
+            },
+        )
+
+        original_sbatch = fake_slurm._sbatch
+
+        def sbatch_then_finish(argv, kwargs):
+            r = original_sbatch(argv, kwargs)
+            fake_slurm.finish_all("COMPLETED")
+            return r
+
+        fake_slurm._sbatch = sbatch_then_finish
+
+        submit_torchtune.run(tmp_path, user="testuser", max_submit=10)
+
+        # Only rank8 should have been submitted; rank4 was already terminal.
+        submitted_slurms = [s[1] for s in fake_slurm.submissions]
+        submitted_dirs = [Path(s[0]).name for s in fake_slurm.submissions]
+        assert submitted_slurms == ["finetune.slurm"]
+        assert submitted_dirs == ["rank8"]
+
+
+# ---------------------------------------------------------------------------
+# (3) Drip-feed back-pressure
+# ---------------------------------------------------------------------------
+
+
+class TestDripFeed:
+    def test_back_pressure_blocks_when_queue_full(
+        self, tmp_path, fake_slurm, fast_sleep
+    ):
+        """If queue_depth >= max_submit, sbatch must not run until queue drains."""
+        _write_finetune_experiment(tmp_path, ["rank4", "rank8"], include_control=False)
+
+        # Start with the queue full (depth == max_submit). Drain on the second
+        # check so the loop can proceed.
+        fake_slurm.queue_depth = 2
+        check_count = {"n": 0}
+        original_squeue = fake_slurm._squeue
+
+        def squeue_drain(argv):
+            if "-u" in argv:
+                check_count["n"] += 1
+                # First poll: full. Subsequent polls: empty.
+                fake_slurm.queue_depth = 0 if check_count["n"] >= 2 else 2
+            return original_squeue(argv)
+
+        fake_slurm._squeue = squeue_drain
+
+        original_sbatch = fake_slurm._sbatch
+
+        def sbatch_then_finish(argv, kwargs):
+            r = original_sbatch(argv, kwargs)
+            fake_slurm.finish_all("COMPLETED")
+            return r
+
+        fake_slurm._sbatch = sbatch_then_finish
+
+        submit_torchtune.run(tmp_path, user="testuser", max_submit=2)
+
+        # Both jobs eventually submitted, but at least one POLL_SEC sleep
+        # happened due to back-pressure.
+        assert len(fake_slurm.submissions) == 2
+        assert any(s == common.DEFAULT_POLL_SEC for s in fast_sleep), (
+            f"expected a {common.DEFAULT_POLL_SEC}s back-pressure sleep, "
+            f"got sleeps {fast_sleep}"
+        )
+
+    def test_stagger_between_submissions(self, tmp_path, fake_slurm, fast_sleep):
+        """5-second stagger after each submission (HF cache race)."""
+        _write_finetune_experiment(tmp_path, ["rank4", "rank8"], include_control=False)
+
+        original_sbatch = fake_slurm._sbatch
+
+        def sbatch_then_finish(argv, kwargs):
+            r = original_sbatch(argv, kwargs)
+            fake_slurm.finish_all("COMPLETED")
+            return r
+
+        fake_slurm._sbatch = sbatch_then_finish
+
+        submit_torchtune.run(tmp_path, user="testuser", max_submit=10)
+
+        stagger_sleeps = [s for s in fast_sleep if s == common.DEFAULT_STAGGER_SEC]
+        assert len(stagger_sleeps) >= 1, (
+            f"expected at least one {common.DEFAULT_STAGGER_SEC}s stagger sleep, "
+            f"got {fast_sleep}"
+        )
+
+    def test_submit_failure_recorded_in_state(self, tmp_path, fake_slurm, fast_sleep):
+        """A QoS-style sbatch failure is captured as SUBMIT_FAILED in state and log."""
+        _write_finetune_experiment(tmp_path, ["rank4"], include_control=False)
+        fake_slurm.sbatch_failures = ["finetune.slurm"]
+
+        submit_torchtune.run(tmp_path, user="testuser", max_submit=10)
+
+        state = json.loads((tmp_path / "logs" / "run-torchtune.state.json").read_text())
+        assert state["rank4/finetune.slurm"]["state"] == "SUBMIT_FAILED"
+        log = (tmp_path / "logs" / "run-torchtune.log").read_text()
+        assert "Result: failure" in log
+        assert "QOS policy" in log
+
+
+# ---------------------------------------------------------------------------
+# (4) End-to-end shape — regression for the eval-collision bug
+# ---------------------------------------------------------------------------
+
+
+class TestEvalCollisionRegression:
+    def test_two_runs_with_same_eval_filename_get_distinct_state_entries(
+        self, tmp_path, fake_slurm, fast_sleep
+    ):
+        """Pre-#451 regression: when two runs each had `eval/capitalization.slurm`,
+        keying by `work_dir.name == 'eval'` collapsed both entries onto one
+        state-file key. Resume after interruption then re-submitted everything
+        as duplicates."""
+        _write_eval_experiment(
+            tmp_path,
+            {
+                "run_a": ["capitalization.slurm"],
+                "run_b": ["capitalization.slurm"],
+            },
+        )
+
+        original_sbatch = fake_slurm._sbatch
+
+        def sbatch_then_finish(argv, kwargs):
+            r = original_sbatch(argv, kwargs)
+            fake_slurm.finish_all("COMPLETED")
+            return r
+
+        fake_slurm._sbatch = sbatch_then_finish
+
+        submit_inspect.run(tmp_path, user="testuser", max_submit=10)
+
+        state = json.loads((tmp_path / "logs" / "run-inspect.state.json").read_text())
+        assert "run_a/eval/capitalization.slurm" in state
+        assert "run_b/eval/capitalization.slurm" in state
+        assert len(state) == 2


### PR DESCRIPTION
Closes #451
Closes #479

# Description

Two scopes, landed on the same branch. The first commit (`4e21e42`) replaces the prose-only execution path of `run-experiment` with callable Python submitters. The second commit (`e3b999a`) makes the resulting watcher *detachable* so overnight / AFK / agent-driven runs can come back to a clean audit trail.

## Scope A — Callable submitters (closes #451)

**Why.** The skill was entirely `.md` — every operational step was prose for the agent to follow, with no Python emitting the `SUBMIT_JOB:` / `Job ID:` lines that the analyze-experiment regex consumes. Combined with Della's gpu-test QoS cap (`MaxSubmitJobsPerUser=25`), this meant: (a) agent-driven submissions wrote narrative logs the regex couldn't parse, so `analyze-experiment` silently skipped the compute section; (b) >25-job experiments crashed with QoS violations because the prose contract didn't enforce drip-feed; (c) eval-side resume occasionally collapsed entries onto a single state-file key when every run's eval workdir was named `eval/`.

**What changed.**

| Layer | Change |
|---|---|
| **New `src/tools/run/` package** | `submit_torchtune.py` + `submit_inspect.py` are CLI entrypoints (also importable for tests). `_submit_common.py` holds shared drip-feed/state/log helpers. |
| **Drip-feed under QoS** | Both submitters poll `squeue -u $USER -h \| wc -l`, sbatch only when `MAX_SUBMIT - depth > 0`. Defaults to 25; override via `MAX_SUBMIT` env var or `--max-submit`. 5-second stagger between submissions on both fine-tune and eval sides (HF datasets cache race). |
| **Canonical log emission** | Both submitters write the 4-line `[<ts>] SUBMIT_JOB: <name>\nDetails: sbatch <slurm>\nJob ID: <jid>\nResult: success` block documented in `.claude/skills/run-experiment/logging.md`, which exactly matches the regex in `analyze-experiment/generation.md:387-388`. |
| **Resume-safe JSON state** | Per-job entry under `logs/run-*.state.json`, atomic write (`.tmp` + rename), keyed by `{work_dir.relative_to(experiment_dir)}/{slurm_name}` to prevent the eval-collision bug. |
| **Loud-warn in analyze-experiment** | New `harvest_jids_from_run_logs()` in `src/tools/slurm/compute_metrics.py` returns `(jids, warnings)`; emits `WARNING:` to stderr when logs are missing or malformed. Skill doc updated to surface a "Compute Utilization unavailable: ..." note in `report.md` instead of silently omitting the section. |
| **Skill docs** | `run-experiment/SKILL.md`, `optimizers/torchtune/main.md`, `evaluators/inspect/main.md` now point at the scripts. Sub-files (parsing/monitoring/etc.) remain as schema descriptions for downstream readers, with the Python as the source of truth. |
| **Workflow tests** | All three workflow_test variants now assert that `logs/run-*.log` contain canonical `SUBMIT_*:` blocks AND that `analysis/report.md` includes the `## Compute Utilization` header after `analyze-experiment` runs. |

## Scope B — Detachable monitoring (closes #479)

**Why.** The submitters from Scope A watch jobs to terminal state in a single foreground process. Fine for short interactive runs, rough for overnight: an agent's monitor loop sits idle for hours and burns context, and there's no graceful way to detach mid-flight without leaving the audit trail in an uncertain shape.

**What changed.** Watching becomes a detachable concern. State file + canonical log blocks remain the durable contract; whether anyone is currently watching becomes ephemeral.

| Mechanism | Who uses it |
|---|---|
| `touch <exp_dir>/logs/.detach` | Anyone with FS access — humans, agents, `/loop`, cron. Sticky: remove it before re-attaching. |
| `SIGINT` (Ctrl+C) | Human at terminal |
| `SIGTERM` | Parent process killing subprocess |

All three converge on the same exit path: flush state → emit canonical `MONITOR_DETACHED` block → print re-attach hint to stderr → exit 0. SLURM jobs are untouched. `time.sleep` is wrapped in `_interruptible_sleep` so detach latency is **sub-second** regardless of the 60s SLURM-refresh cadence.

New entry points:
- `submit_{torchtune,inspect}.py --resume-monitor` — skips the submit phase and re-attaches a watcher to the existing state file. Idempotent.
- `src/tools/run/status.py` — one-shot consolidated read across both submitters. Refreshes from `squeue`/`sacct`, prints a table (or `--json`). Emits a per-tool `ALL_COMPLETE` block when refresh first observes all-terminal so a finished experiment closes its log cleanly without a separate `--resume-monitor` ceremony.

`log_all_complete` is now idempotent (at most one block per per-tool log), which also closes a latent issue where re-invoking `--resume-monitor` on a finished experiment would have written duplicate blocks.

## Tests

26 unit tests passing (12 baseline from Scope A + 14 new in Scope B across `TestDetach`, `TestResumeMonitor`, `TestStatus`).

## New Dependencies

None. Reuses `subprocess`, `json`, `signal`, `yaml`.

# Testing Instructions

- [ ] `pytest tests/unit/test_run_experiment_logs.py tests/unit/test_compute_metrics.py::TestHarvestJidsFromRunLogs -v` → 26+ passed
- [ ] `pytest tests/unit/ --ignore=tests/unit/test_render_quiz.py -q` → no regressions (the ignored file has a pre-existing missing-`markdown` env issue unrelated to this PR)
- [ ] `ruff check src/tools/run/ src/tools/slurm/compute_metrics.py tests/unit/test_run_experiment_logs.py tests/unit/test_compute_metrics.py` → clean
- [ ] `ruff format --check ...` → clean
- [ ] **End-to-end smoke** (recommended): run any workflow_test variant via `design-experiment` → `scaffold-experiment` → invoke the new submitters → `analyze-experiment`, then verify `analysis/report.md` contains a `## Compute Utilization` header and `analysis/compute_metrics.json` exists with one entry per submitted job.
- [ ] **Loud-warn smoke**: from a completed experiment, `rm logs/run-torchtune.log` and re-run `analyze-experiment` → expect `WARNING:` on stderr identifying the missing file, plus a "*Compute Utilization unavailable: ...*" note in `report.md`.
- [ ] **Detach smoke**: kick off `submit_torchtune` in one shell; in another, `touch <exp_dir>/logs/.detach`; expect sub-second graceful exit, `MONITOR_DETACHED` in `logs/run-torchtune.log`, both SLURM jobs still in `squeue`. Then re-attach via `rm <exp_dir>/logs/.detach && python -m cruijff_kit.tools.run.submit_torchtune <exp_dir> --resume-monitor`.
- [ ] **Status smoke**: at any point during or after a run, `python -m cruijff_kit.tools.run.status <exp_dir>` should print a consolidated table (or `--json`); on a finished experiment it should emit `ALL_COMPLETE` exactly once, idempotent across repeated calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

—MxC