### PR TITLE
Instruct model cleanup: fix system_prompt for base model + and add assistant prefill

### DIFF
--- a/.claude/agents/scaffold-torchtune.md
+++ b/.claude/agents/scaffold-torchtune.md
@@ -89,7 +89,8 @@ These are *example* parameters that the user might vary. There may be other para
    - `controls.epochs` - Number of training epochs
    - `controls.batch_size` - Batch size (if not varied)
    - `controls.batch_size_val` - Optional larger batch size for validation passes. Honored by `_single_device_nightly` (the default recipe); silently ignored by `_stable` / `_distributed` recipes since their custom-recipe builds don't read the field. Recipe falls back to `controls.batch_size` when absent.
-   - `controls.system_prompt` - Training system prompt
+   - `controls.system_prompt` - Training system prompt. 
+      - Omit this field from `setup_finetune.yaml` when `dataset_type` is `text_completion` or `text_completion_dataset` (i.e. base / non-instruct models). Base models have no chat template, so the system prompt has nowhere to go — `setup_finetune.py` will drop it with a warning.
    - `controls.prompt` - Prompt template with {input} placeholder (e.g., "Capitalize: {input}\n")
    - `controls.validation_during_training` - Whether to run validation during training. Translates to `run_val_every_n_steps`: if `true`, set to `50` (the `finetune_template.yaml` default); if `false`, set to `0` (which causes `setup_finetune.py` to drop the validation dataset config). Do not emit `0` when the user requested validation — that silently disables it.
    - `controls.gradient_accumulation_steps` - Gradient accumulation
@@ -266,6 +267,9 @@ mem: {from runs[].compute.mem, if present, e.g., "80G"}
 cpus_per_task: {from runs[].compute.cpus_per_task, if present, e.g., 8}
 
 # System prompt (if specified)
+# If `dataset_type` is `text_completion` or `text_completion_dataset` 
+# (i.e. base / non-instruct models), omit system_prompt. Base models have no chat template, so the system prompt has no slot.
+# Only emit for chat_completion / chat_dataset / instruct_dataset.
 system_prompt: {from controls.system_prompt, often empty string ""}
 
 # Prompt template (if specified)

--- a/blueprints/folktexts/README.md
+++ b/blueprints/folktexts/README.md
@@ -68,6 +68,27 @@ inspect eval blueprints/folktexts/inspect_task.py@acs_employment \
 | `split` | `test` | Data split: train, validation, or test |
 | `temperature` | `1e-7` | Generation temperature |
 | `max_tokens` | `5` | Max tokens to generate |
+| `use_chat_template` | `True` | Wrap prompt with the model's chat template. Set `False` for base (non-instruct) models. |
+| `assistant_prefix` | `""` | If set, prefill an assistant turn with this string. See "Evaluating base models" below. |
+| `top_logprobs` | `20` | Number of top tokens to return logprobs for. |
+
+### Evaluating base (non-instruct) models
+
+Base models often won't emit a clean `"1"` / `"0"` when handed a chat-template prompt — they continue the document instead of answering. Two knobs help:
+
+- `use_chat_template=False` skips the chat wrapper so the prompt is fed as raw text.
+- `assistant_prefix="Answer: "` (or whatever leads naturally into the label in your prompt) prefills an assistant turn, so the next token the model generates lands in the answer position. The scorer then matches `"1"` / `"0"` as usual.
+
+Example:
+
+```bash
+inspect eval inspect_task.py@acs_income --model hf/local \
+    -M model_path=meta-llama/Meta-Llama-3.1-8B \
+    -T config_path=/path/to/setup_finetune.yaml \
+    -T data_path=/path/to/acs_income_condensed_50000_80P.json \
+    -T use_chat_template=False \
+    -T assistant_prefix="Answer: "
+```
 
 ### Scoring
 

--- a/blueprints/folktexts/inspect_task.py
+++ b/blueprints/folktexts/inspect_task.py
@@ -20,7 +20,7 @@ import yaml
 from inspect_ai import Task, task
 from inspect_ai.dataset import hf_dataset, Sample
 from inspect_ai.solver import chain, generate, system_message
-from inspect_ai.model import GenerateConfig
+from inspect_ai.model import GenerateConfig, ChatMessageUser, ChatMessageAssistant
 from cruijff_kit.tools.inspect.scorers import build_scorers
 
 
