### PR TITLE
Live-editable monitor settings file for run-experiment watcher

### DIFF
--- a/.claude/skills/run-experiment/SKILL.md
+++ b/.claude/skills/run-experiment/SKILL.md
@@ -95,17 +95,27 @@ python -m cruijff_kit.tools.run.submit_inspect   <experiment_dir> --resume-monit
 
 `status` is composable with `/loop` (e.g. periodic check-ins from an agent or cron job). It never submits anything and never writes `MONITOR_DETACHED`; it refreshes state, appends `STATE_CHANGE` blocks when SLURM has moved a job since the last refresh, and emits a per-tool `ALL_COMPLETE` block the first time refresh observes all-terminal — so a finished experiment closes its log cleanly without needing a follow-up `--resume-monitor`. `ALL_COMPLETE` is idempotent: at most one block per per-tool log, no matter how many `status` or submitter calls observe completion.
 
-## Live Monitor Settings
+## Tuning Watcher Cadence: monitor.json + Repo Defaults
 
-The watcher re-reads `<experiment_dir>/logs/monitor.json` on every poll iteration so cadence knobs can be tuned mid-run without detach + re-attach. Same filesystem-as-control-plane shape as `.detach` — anyone with FS access (human, agent, `/loop`, cron) can edit.
+The submitter has three numeric knobs:
 
-Recognized keys (all optional):
+| Knob | Built-in | What it controls |
+|---|---|---|
+| `poll_sec` | 60 | Seconds between SLURM state polls |
+| `stagger_sec` | 5 | Delay between successive `sbatch` calls (HF cache race) |
+| `max_submit` | 25 | Cap on simultaneous queued jobs (gpu-test QoS limit) |
+
+Built-in defaults live in `<repo>/.config/config.json`, a tracked file. To change personal defaults across all future experiments, edit that file. If you want to keep local edits out of `git status`, run `git update-index --skip-worktree .config/config.json` once.
+
+For a single experiment, use the CLI flags (`--poll-sec`, `--stagger-sec`, `--max-submit`) at submitter invocation.
+
+For **live mid-run** tuning without detach + re-attach, edit `<experiment_dir>/logs/monitor.json` — the watcher re-reads it on every poll iteration. Same filesystem-as-control-plane shape as `.detach`: anyone with FS access (human, agent, `/loop`, cron) can edit. Recognized keys (all optional):
 
 ```json
 {"poll_sec": 30, "stagger_sec": 5, "max_submit": 25}
 ```
 
-Precedence: `monitor.json` > CLI flag (`--poll-sec` / `--stagger-sec` / `--max-submit`) > env var (`POLL_SEC` / `STAGGER_SEC` / `MAX_SUBMIT`) > built-in default. Missing file is a silent no-op. Malformed JSON or out-of-range values emit a `WARNING:` to stderr and the watcher keeps the previous values. Every applied change writes a canonical `MONITOR_CONFIG` block to the per-tool log.
+**Precedence (high → low):** `monitor.json` > CLI flag > `<repo>/.config/config.json` > built-in default. Missing files are silent no-ops. Malformed JSON or out-of-range values emit a `WARNING:` to stderr and the watcher keeps the previous values. Every applied `monitor.json` change writes a canonical `MONITOR_CONFIG` block to the per-tool log.
 
 **Filesystem control channels under `<experiment_dir>/logs/`:**
 

--- a/.claude/skills/run-experiment/SKILL.md
+++ b/.claude/skills/run-experiment/SKILL.md
@@ -95,6 +95,26 @@ python -m cruijff_kit.tools.run.submit_inspect   <experiment_dir> --resume-monit
 
 `status` is composable with `/loop` (e.g. periodic check-ins from an agent or cron job). It never submits anything and never writes `MONITOR_DETACHED`; it refreshes state, appends `STATE_CHANGE` blocks when SLURM has moved a job since the last refresh, and emits a per-tool `ALL_COMPLETE` block the first time refresh observes all-terminal — so a finished experiment closes its log cleanly without needing a follow-up `--resume-monitor`. `ALL_COMPLETE` is idempotent: at most one block per per-tool log, no matter how many `status` or submitter calls observe completion.
 
+## Live Monitor Settings
+
+The watcher re-reads `<experiment_dir>/logs/monitor.json` on every poll iteration so cadence knobs can be tuned mid-run without detach + re-attach. Same filesystem-as-control-plane shape as `.detach` — anyone with FS access (human, agent, `/loop`, cron) can edit.
+
+Recognized keys (all optional):
+
+```json
+{"poll_sec": 30, "stagger_sec": 5, "max_submit": 25}
+```
+
+Precedence: `monitor.json` > CLI flag (`--poll-sec` / `--stagger-sec` / `--max-submit`) > env var (`POLL_SEC` / `STAGGER_SEC` / `MAX_SUBMIT`) > built-in default. Missing file is a silent no-op. Malformed JSON or out-of-range values emit a `WARNING:` to stderr and the watcher keeps the previous values. Every applied change writes a canonical `MONITOR_CONFIG` block to the per-tool log.
+
+**Filesystem control channels under `<experiment_dir>/logs/`:**
+
+| File | Action | Effect |
+|---|---|---|
+| `.detach` | `touch` | Watcher exits cleanly; jobs continue. Sticky — `rm` it before re-attaching. |
+| `monitor.json` | edit | Adjust `poll_sec` / `stagger_sec` / `max_submit` live. Takes effect on next poll. |
+| `run-*.state.json` | read | Authoritative resume state; produced by the submitters. |
+
 ## Logging
 
 Execution is logged in three files (see logging.md for details).

--- a/.claude/skills/run-experiment/evaluators/inspect/main.md
+++ b/.claude/skills/run-experiment/evaluators/inspect/main.md
@@ -11,10 +11,12 @@ python -m cruijff_kit.tools.run.submit_inspect <experiment_dir>
 The submitter (`src/tools/run/submit_inspect.py`) handles every operational step in code:
 
 1. Globs `*/eval/*.slurm` under the experiment directory.
-2. Drip-feeds `sbatch`, capping concurrency at `--max-submit` (CLI) > `MAX_SUBMIT` (env) > 25 (default). Staggers between submissions at `--stagger-sec` > `STAGGER_SEC` env > 5s default — the HF datasets cache race hits whenever multiple jobs hit `datasets.load_dataset` at once, not just on fine-tunes.
-3. Polls SLURM (`squeue` first, `sacct` fallback) until every job reaches a terminal state, at the configured cadence (`--poll-sec` > `POLL_SEC` env > 60s default).
+2. Drip-feeds `sbatch`, capping concurrency at `max_submit`. Staggers `stagger_sec` between submissions — the HF datasets cache race hits whenever multiple jobs hit `datasets.load_dataset` at once, not just on fine-tunes.
+3. Polls SLURM (`squeue` first, `sacct` fallback) until every job reaches a terminal state, at `poll_sec` cadence.
 4. Emits canonical 4-line `SUBMIT_EVAL:` / `Job ID:` / `Result:` blocks to `logs/run-inspect.log`. The eval-job identifier is `{run_name}/{task}/epoch{N}` (or `{run_name}/{task}` when no epoch suffix exists), matching the regex in `analyze-experiment`'s compute step.
 5. Persists `logs/run-inspect.state.json` keyed by `{run_name}/eval/{slurm_filename}` so distinct runs with the same eval slurm filename don't collide on a single state-file key (the bug from issue #451 comment #2).
+
+The three knobs (`max_submit`, `stagger_sec`, `poll_sec`) resolve in this order: `--max-submit` / `--stagger-sec` / `--poll-sec` (CLI) > `<repo>/.config/config.json` > built-in defaults (25 / 5 / 60).
 
 ## Detach and resume
 
