### PR TITLE
Expose cpus_per_task as a setup_finetune.py CLI override

### DIFF
--- a/.claude/agents/scaffold-torchtune.md
+++ b/.claude/agents/scaffold-torchtune.md
@@ -112,9 +112,9 @@ These are *example* parameters that the user might vary. There may be other para
      - `parameters` - Dict of parameter values (lora_rank, lr, etc.)
 
 6. **Compute estimates (optional):**
-   - For each run: `runs[].compute.time`, `runs[].compute.gpus`, `runs[].compute.mem`
-   - If present, pass as `--time`, `--gpus`, `--mem` CLI args to `setup_finetune.py`
-   - If absent, omit these flags (`setup_finetune.py` uses its defaults)
+   - For each run: `runs[].compute.time`, `runs[].compute.gpus`, `runs[].compute.mem`, `runs[].compute.cpus_per_task`
+   - If present, pass as `--time`, `--gpus`, `--mem`, `--cpus_per_task` CLI args to `setup_finetune.py`
+   - If absent, omit these flags (`setup_finetune.py` uses its defaults: MODEL_CONFIGS for cpus, etc.)
 
 ### Filtering Fine-tuned Runs
 
@@ -261,6 +261,7 @@ account: {from claude.local.md SLURM Defaults, if present}
 time: {from runs[].compute.time, if present, e.g., "0:15:00"}
 gpus: {from runs[].compute.gpus, if present}
 mem: {from runs[].compute.mem, if present, e.g., "80G"}
+cpus_per_task: {from runs[].compute.cpus_per_task, if present, e.g., 8}
 
 # System prompt (if specified)
 system_prompt: {from controls.system_prompt, often empty string ""}
@@ -321,7 +322,7 @@ For each run directory:
 
    **With compute estimates** (when `runs[].compute` block exists):
    ```bash
-   bash -c "cd {experiment_dir}/{run_directory_name} && conda run -n cruijff python {cruijff_kit_path}/src/tools/torchtune/setup_finetune.py --training_samples {data.training.splits.train} --time {compute.time} --gpus {compute.gpus} --mem {compute.mem}"
+   bash -c "cd {experiment_dir}/{run_directory_name} && conda run -n cruijff python {cruijff_kit_path}/src/tools/torchtune/setup_finetune.py --training_samples {data.training.splits.train} --time {compute.time} --gpus {compute.gpus} --mem {compute.mem} --cpus_per_task {compute.cpus_per_task}"
    ```
 
    **Example (without compute estimates):**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to cruijff_kit will be documented in this file.
 
 ### Added
 