@@ -33,6 +33,8 @@ def _create_acs_task(
     max_tokens: int = 5,
     vis_label: str = "",
     use_chat_template=True,
+    assistant_prefix: str = "",
+    top_logprobs: int = 20,
 ) -> Task:
     """
     Create an ACS binary prediction eval task.
@@ -46,6 +48,9 @@ def _create_acs_task(
         max_tokens: Max tokens to generate
         vis_label: Optional label for visualization (appended to task name)
         use_chat_template: Whether apply_chat_template should be used for tokenization (i.e., Instruction-tuned models)
+        assistant_prefix: If set, prefill an assistant turn with this string. Useful for
+            coaxing base (non-instruct) models into the expected output format.
+        top_logprobs: Number of top tokens to return logprobs for (passed to GenerateConfig).
     """
     # Construct task name with optional vis_label suffix
     full_task_name = f"{task_name}_{vis_label}" if vis_label else task_name
@@ -63,6 +68,15 @@ def _create_acs_task(
     def record_to_sample(record):
         # Wrap input with prompt template - same as chat_completion training
         formatted_input = prompt_str.format(input=record["input"])
+        if assistant_prefix:
+            # Prefill an assistant turn
+            return Sample(
+                input=[
+                    ChatMessageUser(content=formatted_input),
+                    ChatMessageAssistant(content=assistant_prefix),
+                ],
+                target=record["output"],
+            )
         return Sample(input=formatted_input, target=record["output"])
 
     dataset = hf_dataset(
@@ -89,8 +103,8 @@ def _create_acs_task(
         dataset=dataset,
         solver=solver,
         scorer=build_scorers(config),
-        # generate log probabilities of top 20 tokens from inspect (sets output_logits=True on model generate() call)
-        config=GenerateConfig(logprobs=True, top_logprobs=20),
+        # generate log probabilities of top_logprobs tokens (sets output_logits=True on model generate() call)
+        config=GenerateConfig(logprobs=True, top_logprobs=top_logprobs),
     )
 
 
@@ -104,6 +118,8 @@ def acs_binary(
     max_tokens: int = 5,
     vis_label: str = "",
     use_chat_template=True,
+    assistant_prefix: str = "",
+    top_logprobs: int = 20,
 ) -> Task:
     """Generic ACS binary prediction task. Works with any ACS dataset."""
     return _create_acs_task(
@@ -115,6 +131,8 @@ def acs_binary(
         max_tokens,
         vis_label,
         use_chat_template,
+        assistant_prefix,
+        top_logprobs,
     )
 
 
@@ -128,6 +146,8 @@ def acs_income(
     max_tokens: int = 5,
     vis_label: str = "",
     use_chat_template=True,
+    assistant_prefix: str = "",
+    top_logprobs: int = 20,
 ) -> Task:
     """ACS income prediction (>$50k)."""
     return _create_acs_task(
@@ -139,6 +159,8 @@ def acs_income(
         max_tokens,
         vis_label,
         use_chat_template,
+        assistant_prefix,
+        top_logprobs,
     )
 
 
@@ -151,6 +173,8 @@ def acs_employment(
     max_tokens: int = 5,
     vis_label: str = "",
     use_chat_template=True,
+    assistant_prefix: str = "",
+    top_logprobs: int = 20,
 ) -> Task:
     """ACS employment prediction (employed as civilian)."""
     return _create_acs_task(
@@ -162,6 +186,8 @@ def acs_employment(
         max_tokens,
         vis_label,
         use_chat_template,
+        assistant_prefix,
+        top_logprobs,
     )
 
 
@@ -174,6 +200,8 @@ def acs_mobility(
     max_tokens: int = 5,
     vis_label: str = "",
     use_chat_template=True,
+    assistant_prefix: str = "",
+    top_logprobs: int = 20,
 ) -> Task:
     """ACS mobility prediction (moved in last year)."""
     return _create_acs_task(
@@ -185,6 +213,8 @@ def acs_mobility(
         max_tokens,
         vis_label,
         use_chat_template,
+        assistant_prefix,
+        top_logprobs,
     )
 
 
@@ -197,6 +227,8 @@ def acs_publiccoverage(
     max_tokens: int = 5,
     vis_label: str = "",
     use_chat_template=True,
+    assistant_prefix: str = "",
+    top_logprobs: int = 20,
 ) -> Task:
     """ACS public health coverage prediction."""
     return _create_acs_task(
@@ -208,6 +240,8 @@ def acs_publiccoverage(
         max_tokens,
         vis_label,
         use_chat_template,
+        assistant_prefix,
+        top_logprobs,
     )
 
 
@@ -220,6 +254,8 @@ def acs_traveltime(
     max_tokens: int = 5,
     vis_label: str = "",
     use_chat_template=True,
+    assistant_prefix: str = "",
+    top_logprobs: int = 20,
 ) -> Task:
     """ACS travel time prediction (>20 min commute)."""
     return _create_acs_task(
@@ -231,4 +267,6 @@ def acs_traveltime(
         max_tokens,
         vis_label,
         use_chat_template,
+        assistant_prefix,
+        top_logprobs,
     )

--- a/src/tools/torchtune/setup_finetune.py
+++ b/src/tools/torchtune/setup_finetune.py
@@ -807,12 +807,21 @@ def main():
         elif key in ("prompt", "input_key", "output_key"):
             pass  # Handled in dataset_type
         elif key == "system_prompt":
-            # chat_completion handles system_prompt in dataset_type switch
-            # Only apply new_system_prompt for legacy instruct_dataset
-            if value and args.dataset_type != "chat_completion":
+            # chat_completion handles system_prompt via apply_chat_template.
+            # text_completion / text_completion_dataset have no system-prompt slot
+            if value and args.dataset_type in ("instruct_dataset", "chat_dataset"):
                 config["dataset"]["new_system_prompt"] = value
                 if "dataset_val" in config:
                     config["dataset_val"]["new_system_prompt"] = value
+            elif value and args.dataset_type in (
+                "text_completion",
+                "text_completion_dataset",
+            ):
+                print(
+                    f"[setup_finetune] WARNING: system_prompt is set but "
+                    f"dataset_type='{args.dataset_type}' has no system-prompt slot; "
+                    f"ignoring."
+                )
         elif key == "train_on_input":
             # Handled in dataset_type switch for chat_completion
             pass

--- a/tests/unit/test_setup_finetune_main.py
+++ b/tests/unit/test_setup_finetune_main.py
@@ -433,6 +433,21 @@ class TestMainDatasetTypes:
         assert "text_completion" in config["dataset"]["_component_"]
         assert "system_prompt" not in config["dataset"]
 
+    def test_text_completion_omits_new_system_prompt(self, run_main, setup_yaml):
+        """Test that text_completion must not emit
+        `new_system_prompt`, which `text_completion_dataset()` rejects."""
+        with open(setup_yaml) as f:
+            cfg = yaml.safe_load(f)
+        cfg["dataset_type"] = "text_completion"
+        cfg["system_prompt"] = "You are a helpful assistant."
+        with open(setup_yaml, "w") as f:
+            yaml.dump(cfg, f)
+
+        config, _ = run_main()
+        assert "new_system_prompt" not in config["dataset"]
+        if "dataset_val" in config:
+            assert "new_system_prompt" not in config["dataset_val"]
+
     def test_custom_prompt(self, run_main):
         config, _ = run_main(extra_args=["--prompt", "Answer: {input}"])
         assert config["dataset"]["prompt"] == "Answer: {input}"


### PR DESCRIPTION
Closes #459

# Description

**ACS Inspect task** 
- Adds field `assistant_prefix`: enables the user to autofill the start of the model's response (e.g., "My answer is "); found successful in coaxing zero-shot evaluations to conform to multiple choice output format in folktexts experiments
- Pipes `top_logprobs` argument through Inspect task to enable the user to vary number of desired next-token probabilities to pull in evaluation 
- Documents new behavior in the blueprint README 

**Base model bug** 
- When generating `finetune.yaml` in `setup_finetune.py`, checks `args.dataset_type` and ignores `new_system_prompt` field when the type is `text_completion` with warning (do not have chat template and will throw error when given a system prompt) 
- Add note in scaffold-torchtune to omit the field for base models to circumvent the Python check/warning 
 
# Testing Instructions
- adds test `test_text_completion_omits_new_system_prompt`