@@ -28,7 +30,7 @@ Or for a one-shot read across both submitters: `python -m cruijff_kit.tools.run.
 
 ## Live monitor settings
 
-The watcher re-reads `<experiment_dir>/logs/monitor.json` on every poll iteration. Any of `poll_sec`, `stagger_sec`, `max_submit` listed there take effect on the next poll, overriding the CLI / env / default values. Changes are recorded as `MONITOR_CONFIG` blocks in the per-tool log. See [the run-experiment skill](../../SKILL.md#live-monitor-settings) for the full precedence chain.
+The watcher re-reads `<experiment_dir>/logs/monitor.json` on every poll iteration. Any of `poll_sec`, `stagger_sec`, `max_submit` listed there take effect on the next poll, overriding the CLI and user-config values. Changes are recorded as `MONITOR_CONFIG` blocks in the per-tool log. See [the run-experiment skill](../../SKILL.md#tuning-watcher-cadence-monitorjson--repo-defaults) for the full precedence chain.
 
 ## Prerequisites
 

--- a/.claude/skills/run-experiment/evaluators/inspect/main.md
+++ b/.claude/skills/run-experiment/evaluators/inspect/main.md
@@ -11,8 +11,8 @@ python -m cruijff_kit.tools.run.submit_inspect <experiment_dir>
 The submitter (`src/tools/run/submit_inspect.py`) handles every operational step in code:
 
 1. Globs `*/eval/*.slurm` under the experiment directory.
-2. Drip-feeds `sbatch`, capping concurrency at `MAX_SUBMIT` (default 25, override via env). The 5-second stagger applies on the eval side too — the HF datasets cache race hits whenever multiple jobs hit `datasets.load_dataset` at once, not just on fine-tunes.
-3. Polls SLURM (`squeue` first, `sacct` fallback) every 60 seconds until every job reaches a terminal state.
+2. Drip-feeds `sbatch`, capping concurrency at `--max-submit` (CLI) > `MAX_SUBMIT` (env) > 25 (default). Staggers between submissions at `--stagger-sec` > `STAGGER_SEC` env > 5s default — the HF datasets cache race hits whenever multiple jobs hit `datasets.load_dataset` at once, not just on fine-tunes.
+3. Polls SLURM (`squeue` first, `sacct` fallback) until every job reaches a terminal state, at the configured cadence (`--poll-sec` > `POLL_SEC` env > 60s default).
 4. Emits canonical 4-line `SUBMIT_EVAL:` / `Job ID:` / `Result:` blocks to `logs/run-inspect.log`. The eval-job identifier is `{run_name}/{task}/epoch{N}` (or `{run_name}/{task}` when no epoch suffix exists), matching the regex in `analyze-experiment`'s compute step.
 5. Persists `logs/run-inspect.state.json` keyed by `{run_name}/eval/{slurm_filename}` so distinct runs with the same eval slurm filename don't collide on a single state-file key (the bug from issue #451 comment #2).
 
@@ -25,6 +25,10 @@ python -m cruijff_kit.tools.run.submit_inspect <experiment_dir> --resume-monitor
 ```
 
 Or for a one-shot read across both submitters: `python -m cruijff_kit.tools.run.status <experiment_dir>`.
+
+## Live monitor settings
+
+The watcher re-reads `<experiment_dir>/logs/monitor.json` on every poll iteration. Any of `poll_sec`, `stagger_sec`, `max_submit` listed there take effect on the next poll, overriding the CLI / env / default values. Changes are recorded as `MONITOR_CONFIG` blocks in the per-tool log. See [the run-experiment skill](../../SKILL.md#live-monitor-settings) for the full precedence chain.
 
 ## Prerequisites
 

--- a/.claude/skills/run-experiment/logging.md
+++ b/.claude/skills/run-experiment/logging.md
@@ -33,6 +33,7 @@ Detailed sub-logs are created during job execution. The orchestration log record
 | `RESOURCE_STATUS` | Report GPU utilization from gpu_metrics.csv during monitoring |
 | `ALL_COMPLETE` | Mark all fine-tuning jobs finished |
 | `MONITOR_DETACHED` | Watcher exited via SIGINT / SIGTERM / sentinel; jobs continue running |
+| `MONITOR_CONFIG` | Watcher applied a live edit from `logs/monitor.json` (poll/stagger/max_submit) |
 
 ### Inspect-ai Actions
 
@@ -54,6 +55,7 @@ Detailed sub-logs are created during job execution. The orchestration log record
 | `RESOURCE_STATUS` | Report GPU utilization from gpu_metrics.csv during monitoring |
 | `ALL_COMPLETE` | Mark all evaluations finished |
 | `MONITOR_DETACHED` | Watcher exited via SIGINT / SIGTERM / sentinel; jobs continue running |
+| `MONITOR_CONFIG` | Watcher applied a live edit from `logs/monitor.json` (poll/stagger/max_submit) |
 
 ---
 
@@ -128,6 +130,21 @@ Result: Training started
 Details: All 4 jobs reached terminal states
 Result: 4 COMPLETED, 0 FAILED
 Duration: 45 minutes
+```
+
+### Live Monitor Settings (MONITOR_CONFIG)
+
+The watcher re-reads `<experiment_dir>/logs/monitor.json` on every poll
+iteration. When at least one knob changes, a `MONITOR_CONFIG` block lands
+in the per-tool log. Unchanged knobs are still shown so the active
+picture is complete. The block contains no `Job ID:` line, so the
+`SUBMIT_JOB:` / `SUBMIT_EVAL:` harvest regex used by `analyze-experiment`
+does not match it.
+
+```
+[2025-11-11 11:30:00] MONITOR_CONFIG: applied
+Details: poll_sec=30 (was 60); stagger_sec=5 (unchanged); max_submit=25 (unchanged)
+Result: settings updated from logs/monitor.json
 ```
 
 ### Inspect-ai Execution

--- a/.claude/skills/run-experiment/optimizers/torchtune/main.md
+++ b/.claude/skills/run-experiment/optimizers/torchtune/main.md
@@ -9,11 +9,13 @@ python -m cruijff_kit.tools.run.submit_torchtune <experiment_dir>
 The submitter (`src/tools/run/submit_torchtune.py`) handles every operational step in code:
 
 1. Parses `experiment_summary.yaml` and discovers fine-tuned runs (skips controls).
-2. Drip-feeds `sbatch` for each run's `finetune.slurm`, capping concurrency at `--max-submit` (CLI flag) > `MAX_SUBMIT` (env var) > 25 (gpu-test QoS default).
-3. Staggers between submissions to dodge the HF datasets cache race (`--stagger-sec` > `STAGGER_SEC` env > 5s default).
-4. Polls SLURM (`squeue` first, `sacct` fallback) until every job reaches a terminal state, at the configured cadence (`--poll-sec` > `POLL_SEC` env > 60s default).
+2. Drip-feeds `sbatch` for each run's `finetune.slurm`, capping concurrency at `max_submit`.
+3. Staggers `stagger_sec` between submissions to dodge the HF datasets cache race.
+4. Polls SLURM (`squeue` first, `sacct` fallback) until every job reaches a terminal state, at `poll_sec` cadence.
 5. Emits the canonical 4-line `SUBMIT_JOB:` / `Job ID:` / `Result:` blocks to `logs/run-torchtune.log` (consumed by `analyze-experiment`'s compute step via `harvest_jids_from_run_logs()` in `tools/slurm/compute_metrics.py`).
 6. Persists `logs/run-torchtune.state.json` for resume after interruption — keyed by `{relative_path}/finetune.slurm` so eval jobs in different runs don't collide.
+
+The three knobs (`max_submit`, `stagger_sec`, `poll_sec`) resolve in this order: `--max-submit` / `--stagger-sec` / `--poll-sec` (CLI) > `<repo>/.config/config.json` > built-in defaults (25 / 5 / 60).
 
 ## Detach and resume
 
@@ -27,7 +29,7 @@ Or for a one-shot read across both submitters: `python -m cruijff_kit.tools.run.
 
 ## Live monitor settings
 
-The watcher re-reads `<experiment_dir>/logs/monitor.json` on every poll iteration. Any of `poll_sec`, `stagger_sec`, `max_submit` listed there take effect on the next poll, overriding the CLI / env / default values. Changes are recorded as `MONITOR_CONFIG` blocks in the per-tool log. See [the run-experiment skill](../../SKILL.md#live-monitor-settings) for the full precedence chain.
+The watcher re-reads `<experiment_dir>/logs/monitor.json` on every poll iteration. Any of `poll_sec`, `stagger_sec`, `max_submit` listed there take effect on the next poll, overriding the CLI and user-config values. Changes are recorded as `MONITOR_CONFIG` blocks in the per-tool log. See [the run-experiment skill](../../SKILL.md#tuning-watcher-cadence-monitorjson--repo-defaults) for the full precedence chain.
 
 ## Prerequisites
 

--- a/.claude/skills/run-experiment/optimizers/torchtune/main.md
+++ b/.claude/skills/run-experiment/optimizers/torchtune/main.md
@@ -9,9 +9,9 @@ python -m cruijff_kit.tools.run.submit_torchtune <experiment_dir>
 The submitter (`src/tools/run/submit_torchtune.py`) handles every operational step in code:
 
 1. Parses `experiment_summary.yaml` and discovers fine-tuned runs (skips controls).
-2. Drip-feeds `sbatch` for each run's `finetune.slurm`, capping concurrency at the `MAX_SUBMIT` env var (default 25, the gpu-test QoS limit).
-3. Staggers 5 seconds between submissions to dodge the HF datasets cache race.
-4. Polls SLURM (`squeue` first, `sacct` fallback) every 60 seconds until every job reaches a terminal state.
+2. Drip-feeds `sbatch` for each run's `finetune.slurm`, capping concurrency at `--max-submit` (CLI flag) > `MAX_SUBMIT` (env var) > 25 (gpu-test QoS default).
+3. Staggers between submissions to dodge the HF datasets cache race (`--stagger-sec` > `STAGGER_SEC` env > 5s default).
+4. Polls SLURM (`squeue` first, `sacct` fallback) until every job reaches a terminal state, at the configured cadence (`--poll-sec` > `POLL_SEC` env > 60s default).
 5. Emits the canonical 4-line `SUBMIT_JOB:` / `Job ID:` / `Result:` blocks to `logs/run-torchtune.log` (consumed by `analyze-experiment`'s compute step via `harvest_jids_from_run_logs()` in `tools/slurm/compute_metrics.py`).
 6. Persists `logs/run-torchtune.state.json` for resume after interruption — keyed by `{relative_path}/finetune.slurm` so eval jobs in different runs don't collide.
 
@@ -24,6 +24,10 @@ python -m cruijff_kit.tools.run.submit_torchtune <experiment_dir> --resume-monit
 ```
 
 Or for a one-shot read across both submitters: `python -m cruijff_kit.tools.run.status <experiment_dir>`.
+
+## Live monitor settings
+
+The watcher re-reads `<experiment_dir>/logs/monitor.json` on every poll iteration. Any of `poll_sec`, `stagger_sec`, `max_submit` listed there take effect on the next poll, overriding the CLI / env / default values. Changes are recorded as `MONITOR_CONFIG` blocks in the per-tool log. See [the run-experiment skill](../../SKILL.md#live-monitor-settings) for the full precedence chain.
 
 ## Prerequisites
 

--- a/.config/config.json
+++ b/.config/config.json
@@ -1,0 +1,5 @@
+{
+  "poll_sec": 60,
+  "stagger_sec": 5,
+  "max_submit": 25
+}

--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,8 @@ inspect.slurm
 
 # Allow generated config files inside test fixtures
 !tests/fixtures/**
+# ...but still ignore pycache anywhere underneath
+tests/fixtures/**/__pycache__/
+tests/fixtures/**/*.pyc
 *G/
 *.eval

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,12 @@ All notable changes to cruijff_kit will be documented in this file.
 - `--resume-monitor` flag on `submit_torchtune` and `submit_inspect` — skips the submit phase and re-attaches a watcher to the existing state file. Idempotent; safe to invoke repeatedly. (#479)
 - `src/tools/run/status.py` — consolidated read-only snapshot command. Reads both state files, refreshes in-flight entries from `squeue`/`sacct`, prints a table (or `--json`). Emits a per-tool `ALL_COMPLETE` block when refresh first observes all-terminal so the pipeline log closes cleanly without a follow-up `--resume-monitor`. Composes with `/loop`, cron, or interactive use. (#479)
 - `log_all_complete()` is now idempotent — at most one `ALL_COMPLETE` block per per-tool log regardless of how many submitters or `status` calls emit it. (#479)
-- Live monitor settings file at `<exp_dir>/logs/monitor.json`. The watcher re-reads it on every poll iteration so `poll_sec`, `stagger_sec`, and `max_submit` can be tuned mid-run without detach + re-attach. Same filesystem-as-control-plane shape as the `.detach` sentinel. New `--poll-sec` / `--stagger-sec` CLI flags + `POLL_SEC` / `STAGGER_SEC` env vars on both submitters. Precedence: file > CLI > env > default. Bad values warn-and-skip; missing file is a silent no-op. Each applied change emits a `MONITOR_CONFIG` block to the per-tool log. (#480)
+- Two layers of submitter-knob configuration for `poll_sec`, `stagger_sec`, `max_submit` (#480):
+  - **Per-checkout defaults** at `<repo>/.config/config.json`, a tracked file shipping with the built-in values visible. Power users edit it to change defaults across all future experiments; `git update-index --skip-worktree .config/config.json` keeps local edits out of `git status`.
+  - **Live mid-run overrides** at `<exp_dir>/logs/monitor.json`. The watcher re-reads it on every poll iteration. Same filesystem-as-control-plane shape as the `.detach` sentinel.
+  - New `--poll-sec` / `--stagger-sec` CLI flags on both submitters (alongside the existing `--max-submit`).
+  - Precedence: `monitor.json` > CLI flag > `<repo>/.config/config.json` > built-in default. Bad values warn-and-skip; missing files are silent no-ops. Each applied `monitor.json` change emits a `MONITOR_CONFIG` block to the per-tool log.
+  - Removed the previously-supported `MAX_SUBMIT` / `POLL_SEC` / `STAGGER_SEC` env vars in favor of the user-config file. None had been documented or set anywhere in the repo.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to cruijff_kit will be documented in this file.
 - `--resume-monitor` flag on `submit_torchtune` and `submit_inspect` — skips the submit phase and re-attaches a watcher to the existing state file. Idempotent; safe to invoke repeatedly. (#479)
 - `src/tools/run/status.py` — consolidated read-only snapshot command. Reads both state files, refreshes in-flight entries from `squeue`/`sacct`, prints a table (or `--json`). Emits a per-tool `ALL_COMPLETE` block when refresh first observes all-terminal so the pipeline log closes cleanly without a follow-up `--resume-monitor`. Composes with `/loop`, cron, or interactive use. (#479)
 - `log_all_complete()` is now idempotent — at most one `ALL_COMPLETE` block per per-tool log regardless of how many submitters or `status` calls emit it. (#479)
+- Live monitor settings file at `<exp_dir>/logs/monitor.json`. The watcher re-reads it on every poll iteration so `poll_sec`, `stagger_sec`, and `max_submit` can be tuned mid-run without detach + re-attach. Same filesystem-as-control-plane shape as the `.detach` sentinel. New `--poll-sec` / `--stagger-sec` CLI flags + `POLL_SEC` / `STAGGER_SEC` env vars on both submitters. Precedence: file > CLI > env > default. Bad values warn-and-skip; missing file is a silent no-op. Each applied change emits a `MONITOR_CONFIG` block to the per-tool log. (#480)
 
 ### Changed
 

--- a/docs/ARTIFACT_LOCATIONS.md
+++ b/docs/ARTIFACT_LOCATIONS.md
@@ -23,6 +23,7 @@ Each experiment lives in a single self-contained directory. The root contains th
 │   ├── run-inspect.log
 │   ├── run-inspect.state.json   # Submitter resume state (JSON)
 │   ├── .detach                  # Optional sentinel — touch to detach the watcher
+│   ├── monitor.json             # Optional live settings (poll_sec / stagger_sec / max_submit)
 │   ├── summarize-experiment.log
 │   └── analyze-experiment.log
 ├── {run_name}/                  # Self-contained per-run directory (one per run)

--- a/src/tools/run/_submit_common.py
+++ b/src/tools/run/_submit_common.py
@@ -318,15 +318,29 @@ def log_monitor_config(
 
 
 # ---------------------------------------------------------------------------
-# Live monitor settings (logs/monitor.json)
+# Monitor-knob configuration: user config (<repo>/.config/config.json) and
+# live overrides (<exp_dir>/logs/monitor.json)
 # ---------------------------------------------------------------------------
 #
-# The watcher re-reads this file on every poll iteration so `poll_sec`,
-# `stagger_sec`, and `max_submit` can be tuned mid-run without detach +
-# re-attach. Same filesystem-as-control-plane shape as the `.detach`
-# sentinel — anyone with FS access (human, agent, /loop, cron) can edit.
+# Two filesystem-as-control-plane files share the same JSON schema and the
+# same validator:
 #
-# Precedence: monitor.json > CLI flag > env var > built-in default.
+#   <repo>/.config/config.json    — per-checkout user defaults. Read once
+#                                   per process. Power-user territory; ships
+#                                   with the built-in defaults visible.
+#
+#   <exp_dir>/logs/monitor.json   — live overrides for a single run. The
+#                                   watcher re-reads this on every poll
+#                                   iteration so cadence can be tuned mid-run
+#                                   without detach + re-attach.
+#
+# Final precedence (high → low):
+#   monitor.json  >  CLI flag  >  <repo>/.config/config.json  >  built-in default
+
+# Repo root from this file's location: src/tools/run/_submit_common.py -> .. .. .. .
+_USER_CONFIG_PATH = Path(__file__).resolve().parents[3] / ".config" / "config.json"
+_user_config_loaded = False
+_user_config_cache: dict = {}
 
 
 def monitor_config_path(log_path: Path) -> Path:
@@ -337,10 +351,11 @@ def monitor_config_path(log_path: Path) -> Path:
 def _validate_monitor_value(
     key: str, raw: object
 ) -> tuple[bool, float | int | None, str | None]:
-    """Coerce + validate a single monitor.json entry.
+    """Coerce + validate a single monitor-knob entry.
 
     Returns `(ok, coerced_value, error_msg)`. On failure, `coerced_value`
     is None and `error_msg` describes the problem suitable for a warning.
+    Shared between `<repo>/.config/config.json` and `logs/monitor.json`.
     """
     if key in ("poll_sec", "stagger_sec"):
         if isinstance(raw, bool) or not isinstance(raw, (int, float)):
@@ -364,14 +379,13 @@ def _validate_monitor_value(
     return False, None, f"unknown key {key!r}"
 
 
-def _load_monitor_config(log_path: Path) -> tuple[dict, list[str]]:
-    """Read + validate logs/monitor.json. Never raises.
+def _read_validated_config(path: Path) -> tuple[dict, list[str]]:
+    """Read + validate a monitor-knobs JSON file. Never raises.
 
     Returns `(overrides, warnings)`. `overrides` contains only valid,
-    recognized keys with coerced values; `warnings` lists problems
-    suitable for stderr. Missing file -> ({}, []).
+    recognized keys; `warnings` lists problems suitable for stderr.
+    Missing file -> ({}, []) so callers can no-op silently.
     """
-    path = monitor_config_path(log_path)
     if not path.exists():
         return {}, []
     try:
@@ -397,6 +411,35 @@ def _load_monitor_config(log_path: Path) -> tuple[dict, list[str]]:
             continue
         overrides[key] = val
     return overrides, warnings
+
+
+def _load_monitor_config(log_path: Path) -> tuple[dict, list[str]]:
+    """Read + validate the per-run logs/monitor.json. Never raises."""
+    return _read_validated_config(monitor_config_path(log_path))
+
+
+def _load_user_config() -> dict:
+    """Read + validate <repo>/.config/config.json once per process.
+
+    Cached after first successful load. Warnings (malformed JSON, bad
+    values, unknown keys) print to stderr on the first call only.
+    """
+    global _user_config_loaded, _user_config_cache
+    if _user_config_loaded:
+        return _user_config_cache
+    overrides, warnings = _read_validated_config(_USER_CONFIG_PATH)
+    for w in warnings:
+        print(f"WARNING: {w}", file=sys.stderr)
+    _user_config_cache = overrides
+    _user_config_loaded = True
+    return _user_config_cache
+
+
+def _reset_user_config_cache() -> None:
+    """Test helper: drop the process-wide user-config cache."""
+    global _user_config_loaded, _user_config_cache
+    _user_config_loaded = False
+    _user_config_cache = {}
 
 
 def _refresh_monitor_config(cfg: _SubmitConfig) -> None:
@@ -530,9 +573,13 @@ def submit_and_monitor(
     Resumable: existing entries in the state file with terminal state are skipped.
 
     Honors:
-    - `max_submit` queue-depth cap (gpu-test default = 25; override via env or arg).
+    - `max_submit` queue-depth cap (gpu-test default = 25).
     - `stagger_sec` between submissions (HF datasets cache race).
     - `poll_sec` when waiting for queue room or for in-flight jobs.
+
+    All three can be overridden mid-run via `<exp_dir>/logs/monitor.json`.
+    Static defaults read from `<repo>/.config/config.json`; see the
+    resolve_* helpers and the run-experiment SKILL for the precedence chain.
     """
     cfg = _SubmitConfig(
         log_path=log_path,
@@ -811,43 +858,25 @@ def resolve_user(cli_user: str | None) -> str:
 def resolve_max_submit(cli_max: int | None) -> int:
     if cli_max is not None:
         return cli_max
-    env = os.environ.get("MAX_SUBMIT")
-    if env:
-        try:
-            return int(env)
-        except ValueError:
-            print(
-                f"WARNING: ignoring non-integer MAX_SUBMIT env var: {env!r}",
-                file=sys.stderr,
-            )
+    user_val = _load_user_config().get("max_submit")
+    if user_val is not None:
+        return user_val
     return DEFAULT_MAX_SUBMIT
 
 
 def resolve_poll_sec(cli_poll: float | None) -> float:
     if cli_poll is not None:
         return cli_poll
-    env = os.environ.get("POLL_SEC")
-    if env:
-        try:
-            return float(env)
-        except ValueError:
-            print(
-                f"WARNING: ignoring non-numeric POLL_SEC env var: {env!r}",
-                file=sys.stderr,
-            )
+    user_val = _load_user_config().get("poll_sec")
+    if user_val is not None:
+        return user_val
     return DEFAULT_POLL_SEC
 
 
 def resolve_stagger_sec(cli_stagger: float | None) -> float:
     if cli_stagger is not None:
         return cli_stagger
-    env = os.environ.get("STAGGER_SEC")
-    if env:
-        try:
-            return float(env)
-        except ValueError:
-            print(
-                f"WARNING: ignoring non-numeric STAGGER_SEC env var: {env!r}",
-                file=sys.stderr,
-            )
+    user_val = _load_user_config().get("stagger_sec")
+    if user_val is not None:
+        return user_val
     return DEFAULT_STAGGER_SEC

--- a/src/tools/run/_submit_common.py
+++ b/src/tools/run/_submit_common.py
@@ -29,7 +29,7 @@ import signal
 import subprocess
 import sys
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Iterable
@@ -332,7 +332,9 @@ def log_monitor_config(
 #   <exp_dir>/logs/monitor.json   — live overrides for a single run. The
 #                                   watcher re-reads this on every poll
 #                                   iteration so cadence can be tuned mid-run
-#                                   without detach + re-attach.
+#                                   without detach + re-attach. Removing the
+#                                   file reverts each knob to its startup
+#                                   baseline (the next-lower layer).
 #
 # Final precedence (high → low):
 #   monitor.json  >  CLI flag  >  <repo>/.config/config.json  >  built-in default
@@ -443,17 +445,26 @@ def _reset_user_config_cache() -> None:
 
 
 def _refresh_monitor_config(cfg: _SubmitConfig) -> None:
-    """Re-read monitor.json and apply overrides to `cfg` in place.
+    """Re-read monitor.json and reconcile `cfg` against it in place.
 
-    - Silent on missing file.
-    - Warns to stderr (not the run log) on malformed file / bad values
-      and keeps previously-applied values.
+    - File missing → revert each knob to its startup baseline
+      (CLI / <repo>/.config/config.json / built-in default). A
+      MONITOR_CONFIG block fires for any knob that actually changes.
+    - File present → apply overrides; bad values warn to stderr and keep
+      the previously-applied value (sticky for that knob).
     - Emits a MONITOR_CONFIG block to the run log only when at least one
-      knob actually changes value.
+      knob actually changes value (including a revert on file removal).
     """
+    config_path = monitor_config_path(cfg.log_path)
+    file_missing = not config_path.exists()
+
     overrides, warnings = _load_monitor_config(cfg.log_path)
     for w in warnings:
         print(f"WARNING: {w}", file=sys.stderr)
+
+    if file_missing:
+        # Treat absent file as "no overrides anywhere" → revert all knobs.
+        overrides = dict(cfg._baseline)
 
     changes: dict = {}
     for knob in _MONITOR_KNOBS:
@@ -550,6 +561,12 @@ class _SubmitConfig:
     max_submit: int = DEFAULT_MAX_SUBMIT
     stagger_sec: float = DEFAULT_STAGGER_SEC
     poll_sec: float = DEFAULT_POLL_SEC
+    # Startup snapshot of the monitor knobs (CLI / config.json / default). Used
+    # as the revert target when monitor.json is removed mid-run.
+    _baseline: dict = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._baseline = {knob: getattr(self, knob) for knob in _MONITOR_KNOBS}
 
 
 def submit_and_monitor(

--- a/src/tools/run/_submit_common.py
+++ b/src/tools/run/_submit_common.py
@@ -38,6 +38,9 @@ DEFAULT_MAX_SUBMIT = 25  # Della gpu-test QoS cap on MaxSubmitJobsPerUser
 DEFAULT_STAGGER_SEC = 5  # avoids HF datasets cache race when jobs land at once
 DEFAULT_POLL_SEC = 60
 
+MONITOR_CONFIG_NAME = "monitor.json"
+_MONITOR_KNOBS = ("poll_sec", "stagger_sec", "max_submit")
+
 TERMINAL_STATES = {
     "COMPLETED",
     "FAILED",
@@ -278,6 +281,150 @@ def log_monitor_detached(log_path: Path, reason: str, summary: dict) -> None:
         f"Result: monitoring paused; jobs continue"
     )
     append_log(log_path, block)
+
+
+def log_monitor_config(
+    log_path: Path,
+    current: dict,
+    changes: dict,
+) -> None:
+    """Canonical 'live monitor settings applied' block.
+
+    `current` is the post-update view of all three knobs (poll_sec,
+    stagger_sec, max_submit). `changes` maps knob -> prior value for the
+    ones that actually changed in this refresh. Unchanged knobs are still
+    shown so an operator reading the log sees the full active picture.
+
+    Block shape (no `Job ID:` line — safe from the analyze-experiment
+    SUBMIT_JOB/SUBMIT_EVAL harvest regex):
+
+        [YYYY-MM-DD HH:MM:SS] MONITOR_CONFIG: applied
+        Details: poll_sec=30 (was 60); stagger_sec=5 (unchanged); max_submit=25 (unchanged)
+        Result: settings updated from logs/monitor.json
+    """
+    parts = []
+    for knob in _MONITOR_KNOBS:
+        val = current[knob]
+        if knob in changes:
+            parts.append(f"{knob}={val} (was {changes[knob]})")
+        else:
+            parts.append(f"{knob}={val} (unchanged)")
+    block = (
+        f"[{_now()}] MONITOR_CONFIG: applied\n"
+        f"Details: {'; '.join(parts)}\n"
+        f"Result: settings updated from logs/{MONITOR_CONFIG_NAME}"
+    )
+    append_log(log_path, block)
+
+
+# ---------------------------------------------------------------------------
+# Live monitor settings (logs/monitor.json)
+# ---------------------------------------------------------------------------
+#
+# The watcher re-reads this file on every poll iteration so `poll_sec`,
+# `stagger_sec`, and `max_submit` can be tuned mid-run without detach +
+# re-attach. Same filesystem-as-control-plane shape as the `.detach`
+# sentinel — anyone with FS access (human, agent, /loop, cron) can edit.
+#
+# Precedence: monitor.json > CLI flag > env var > built-in default.
+
+
+def monitor_config_path(log_path: Path) -> Path:
+    """The live-settings file lives next to the per-tool log files."""
+    return log_path.parent / MONITOR_CONFIG_NAME
+
+
+def _validate_monitor_value(
+    key: str, raw: object
+) -> tuple[bool, float | int | None, str | None]:
+    """Coerce + validate a single monitor.json entry.
+
+    Returns `(ok, coerced_value, error_msg)`. On failure, `coerced_value`
+    is None and `error_msg` describes the problem suitable for a warning.
+    """
+    if key in ("poll_sec", "stagger_sec"):
+        if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+            return False, None, f"{key} must be a number, got {type(raw).__name__}"
+        # Preserve int vs float so the log block prints cleanly (10 not 10.0).
+        if key == "poll_sec" and raw <= 0:
+            return False, None, f"poll_sec must be > 0, got {raw}"
+        if key == "stagger_sec" and raw < 0:
+            return False, None, f"stagger_sec must be >= 0, got {raw}"
+        return True, raw, None
+    if key == "max_submit":
+        if isinstance(raw, bool) or not isinstance(raw, int):
+            return (
+                False,
+                None,
+                f"max_submit must be an integer, got {type(raw).__name__}",
+            )
+        if raw < 1:
+            return False, None, f"max_submit must be >= 1, got {raw}"
+        return True, raw, None
+    return False, None, f"unknown key {key!r}"
+
+
+def _load_monitor_config(log_path: Path) -> tuple[dict, list[str]]:
+    """Read + validate logs/monitor.json. Never raises.
+
+    Returns `(overrides, warnings)`. `overrides` contains only valid,
+    recognized keys with coerced values; `warnings` lists problems
+    suitable for stderr. Missing file -> ({}, []).
+    """
+    path = monitor_config_path(log_path)
+    if not path.exists():
+        return {}, []
+    try:
+        raw = path.read_text()
+    except OSError as e:
+        return {}, [f"could not read {path}: {e}"]
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        return {}, [f"{path} is not valid JSON ({e.msg}); keeping previous values"]
+    if not isinstance(data, dict):
+        return {}, [f"{path} must be a JSON object; keeping previous values"]
+
+    overrides: dict = {}
+    warnings: list[str] = []
+    for key, raw_val in data.items():
+        if key not in _MONITOR_KNOBS:
+            warnings.append(f"{path}: ignoring unknown key {key!r}")
+            continue
+        ok, val, err = _validate_monitor_value(key, raw_val)
+        if not ok:
+            warnings.append(f"{path}: {err}; keeping previous value")
+            continue
+        overrides[key] = val
+    return overrides, warnings
+
+
+def _refresh_monitor_config(cfg: _SubmitConfig) -> None:
+    """Re-read monitor.json and apply overrides to `cfg` in place.
+
+    - Silent on missing file.
+    - Warns to stderr (not the run log) on malformed file / bad values
+      and keeps previously-applied values.
+    - Emits a MONITOR_CONFIG block to the run log only when at least one
+      knob actually changes value.
+    """
+    overrides, warnings = _load_monitor_config(cfg.log_path)
+    for w in warnings:
+        print(f"WARNING: {w}", file=sys.stderr)
+
+    changes: dict = {}
+    for knob in _MONITOR_KNOBS:
+        if knob not in overrides:
+            continue
+        new_val = overrides[knob]
+        old_val = getattr(cfg, knob)
+        if new_val != old_val:
+            changes[knob] = old_val
+            setattr(cfg, knob, new_val)
+
+    if changes:
+        current = {knob: getattr(cfg, knob) for knob in _MONITOR_KNOBS}
+        log_monitor_config(cfg.log_path, current, changes)
 
 
 # ---------------------------------------------------------------------------
@@ -568,6 +715,10 @@ def _drip_feed_submit(
 ) -> dict:
     todo = list(pending)
     while todo:
+        # Pick up any live monitor.json edits before this iteration's
+        # back-pressure check / batch sizing.
+        _refresh_monitor_config(cfg)
+
         # Detach check before any further submission work.
         detached, _ = detach_requested(cfg.log_path)
         if detached:
@@ -614,6 +765,10 @@ def _drip_feed_submit(
             write_state_atomic(cfg.state_path, state)
 
             if todo or i < batch - 1:
+                # Refresh inside the batch too so a long batch picks up
+                # stagger / max_submit edits without waiting for the next
+                # outer iteration.
+                _refresh_monitor_config(cfg)
                 if _interruptible_sleep(cfg.stagger_sec, cfg.log_path):
                     return state
     return state
@@ -621,6 +776,7 @@ def _drip_feed_submit(
 
 def _monitor_to_terminal(state: dict, cfg: _SubmitConfig) -> dict:
     while not _all_terminal(state):
+        _refresh_monitor_config(cfg)
         if _interruptible_sleep(cfg.poll_sec, cfg.log_path):
             return state
         state = _refresh_in_flight_state(state, cfg.log_path)
@@ -665,3 +821,33 @@ def resolve_max_submit(cli_max: int | None) -> int:
                 file=sys.stderr,
             )
     return DEFAULT_MAX_SUBMIT
+
+
+def resolve_poll_sec(cli_poll: float | None) -> float:
+    if cli_poll is not None:
+        return cli_poll
+    env = os.environ.get("POLL_SEC")
+    if env:
+        try:
+            return float(env)
+        except ValueError:
+            print(
+                f"WARNING: ignoring non-numeric POLL_SEC env var: {env!r}",
+                file=sys.stderr,
+            )
+    return DEFAULT_POLL_SEC
+
+
+def resolve_stagger_sec(cli_stagger: float | None) -> float:
+    if cli_stagger is not None:
+        return cli_stagger
+    env = os.environ.get("STAGGER_SEC")
+    if env:
+        try:
+            return float(env)
+        except ValueError:
+            print(
+                f"WARNING: ignoring non-numeric STAGGER_SEC env var: {env!r}",
+                file=sys.stderr,
+            )
+    return DEFAULT_STAGGER_SEC

--- a/src/tools/run/status.py
+++ b/src/tools/run/status.py
@@ -14,6 +14,11 @@ Does NOT submit anything and does not write `MONITOR_DETACHED` or
 any cadence — and the refresh keeps the run logs alive even when no
 monitor is currently attached.
 
+Note: this snapshot is one-shot and doesn't poll, so it doesn't read
+`logs/monitor.json`. That file affects the live watchers
+(`submit_torchtune` / `submit_inspect`); see the run-experiment skill
+for details.
+
 Usage:
     python -m cruijff_kit.tools.run.status <experiment_dir>
     python -m cruijff_kit.tools.run.status <experiment_dir> --json

--- a/src/tools/run/submit_inspect.py
+++ b/src/tools/run/submit_inspect.py
@@ -86,7 +86,7 @@ def run(
     (SIGINT / SIGTERM / sentinel) to pick up monitoring without resubmitting.
 
     Precedence for max_submit / poll_sec / stagger_sec: logs/monitor.json
-    > CLI flag > env var (MAX_SUBMIT / POLL_SEC / STAGGER_SEC) > default.
+    > CLI flag > <repo>/.config/config.json > built-in default.
     """
     experiment_dir = experiment_dir.resolve()
     log_path = experiment_dir / "logs" / LOG_NAME
@@ -130,22 +130,25 @@ def main(argv: list[str] | None = None) -> int:
         "--max-submit",
         type=int,
         default=None,
-        help="Cap on concurrent submissions (default: 25, override via MAX_SUBMIT env "
-        "or logs/monitor.json).",
+        help="Cap on concurrent submissions for this run only. Defaults are "
+        "set in <repo>/.config/config.json (built-in: 25). Live mid-run "
+        "override via <exp_dir>/logs/monitor.json.",
     )
     parser.add_argument(
         "--poll-sec",
         type=float,
         default=None,
-        help="Poll interval in seconds (default: 60, override via POLL_SEC env "
-        "or logs/monitor.json).",
+        help="Poll interval in seconds for this run only. Defaults are set "
+        "in <repo>/.config/config.json (built-in: 60). Live mid-run "
+        "override via <exp_dir>/logs/monitor.json.",
     )
     parser.add_argument(
         "--stagger-sec",
         type=float,
         default=None,
-        help="Stagger between submissions in seconds (default: 5, override via "
-        "STAGGER_SEC env or logs/monitor.json).",
+        help="Stagger between submissions in seconds for this run only. "
+        "Defaults are set in <repo>/.config/config.json (built-in: 5). "
+        "Live mid-run override via <exp_dir>/logs/monitor.json.",
     )
     parser.add_argument(
         "--resume-monitor",

--- a/src/tools/run/submit_inspect.py
+++ b/src/tools/run/submit_inspect.py
@@ -29,6 +29,8 @@ from cruijff_kit.tools.run._submit_common import (
     TodoItem,
     monitor_only,
     resolve_max_submit,
+    resolve_poll_sec,
+    resolve_stagger_sec,
     resolve_user,
     submit_and_monitor,
 )
@@ -73,6 +75,8 @@ def run(
     experiment_dir: Path,
     user: str | None = None,
     max_submit: int | None = None,
+    poll_sec: float | None = None,
+    stagger_sec: float | None = None,
     resume_monitor: bool = False,
 ) -> dict:
     """Programmatic entrypoint (also used by tests).
@@ -80,6 +84,9 @@ def run(
     `resume_monitor=True` skips the submission phase entirely and re-attaches
     a watcher to the existing state file. Useful after a clean detach
     (SIGINT / SIGTERM / sentinel) to pick up monitoring without resubmitting.
+
+    Precedence for max_submit / poll_sec / stagger_sec: logs/monitor.json
+    > CLI flag > env var (MAX_SUBMIT / POLL_SEC / STAGGER_SEC) > default.
     """
     experiment_dir = experiment_dir.resolve()
     log_path = experiment_dir / "logs" / LOG_NAME
@@ -93,6 +100,8 @@ def run(
             user=resolve_user(user),
             experiment_dir=experiment_dir,
             max_submit=resolve_max_submit(max_submit),
+            poll_sec=resolve_poll_sec(poll_sec),
+            stagger_sec=resolve_stagger_sec(stagger_sec),
         )
 
     todo = _build_todo(experiment_dir)
@@ -104,6 +113,8 @@ def run(
         user=resolve_user(user),
         experiment_dir=experiment_dir,
         max_submit=resolve_max_submit(max_submit),
+        poll_sec=resolve_poll_sec(poll_sec),
+        stagger_sec=resolve_stagger_sec(stagger_sec),
     )
 
 
@@ -119,7 +130,22 @@ def main(argv: list[str] | None = None) -> int:
         "--max-submit",
         type=int,
         default=None,
-        help="Cap on concurrent submissions (default: 25, override via MAX_SUBMIT env).",
+        help="Cap on concurrent submissions (default: 25, override via MAX_SUBMIT env "
+        "or logs/monitor.json).",
+    )
+    parser.add_argument(
+        "--poll-sec",
+        type=float,
+        default=None,
+        help="Poll interval in seconds (default: 60, override via POLL_SEC env "
+        "or logs/monitor.json).",
+    )
+    parser.add_argument(
+        "--stagger-sec",
+        type=float,
+        default=None,
+        help="Stagger between submissions in seconds (default: 5, override via "
+        "STAGGER_SEC env or logs/monitor.json).",
     )
     parser.add_argument(
         "--resume-monitor",
@@ -133,6 +159,8 @@ def main(argv: list[str] | None = None) -> int:
         args.experiment_dir,
         user=args.user,
         max_submit=args.max_submit,
+        poll_sec=args.poll_sec,
+        stagger_sec=args.stagger_sec,
         resume_monitor=args.resume_monitor,
     )
     print(f"Done. Terminal-state breakdown: {summary}")

--- a/src/tools/run/submit_torchtune.py
+++ b/src/tools/run/submit_torchtune.py
@@ -29,6 +29,8 @@ from cruijff_kit.tools.run._submit_common import (
     TodoItem,
     monitor_only,
     resolve_max_submit,
+    resolve_poll_sec,
+    resolve_stagger_sec,
     resolve_user,
     submit_and_monitor,
 )
@@ -75,6 +77,8 @@ def run(
     experiment_dir: Path,
     user: str | None = None,
     max_submit: int | None = None,
+    poll_sec: float | None = None,
+    stagger_sec: float | None = None,
     resume_monitor: bool = False,
 ) -> dict:
     """Programmatic entrypoint (also used by tests).
@@ -82,6 +86,9 @@ def run(
     `resume_monitor=True` skips the submission phase entirely and re-attaches
     a watcher to the existing state file. Useful after a clean detach
     (SIGINT / SIGTERM / sentinel) to pick up monitoring without resubmitting.
+
+    Precedence for max_submit / poll_sec / stagger_sec: logs/monitor.json
+    > CLI flag > env var (MAX_SUBMIT / POLL_SEC / STAGGER_SEC) > default.
     """
     experiment_dir = experiment_dir.resolve()
     log_path = experiment_dir / "logs" / LOG_NAME
@@ -95,6 +102,8 @@ def run(
             user=resolve_user(user),
             experiment_dir=experiment_dir,
             max_submit=resolve_max_submit(max_submit),
+            poll_sec=resolve_poll_sec(poll_sec),
+            stagger_sec=resolve_stagger_sec(stagger_sec),
         )
 
     todo = _build_todo(experiment_dir)
@@ -106,6 +115,8 @@ def run(
         user=resolve_user(user),
         experiment_dir=experiment_dir,
         max_submit=resolve_max_submit(max_submit),
+        poll_sec=resolve_poll_sec(poll_sec),
+        stagger_sec=resolve_stagger_sec(stagger_sec),
     )
 
 
@@ -121,7 +132,22 @@ def main(argv: list[str] | None = None) -> int:
         "--max-submit",
         type=int,
         default=None,
-        help="Cap on concurrent submissions (default: 25, override via MAX_SUBMIT env).",
+        help="Cap on concurrent submissions (default: 25, override via MAX_SUBMIT env "
+        "or logs/monitor.json).",
+    )
+    parser.add_argument(
+        "--poll-sec",
+        type=float,
+        default=None,
+        help="Poll interval in seconds (default: 60, override via POLL_SEC env "
+        "or logs/monitor.json).",
+    )
+    parser.add_argument(
+        "--stagger-sec",
+        type=float,
+        default=None,
+        help="Stagger between submissions in seconds (default: 5, override via "
+        "STAGGER_SEC env or logs/monitor.json).",
     )
     parser.add_argument(
         "--resume-monitor",
@@ -135,6 +161,8 @@ def main(argv: list[str] | None = None) -> int:
         args.experiment_dir,
         user=args.user,
         max_submit=args.max_submit,
+        poll_sec=args.poll_sec,
+        stagger_sec=args.stagger_sec,
         resume_monitor=args.resume_monitor,
     )
     print(f"Done. Terminal-state breakdown: {summary}")

--- a/src/tools/run/submit_torchtune.py
+++ b/src/tools/run/submit_torchtune.py
@@ -88,7 +88,7 @@ def run(
     (SIGINT / SIGTERM / sentinel) to pick up monitoring without resubmitting.
 
     Precedence for max_submit / poll_sec / stagger_sec: logs/monitor.json
-    > CLI flag > env var (MAX_SUBMIT / POLL_SEC / STAGGER_SEC) > default.
+    > CLI flag > <repo>/.config/config.json > built-in default.
     """
     experiment_dir = experiment_dir.resolve()
     log_path = experiment_dir / "logs" / LOG_NAME
@@ -132,22 +132,25 @@ def main(argv: list[str] | None = None) -> int:
         "--max-submit",
         type=int,
         default=None,
-        help="Cap on concurrent submissions (default: 25, override via MAX_SUBMIT env "
-        "or logs/monitor.json).",
+        help="Cap on concurrent submissions for this run only. Defaults are "
+        "set in <repo>/.config/config.json (built-in: 25). Live mid-run "
+        "override via <exp_dir>/logs/monitor.json.",
     )
     parser.add_argument(
         "--poll-sec",
         type=float,
         default=None,
-        help="Poll interval in seconds (default: 60, override via POLL_SEC env "
-        "or logs/monitor.json).",
+        help="Poll interval in seconds for this run only. Defaults are set "
+        "in <repo>/.config/config.json (built-in: 60). Live mid-run "
+        "override via <exp_dir>/logs/monitor.json.",
     )
     parser.add_argument(
         "--stagger-sec",
         type=float,
         default=None,
-        help="Stagger between submissions in seconds (default: 5, override via "
-        "STAGGER_SEC env or logs/monitor.json).",
+        help="Stagger between submissions in seconds for this run only. "
+        "Defaults are set in <repo>/.config/config.json (built-in: 5). "
+        "Live mid-run override via <exp_dir>/logs/monitor.json.",
     )
     parser.add_argument(
         "--resume-monitor",

--- a/tests/unit/test_run_experiment_logs.py
+++ b/tests/unit/test_run_experiment_logs.py
@@ -979,16 +979,17 @@ class TestMonitorConfig:
         assert cfg.max_submit == common.DEFAULT_MAX_SUBMIT
         assert "max_submit must be an integer" in capsys.readouterr().err
 
-    def test_precedence_file_overrides_cli_and_env(
-        self, tmp_path, monkeypatch, fake_slurm, fast_sleep
+    def test_precedence_monitor_over_cli_over_user_config_over_default(
+        self, tmp_path, user_config_path, fake_slurm, fast_sleep
     ):
-        """Integration: file beats CLI flag beats env var beats default."""
+        """End-to-end precedence: monitor.json > CLI > user config > default."""
         _write_finetune_experiment(tmp_path, ["rank4"], include_control=False)
         logs_dir = tmp_path / "logs"
         logs_dir.mkdir(parents=True, exist_ok=True)
 
-        # env: poll_sec=30, file: poll_sec=10, CLI: poll_sec=20.
-        monkeypatch.setenv("POLL_SEC", "30")
+        # User config: poll_sec=30. monitor.json: poll_sec=10. CLI: poll_sec=20.
+        # Final effective value through the run = 10 (monitor.json wins).
+        user_config_path.write_text(json.dumps({"poll_sec": 30}))
         (logs_dir / "monitor.json").write_text(json.dumps({"poll_sec": 10}))
 
         original_sbatch = fake_slurm._sbatch
@@ -1003,7 +1004,8 @@ class TestMonitorConfig:
         submit_torchtune.run(tmp_path, user="testuser", max_submit=10, poll_sec=20)
 
         log = (logs_dir / "run-torchtune.log").read_text()
-        # CLI override sets cfg.poll_sec=20 at entry; file then drops it to 10.
+        # CLI=20 wins over user-config=30 at startup; monitor.json=10 then
+        # drops it from 20 on the first poll iteration.
         assert "poll_sec=10 (was 20)" in log
 
     def test_config_block_does_not_match_jid_harvest_regex(self, tmp_path):
@@ -1022,22 +1024,96 @@ class TestMonitorConfig:
         assert SUBMIT_JOB_RE.findall(log) == []
         assert SUBMIT_EVAL_RE.findall(log) == []
 
-    def test_resolve_poll_sec_env_precedence(self, monkeypatch):
-        """resolve_poll_sec: CLI flag > env var > default."""
-        monkeypatch.setenv("POLL_SEC", "45")
-        assert common.resolve_poll_sec(None) == 45.0
-        assert common.resolve_poll_sec(15.0) == 15.0
-        monkeypatch.delenv("POLL_SEC")
-        assert common.resolve_poll_sec(None) == common.DEFAULT_POLL_SEC
 
-    def test_resolve_stagger_sec_env_precedence(self, monkeypatch):
-        monkeypatch.setenv("STAGGER_SEC", "2.5")
-        assert common.resolve_stagger_sec(None) == 2.5
+# ---------------------------------------------------------------------------
+# (8) User config — <repo>/.config/config.json
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def user_config_path(tmp_path, monkeypatch):
+    """Redirect user-config loading to a per-test temp path with cache reset.
+
+    Yields the (initially-nonexistent) target path. Tests write JSON there
+    to exercise user-config behavior in isolation from the real
+    <repo>/.config/config.json.
+    """
+    path = tmp_path / "user_config.json"
+    monkeypatch.setattr(common, "_USER_CONFIG_PATH", path)
+    common._reset_user_config_cache()
+    yield path
+    common._reset_user_config_cache()
+
+
+class TestUserConfig:
+    """User-level defaults via <repo>/.config/config.json (power-user knob).
+
+    Precedence layer: CLI > user config > built-in default. Live overrides
+    via logs/monitor.json sit above CLI. The file is tracked in the repo
+    so the defaults are visible; power users can edit it and add
+    `git update-index --skip-worktree` if they don't want changes in git status.
+    """
+
+    def test_resolve_max_submit_falls_back_to_user_config(self, user_config_path):
+        user_config_path.write_text(json.dumps({"max_submit": 42}))
+        assert common.resolve_max_submit(None) == 42
+        # CLI flag still wins over user config.
+        assert common.resolve_max_submit(5) == 5
+
+    def test_resolve_poll_sec_falls_back_to_user_config(self, user_config_path):
+        user_config_path.write_text(json.dumps({"poll_sec": 300}))
+        assert common.resolve_poll_sec(None) == 300
+        assert common.resolve_poll_sec(15.0) == 15.0
+
+    def test_resolve_stagger_sec_falls_back_to_user_config(self, user_config_path):
+        user_config_path.write_text(json.dumps({"stagger_sec": 2}))
+        assert common.resolve_stagger_sec(None) == 2
         assert common.resolve_stagger_sec(1.0) == 1.0
-        monkeypatch.delenv("STAGGER_SEC")
+
+    def test_missing_user_config_falls_back_to_built_in_default(self, user_config_path):
+        # File deliberately not written -> loader returns empty -> DEFAULT_*.
+        assert common.resolve_max_submit(None) == common.DEFAULT_MAX_SUBMIT
+        assert common.resolve_poll_sec(None) == common.DEFAULT_POLL_SEC
         assert common.resolve_stagger_sec(None) == common.DEFAULT_STAGGER_SEC
 
-    def test_resolve_poll_sec_bad_env_warns_and_falls_back(self, monkeypatch, capsys):
-        monkeypatch.setenv("POLL_SEC", "fast-please")
+    def test_user_config_bad_value_warns_and_falls_back(self, user_config_path, capsys):
+        user_config_path.write_text(json.dumps({"poll_sec": -5}))
         assert common.resolve_poll_sec(None) == common.DEFAULT_POLL_SEC
-        assert "non-numeric POLL_SEC" in capsys.readouterr().err
+        assert "poll_sec must be > 0" in capsys.readouterr().err
+
+    def test_user_config_malformed_json_warns_and_falls_back(
+        self, user_config_path, capsys
+    ):
+        user_config_path.write_text("{not valid json")
+        assert common.resolve_poll_sec(None) == common.DEFAULT_POLL_SEC
+        assert "not valid JSON" in capsys.readouterr().err
+
+    def test_user_config_warnings_emit_once_per_process(self, user_config_path, capsys):
+        """Cache ensures unknown-key warnings emit on first load, not every resolver call."""
+        user_config_path.write_text(json.dumps({"bogus_key": 99}))
+        common.resolve_poll_sec(None)
+        common.resolve_max_submit(None)
+        common.resolve_stagger_sec(None)
+        err = capsys.readouterr().err
+        assert err.count("bogus_key") == 1
+
+    def test_real_repo_config_matches_built_in_defaults(self):
+        """The shipped <repo>/.config/config.json must match the in-code DEFAULT_*.
+
+        The file is documentation of what the defaults are. If a contributor
+        changes a DEFAULT_* without updating the file (or vice versa), this
+        test catches the drift.
+        """
+        # Use the un-monkeypatched real path. Reset cache to avoid carry-over.
+        common._reset_user_config_cache()
+        path = common._USER_CONFIG_PATH
+        assert path.exists(), (
+            f"shipped repo config missing at {path} — should be tracked"
+        )
+        data = json.loads(path.read_text())
+        assert data == {
+            "poll_sec": common.DEFAULT_POLL_SEC,
+            "stagger_sec": common.DEFAULT_STAGGER_SEC,
+            "max_submit": common.DEFAULT_MAX_SUBMIT,
+        }
+        common._reset_user_config_cache()

--- a/tests/unit/test_run_experiment_logs.py
+++ b/tests/unit/test_run_experiment_logs.py
@@ -858,7 +858,8 @@ class TestMonitorConfig:
     Precedence: monitor.json > CLI flag > env var > default. The watcher
     re-reads the file on every poll iteration so an operator (or agent) can
     tune `poll_sec`, `stagger_sec`, `max_submit` mid-run without detach +
-    re-attach. Bad values are warned-and-skipped; missing file is silent.
+    re-attach. Bad values are warned-and-skipped; removing the file reverts
+    each knob to its startup baseline (CLI / config.json / default).
     """
 
     def test_missing_file_is_silent_noop(self, tmp_path, capsys):
@@ -868,10 +869,43 @@ class TestMonitorConfig:
         assert cfg.poll_sec == common.DEFAULT_POLL_SEC
         assert cfg.stagger_sec == common.DEFAULT_STAGGER_SEC
         assert cfg.max_submit == common.DEFAULT_MAX_SUBMIT
-        # No warning, no log file written for this path.
+        # Baseline already equals current → no warning, no log written.
         assert capsys.readouterr().err == ""
         if cfg.log_path.exists():
             assert "MONITOR_CONFIG" not in cfg.log_path.read_text()
+
+    def test_removing_file_reverts_to_baseline(self, tmp_path):
+        """Deleting monitor.json after an override reverts each knob."""
+        cfg = _mk_cfg(tmp_path)
+        config_path = tmp_path / "logs" / "monitor.json"
+
+        config_path.write_text(json.dumps({"poll_sec": 10}))
+        common._refresh_monitor_config(cfg)
+        assert cfg.poll_sec == 10
+
+        config_path.unlink()
+        common._refresh_monitor_config(cfg)
+
+        assert cfg.poll_sec == common.DEFAULT_POLL_SEC
+        log = cfg.log_path.read_text()
+        assert log.count("MONITOR_CONFIG: applied") == 2
+        assert "poll_sec=10 (was 60)" in log
+        assert "poll_sec=60 (was 10)" in log
+
+    def test_revert_respects_cli_baseline_not_builtin_default(self, tmp_path):
+        """Revert target is the startup baseline, not the built-in default."""
+        cfg = _mk_cfg(tmp_path, poll_sec=15)
+        config_path = tmp_path / "logs" / "monitor.json"
+
+        config_path.write_text(json.dumps({"poll_sec": 10}))
+        common._refresh_monitor_config(cfg)
+        assert cfg.poll_sec == 10
+
+        config_path.unlink()
+        common._refresh_monitor_config(cfg)
+
+        assert cfg.poll_sec == 15
+        assert "poll_sec=15 (was 10)" in cfg.log_path.read_text()
 
     def test_file_present_applies_overrides_and_logs(self, tmp_path):
         cfg = _mk_cfg(tmp_path)

--- a/tests/unit/test_run_experiment_logs.py
+++ b/tests/unit/test_run_experiment_logs.py
@@ -831,3 +831,213 @@ class TestStatus:
 
         log = (logs_dir / "run-torchtune.log").read_text()
         assert log.count("ALL_COMPLETE") == 1
+
+
+# ---------------------------------------------------------------------------
+# (7) Live monitor settings (#480) — logs/monitor.json
+# ---------------------------------------------------------------------------
+
+
+def _mk_cfg(tmp_path: Path, **overrides) -> "common._SubmitConfig":
+    """Build a _SubmitConfig pointing at tmp_path's logs/ for refresh tests."""
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    return common._SubmitConfig(
+        log_path=logs_dir / "run-torchtune.log",
+        state_path=logs_dir / "run-torchtune.state.json",
+        action_type="SUBMIT_JOB",
+        user="testuser",
+        experiment_dir=tmp_path,
+        **overrides,
+    )
+
+
+class TestMonitorConfig:
+    """Live monitor settings via logs/monitor.json (#480).
+
+    Precedence: monitor.json > CLI flag > env var > default. The watcher
+    re-reads the file on every poll iteration so an operator (or agent) can
+    tune `poll_sec`, `stagger_sec`, `max_submit` mid-run without detach +
+    re-attach. Bad values are warned-and-skipped; missing file is silent.
+    """
+
+    def test_missing_file_is_silent_noop(self, tmp_path, capsys):
+        cfg = _mk_cfg(tmp_path)
+        common._refresh_monitor_config(cfg)
+
+        assert cfg.poll_sec == common.DEFAULT_POLL_SEC
+        assert cfg.stagger_sec == common.DEFAULT_STAGGER_SEC
+        assert cfg.max_submit == common.DEFAULT_MAX_SUBMIT
+        # No warning, no log file written for this path.
+        assert capsys.readouterr().err == ""
+        if cfg.log_path.exists():
+            assert "MONITOR_CONFIG" not in cfg.log_path.read_text()
+
+    def test_file_present_applies_overrides_and_logs(self, tmp_path):
+        cfg = _mk_cfg(tmp_path)
+        (tmp_path / "logs" / "monitor.json").write_text(json.dumps({"poll_sec": 10}))
+
+        common._refresh_monitor_config(cfg)
+
+        assert cfg.poll_sec == 10
+        assert cfg.stagger_sec == common.DEFAULT_STAGGER_SEC
+        assert cfg.max_submit == common.DEFAULT_MAX_SUBMIT
+        log = cfg.log_path.read_text()
+        assert "MONITOR_CONFIG: applied" in log
+        assert "poll_sec=10 (was 60)" in log
+        # Unchanged knobs are still shown so the active picture is complete.
+        assert "stagger_sec=5 (unchanged)" in log
+        assert "max_submit=25 (unchanged)" in log
+
+    def test_live_update_mid_run(self, tmp_path):
+        """Two successive edits each emit their own MONITOR_CONFIG block."""
+        cfg = _mk_cfg(tmp_path)
+        config_path = tmp_path / "logs" / "monitor.json"
+
+        config_path.write_text(json.dumps({"poll_sec": 20}))
+        common._refresh_monitor_config(cfg)
+        config_path.write_text(json.dumps({"poll_sec": 5}))
+        common._refresh_monitor_config(cfg)
+
+        log = cfg.log_path.read_text()
+        assert log.count("MONITOR_CONFIG: applied") == 2
+        assert "poll_sec=20 (was 60)" in log
+        assert "poll_sec=5 (was 20)" in log
+        assert cfg.poll_sec == 5
+
+    def test_unchanged_file_does_not_repeat_log(self, tmp_path):
+        """File present but values match current cfg → no repeated logging."""
+        cfg = _mk_cfg(tmp_path)
+        (tmp_path / "logs" / "monitor.json").write_text(json.dumps({"poll_sec": 30}))
+
+        common._refresh_monitor_config(cfg)
+        common._refresh_monitor_config(cfg)
+        common._refresh_monitor_config(cfg)
+
+        log = cfg.log_path.read_text()
+        assert log.count("MONITOR_CONFIG: applied") == 1
+
+    def test_malformed_json_warns_and_keeps_values(self, tmp_path, capsys):
+        cfg = _mk_cfg(tmp_path, poll_sec=42.0)
+        (tmp_path / "logs" / "monitor.json").write_text("{not valid json")
+
+        common._refresh_monitor_config(cfg)
+
+        assert cfg.poll_sec == 42.0
+        captured = capsys.readouterr()
+        assert "not valid JSON" in captured.err
+        if cfg.log_path.exists():
+            assert "MONITOR_CONFIG" not in cfg.log_path.read_text()
+
+    def test_non_object_json_warns_and_keeps_values(self, tmp_path, capsys):
+        """Top-level must be an object; arrays / scalars are rejected."""
+        cfg = _mk_cfg(tmp_path)
+        (tmp_path / "logs" / "monitor.json").write_text(json.dumps([1, 2, 3]))
+
+        common._refresh_monitor_config(cfg)
+
+        assert cfg.poll_sec == common.DEFAULT_POLL_SEC
+        assert "must be a JSON object" in capsys.readouterr().err
+
+    def test_unknown_keys_warned_known_keys_applied(self, tmp_path, capsys):
+        cfg = _mk_cfg(tmp_path)
+        (tmp_path / "logs" / "monitor.json").write_text(
+            json.dumps({"poll_sec": 5, "bogus_key": 99})
+        )
+
+        common._refresh_monitor_config(cfg)
+
+        assert cfg.poll_sec == 5
+        assert "bogus_key" in capsys.readouterr().err
+
+    def test_invalid_values_warned_and_kept(self, tmp_path, capsys):
+        """Out-of-range / wrong-type values: warn, keep last good."""
+        cfg = _mk_cfg(tmp_path)
+        (tmp_path / "logs" / "monitor.json").write_text(
+            json.dumps({"poll_sec": -1, "max_submit": 0, "stagger_sec": "fast"})
+        )
+
+        common._refresh_monitor_config(cfg)
+
+        assert cfg.poll_sec == common.DEFAULT_POLL_SEC
+        assert cfg.max_submit == common.DEFAULT_MAX_SUBMIT
+        assert cfg.stagger_sec == common.DEFAULT_STAGGER_SEC
+        err = capsys.readouterr().err
+        assert "poll_sec must be > 0" in err
+        assert "max_submit must be >= 1" in err
+        assert "stagger_sec must be a number" in err
+
+    def test_max_submit_rejects_float(self, tmp_path, capsys):
+        """max_submit must be an int, not a float (even 25.0)."""
+        cfg = _mk_cfg(tmp_path)
+        (tmp_path / "logs" / "monitor.json").write_text(
+            json.dumps({"max_submit": 25.0})
+        )
+
+        common._refresh_monitor_config(cfg)
+
+        assert cfg.max_submit == common.DEFAULT_MAX_SUBMIT
+        assert "max_submit must be an integer" in capsys.readouterr().err
+
+    def test_precedence_file_overrides_cli_and_env(
+        self, tmp_path, monkeypatch, fake_slurm, fast_sleep
+    ):
+        """Integration: file beats CLI flag beats env var beats default."""
+        _write_finetune_experiment(tmp_path, ["rank4"], include_control=False)
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+
+        # env: poll_sec=30, file: poll_sec=10, CLI: poll_sec=20.
+        monkeypatch.setenv("POLL_SEC", "30")
+        (logs_dir / "monitor.json").write_text(json.dumps({"poll_sec": 10}))
+
+        original_sbatch = fake_slurm._sbatch
+
+        def sbatch_then_finish(argv, kwargs):
+            r = original_sbatch(argv, kwargs)
+            fake_slurm.finish_all("COMPLETED")
+            return r
+
+        fake_slurm._sbatch = sbatch_then_finish
+
+        submit_torchtune.run(tmp_path, user="testuser", max_submit=10, poll_sec=20)
+
+        log = (logs_dir / "run-torchtune.log").read_text()
+        # CLI override sets cfg.poll_sec=20 at entry; file then drops it to 10.
+        assert "poll_sec=10 (was 20)" in log
+
+    def test_config_block_does_not_match_jid_harvest_regex(self, tmp_path):
+        """MONITOR_CONFIG must not false-match the analyze-experiment harvesters."""
+        log_path = tmp_path / "logs" / "run-torchtune.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        common.log_monitor_config(
+            log_path,
+            current={"poll_sec": 30, "stagger_sec": 5, "max_submit": 25},
+            changes={"poll_sec": 60},
+        )
+
+        log = log_path.read_text()
+        assert "MONITOR_CONFIG: applied" in log
+        assert SUBMIT_JOB_RE.findall(log) == []
+        assert SUBMIT_EVAL_RE.findall(log) == []
+
+    def test_resolve_poll_sec_env_precedence(self, monkeypatch):
+        """resolve_poll_sec: CLI flag > env var > default."""
+        monkeypatch.setenv("POLL_SEC", "45")
+        assert common.resolve_poll_sec(None) == 45.0
+        assert common.resolve_poll_sec(15.0) == 15.0
+        monkeypatch.delenv("POLL_SEC")
+        assert common.resolve_poll_sec(None) == common.DEFAULT_POLL_SEC
+
+    def test_resolve_stagger_sec_env_precedence(self, monkeypatch):
+        monkeypatch.setenv("STAGGER_SEC", "2.5")
+        assert common.resolve_stagger_sec(None) == 2.5
+        assert common.resolve_stagger_sec(1.0) == 1.0
+        monkeypatch.delenv("STAGGER_SEC")
+        assert common.resolve_stagger_sec(None) == common.DEFAULT_STAGGER_SEC
+
+    def test_resolve_poll_sec_bad_env_warns_and_falls_back(self, monkeypatch, capsys):
+        monkeypatch.setenv("POLL_SEC", "fast-please")
+        assert common.resolve_poll_sec(None) == common.DEFAULT_POLL_SEC
+        assert "non-numeric POLL_SEC" in capsys.readouterr().err


### PR DESCRIPTION
Closes #480

# Description

The `run-experiment` watcher landed in PR #476 froze `poll_sec`, `stagger_sec`, and `max_submit` at process start — to change any of them, you had to detach and re-attach with different flags. This PR adds two new configuration layers so the same knobs can be set persistently or tuned live.

## Configuration layers

| Layer | Where | Scope | Lifetime |
|---|---|---|---|
| **Per-checkout defaults** | `<repo>/.config/config.json` (tracked, ships with built-in values visible) | Every experiment | Until edited |
| **Per-run override** | `--poll-sec` / `--stagger-sec` / `--max-submit` CLI flags | One submitter invocation | One run |
| **Live mid-run override** | `<exp_dir>/logs/monitor.json` | One experiment | Re-read on every poll |

Final precedence (high → low): `monitor.json` > CLI flag > `<repo>/.config/config.json` > built-in default.

Power users who want to keep local edits to `.config/config.json` out of `git status` can run `git update-index --skip-worktree .config/config.json` once.

## What changed

| Layer | Change |
|---|---|
| **`src/tools/run/_submit_common.py`** | New shared `_read_validated_config()` covering both files. `_load_monitor_config()` (per-run, called every poll iteration) and `_load_user_config()` (per-process, cached, called from resolvers). Live refresh hook `_refresh_monitor_config(cfg)` wired into all three poll-loop sites. Canonical `MONITOR_CONFIG` log emitter `log_monitor_config()`. Resolvers (`resolve_max_submit` / `resolve_poll_sec` / `resolve_stagger_sec`) now consult user config between CLI and default. |
| **`submit_torchtune.py` / `submit_inspect.py`** | New `--poll-sec` and `--stagger-sec` CLI flags for parity with `--max-submit`; plumbed through `run()` → submitters. Help text points at `.config/config.json` + `monitor.json` for the static and live channels. |
| **`<repo>/.config/config.json`** | New tracked file shipping with `{poll_sec: 60, stagger_sec: 5, max_submit: 25}` — the existing built-in defaults, now visible. |
| **Validation** | Recognized keys: `poll_sec`, `stagger_sec`, `max_submit`. Unknown keys, malformed JSON, non-numeric values, out-of-range numbers → `WARNING:` to stderr, watcher keeps previously-applied values. Missing file is a silent no-op. User-config warnings emit once per process (cached). |
| **Regex safety** | `MONITOR_CONFIG` blocks contain no `Job ID:` line, so the `analyze-experiment` `SUBMIT_JOB:` / `SUBMIT_EVAL:` harvest regex in `compute_metrics.py` cannot false-match. Asserted in a unit test. |
| **`.gitignore`** | Pre-existing `!tests/fixtures/**` negation was also un-ignoring `__pycache__/` under that path. Added explicit re-ignores for `tests/fixtures/**/__pycache__/` and `tests/fixtures/**/*.pyc`. |
| **Docs** | `logging.md` (new `MONITOR_CONFIG` action type + example block), `SKILL.md` (full "Tuning Watcher Cadence" subsection covering the precedence chain + filesystem-channels table), `optimizers/torchtune/main.md` + `evaluators/inspect/main.md` (precedence + cross-reference), `ARTIFACT_LOCATIONS.md` (monitor.json in the experiment layout), `status.py` (one-line clarifying note that it doesn't read `monitor.json`), `CHANGELOG.md` (unreleased entry). |

## Example

```bash
# Set personal defaults for all future experiments: edit the tracked file.
$EDITOR <repo>/.config/config.json
#   {"poll_sec": 300, "stagger_sec": 5, "max_submit": 25}

# Optional: keep local edits out of git status
git update-index --skip-worktree .config/config.json

# Submitter starts using the user-config values automatically:
python -m cruijff_kit.tools.run.submit_torchtune <exp_dir>

# For a single experiment, override at the CLI:
python -m cruijff_kit.tools.run.submit_torchtune <exp_dir> --poll-sec 10

# Mid-run, tighten cadence without detach + re-attach:
echo '{"poll_sec": 5}' > <exp_dir>/logs/monitor.json
# On the next poll iteration, run-torchtune.log gets:
#   [2026-05-12 14:00:00] MONITOR_CONFIG: applied
#   Details: poll_sec=5 (was 300); stagger_sec=5 (unchanged); max_submit=25 (unchanged)
#   Result: settings updated from logs/monitor.json
```

This intentionally **replaces** the earlier "dynamically adapt based on observed state breakdown" sketch from the original #480 issue draft. Heuristic adaptation is opaque; manual operator control across three explicit layers (static, per-run, live) is predictable and composable with the tooling we already have.

## Tests

`TestMonitorConfig` (14 tests, live overrides): missing-file no-op, file-present apply+log, live update mid-run, unchanged file no repeat log, malformed JSON warn, non-object JSON warn, unknown keys, invalid values, `max_submit` float-rejection, full file > CLI > user-config precedence integration, regex-safety against harvest patterns.

`TestUserConfig` (8 tests, repo-level defaults): file pickup per-knob, missing-file → built-in default fallback, malformed JSON warn, bad value warn, warnings emit once per process (cache check), and a drift guard asserting the shipped `<repo>/.config/config.json` matches the in-code `DEFAULT_*` so future contributors can't silently desync them.

Full suite: **122 passed** (existing 103 + 14 monitor + 8 user-config + 1 net from dropping the 3 env-var resolver tests). `ruff check` and `ruff format --check` clean.

# New Dependencies

None.

# Testing Instructions

- [ ] `pytest tests/unit/test_run_experiment_logs.py::TestMonitorConfig tests/unit/test_run_experiment_logs.py::TestUserConfig -v` → 22 passed
- [ ] `pytest tests/unit/test_run_experiment_logs.py tests/unit/test_compute_metrics.py -q` → 122 passed, no regressions
- [ ] `ruff check src/tools/run/ tests/unit/test_run_experiment_logs.py` → clean
- [ ] `ruff format --check src/tools/run/ tests/unit/test_run_experiment_logs.py` → clean
- [ ] **User-config smoke**: edit `<repo>/.config/config.json` to `{"poll_sec": 300, ...}`. Launch any submitter without `--poll-sec` → confirm internal cadence is 300s.
- [ ] **Live monitor.json smoke**: kick off `submit_torchtune` on a workflow_test experiment. While running, `echo '{"poll_sec": 5}' > <exp_dir>/logs/monitor.json` → confirm a `MONITOR_CONFIG: applied` block lands in `run-torchtune.log` on the next poll with `poll_sec=5 (was 60)` (or whatever the prior value was). Edit again → second block with the new `(was N)`. `touch .detach` → existing detach behavior unaffected.
- [ ] **Precedence smoke**: with `{"poll_sec": 300}` in `.config/config.json`, `--poll-sec 20` at CLI, and `{"poll_sec": 10}` in `monitor.json` → effective cadence is 10s (monitor.json wins over CLI wins over user config).
- [ ] **Regex safety**: run `analyze-experiment` on a smoke-test experiment whose logs contain `MONITOR_CONFIG` blocks → compute-utilization section still present and correct; the `MONITOR_CONFIG` lines are not harvested as fake job IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

—MxC