+- `--cpus_per_task` flag on `setup_finetune.py`, wired through `scaffold-torchtune` as `runs[].compute.cpus_per_task`. Overrides `MODEL_CONFIGS[model]["slurm"]["cpus"]` for the generated `#SBATCH --cpus-per-task=`. Useful for workloads with long sequences or heavy preprocessing where tokenizer threading and OpenMP can give a small GPU-util bump even at `num_workers=0`. Does *not* parallelize data loading itself — that's recipe-level and tracked separately. (#449)
 - `src/tools/run/submit_torchtune.py` and `submit_inspect.py` — callable submitters for `run-experiment`. Drip-feed against the gpu-test QoS cap (default `MAX_SUBMIT=25`), 5-second stagger, resume-safe JSON state file, canonical `SUBMIT_JOB:` / `SUBMIT_EVAL:` log emission. Replaces the prose-only execution path the skill used to rely on. (#451)
 - `harvest_jids_from_run_logs()` in `src/tools/slurm/compute_metrics.py` — single helper that `analyze-experiment` calls to extract job IDs from `run-torchtune.log` / `run-inspect.log` and surface loud warnings when those logs are missing or malformed. (#451)
 - Detach mechanisms for `run-experiment` submitters — SIGINT, SIGTERM, and a sticky `<exp_dir>/logs/.detach` sentinel file. Any path flushes state, emits a canonical `MONITOR_DETACHED` log block, prints a re-attach hint to stderr, and exits cleanly; SLURM jobs continue running. (#479)

--- a/src/tools/torchtune/setup_finetune.py
+++ b/src/tools/torchtune/setup_finetune.py
@@ -583,6 +583,12 @@ def create_parser():
     parser.add_argument(
         "--mem", type=str, help="Slurm memory allocation (e.g., '40G', '16G')"
     )
+    parser.add_argument(
+        "--cpus_per_task",
+        type=int,
+        default=None,
+        help="Cores requested in the SLURM script (overrides MODEL_CONFIGS).",
+    )
     parser.add_argument("--constraint", type=str, help="Slurm constraint to use")
 
     # ------ Training Step Guard -----
@@ -957,8 +963,11 @@ def main():
             stacklevel=2,
         )
 
-    # CPUs: use model config value
-    cpus = slurm_config.get("cpus", 4)
+    cpus = (
+        args.cpus_per_task
+        if args.cpus_per_task is not None
+        else slurm_config.get("cpus", 1)
+    )
 
     # Multi-GPU setup: update SLURM and use distributed training
     if gpus > 1:

--- a/src/tools/torchtune/setup_finetune.py
+++ b/src/tools/torchtune/setup_finetune.py
@@ -15,7 +15,16 @@ from cruijff_kit.tools.torchtune.model_configs import MODEL_CONFIGS, configure_t
 script_dir = Path(__file__).parent
 
 # Skip these when writing the yaml file
-SLURM_ONLY = ["time", "gpus", "conda_env", "account", "partition", "constraint", "mem"]
+SLURM_ONLY = [
+    "time",
+    "gpus",
+    "conda_env",
+    "account",
+    "partition",
+    "constraint",
+    "mem",
+    "cpus_per_task",
+]
 # Meta-arguments that are not torchtune config parameters
 META_ARGS = ["training_samples"]
 

--- a/tests/unit/test_setup_finetune_main.py
+++ b/tests/unit/test_setup_finetune_main.py
@@ -224,14 +224,35 @@ class TestMainSlurmGeneration:
         assert "lora_finetune_distributed" in slurm
         assert "--gres=gpu:4" in slurm
 
-    def test_cpus_per_task_cli_overrides_model_config(self, run_main):
+
+class TestCpusPerTask:
+    """Tests for the --cpus_per_task override (issue #449).
+
+    Resolution order: CLI > setup_finetune.yaml > MODEL_CONFIGS["slurm"]["cpus"] > 1.
+    The fixture's model is Llama-3.2-1B-Instruct, which has cpus=1 in MODEL_CONFIGS.
+    """
+
+    def test_cli_override_writes_to_slurm(self, run_main):
         _, slurm = run_main(extra_args=["--cpus_per_task", "8"])
         assert "#SBATCH --cpus-per-task=8" in slurm
 
-    def test_no_cpus_per_task_uses_model_config_default(self, run_main):
-        # Llama-3.2-1B-Instruct has cpus: 1 in MODEL_CONFIGS
+    def test_default_falls_back_to_model_config(self, run_main):
         _, slurm = run_main()
         assert "#SBATCH --cpus-per-task=1" in slurm
+
+    def test_cli_overrides_yaml(self, run_main, setup_yaml):
+        with open(setup_yaml) as f:
+            data = yaml.safe_load(f)
+        data["cpus_per_task"] = 4
+        with open(setup_yaml, "w") as f:
+            yaml.dump(data, f)
+        _, slurm = run_main(extra_args=["--cpus_per_task", "12"])
+        assert "#SBATCH --cpus-per-task=12" in slurm
+
+    def test_cpus_per_task_not_in_finetune_yaml(self, run_main):
+        # SLURM-only knob; must not leak into the rendered torchtune config.
+        config, _ = run_main(extra_args=["--cpus_per_task", "8"])
+        assert "cpus_per_task" not in config
 
 
 class TestCustomRecipeGuard:

--- a/tests/unit/test_setup_finetune_main.py
+++ b/tests/unit/test_setup_finetune_main.py
@@ -224,6 +224,15 @@ class TestMainSlurmGeneration:
         assert "lora_finetune_distributed" in slurm
         assert "--gres=gpu:4" in slurm
 
+    def test_cpus_per_task_cli_overrides_model_config(self, run_main):
+        _, slurm = run_main(extra_args=["--cpus_per_task", "8"])
+        assert "#SBATCH --cpus-per-task=8" in slurm
+
+    def test_no_cpus_per_task_uses_model_config_default(self, run_main):
+        # Llama-3.2-1B-Instruct has cpus: 1 in MODEL_CONFIGS
+        _, slurm = run_main()
+        assert "#SBATCH --cpus-per-task=1" in slurm
+
 
 class TestCustomRecipeGuard:
     """Tests for the auto-switch guard added in #471.


### PR DESCRIPTION
Closes #449

# Description

`setup_finetune.py` already substituted `MODEL_CONFIGS[model]["slurm"]["cpus"]` into the slurm template's `--cpus-per-task` placeholder, but the value was `1` for every model except Llama-3.3-70B-Instruct (which sets `cpus: 4`). Users had no way to allocate more cores when the data pipeline was CPU-bound, even when the overall slurm allocation was bumped.

This PR adds a `--cpus_per_task` flag to `setup_finetune.py` (mirroring the `--gpus`/`--mem` precedence pattern) and wires it through `scaffold-torchtune` as `runs[].compute.cpus_per_task` — matching the existing slurm-resource schema slot alongside `time`, `gpus`, and `mem`.

**Scope** (per the 2026-05-11 narrowing on the issue): only `cpus_per_task` propagation. `num_workers` / `persistent_workers` are deferred to separate follow-up issues — they require recipe-level edits that are blocked on the #465 wrapper-only-principle discussion.

**Schema decision**: `runs[].compute.cpus_per_task` rather than `controls.cpus_per_task` (as the original issue body suggested). Rationale: `cpus_per_task` is a slurm resource (siblings: `time`, `gpus`, `mem`), not a training hyperparameter (siblings: `epochs`, `batch_size`). The eval pipeline keeps its own analogous slot under `evaluation.compute.*` (see issue #318 for the eval-side counterpart). This keeps finetune and eval cleanly separate and lets `design-experiment`'s existing prior-run propagation handle the per-run repetition.

## New Dependencies

None.

# Testing Instructions

**Unit tests:**
```bash
pytest tests/unit/test_setup_finetune_main.py -v
```
Two new tests under `TestMainSlurmGeneration`:
- `test_cpus_per_task_cli_overrides_model_config` — `--cpus_per_task 8` → `#SBATCH --cpus-per-task=8`
- `test_no_cpus_per_task_uses_model_config_default` — no flag → MODEL_CONFIGS default (1 for Llama-3.2-1B-Instruct)

**Integration check** (any project dir with a setup_finetune.yaml):
```bash
python src/tools/torchtune/setup_finetune.py --config_file setup_finetune.yaml --cpus_per_task 8
grep "cpus-per-task" finetune.slurm   # expect: --cpus-per-task=8
```

**End-to-end**: scaffold an experiment with `runs[].compute.cpus_per_task: 8` set in `experiment_summary.yaml`. Verify `finetune.slurm` shows `--cpus-per-task=8` and `seff <jobid>` reports `Cores: 8` after running.

—MxC