### PR TITLE
Make --training_samples actually slice the training dataset

### DIFF
--- a/src/tools/torchtune/datasets/chat_completion.py
+++ b/src/tools/torchtune/datasets/chat_completion.py
@@ -18,7 +18,9 @@ class ChatCompletionConfig:
     """Configuration for chat completion dataset."""
 
     model_path: str  # Path to HuggingFace model (for loading tokenizer)
-    prompt: str = "{input}"  # Format string to wrap input before placing in user message
+    prompt: str = (
+        "{input}"  # Format string to wrap input before placing in user message
+    )
     system_prompt: str = ""  # Optional system message
     input_key: str = "input"
     output_key: str = "output"
@@ -121,6 +123,7 @@ def chat_completion_dataset(
     input_key: str = "input",
     output_key: str = "output",
     max_length: Optional[int] = None,
+    max_samples: Optional[int] = None,
     train_on_input: bool = False,
     split: str = "train",
     packed: bool = False,  # Accepted but not used - recipe reads this for collate_fn selection
@@ -140,6 +143,7 @@ def chat_completion_dataset(
           input_key: input
           output_key: output
           train_on_input: false
+          max_samples: 100  # optional: slice to first N rows after loading
 
     Note: The `tokenizer` argument is ignored. This dataset loads its own
     HuggingFace tokenizer from model_path to ensure apply_chat_template()
@@ -157,7 +161,12 @@ def chat_completion_dataset(
     elif isinstance(data, list):
         rows = data
     else:
-        raise ValueError(f"Unexpected JSON structure: expected list or dict with '{split}' key")
+        raise ValueError(
+            f"Unexpected JSON structure: expected list or dict with '{split}' key"
+        )
+
+    if max_samples is not None:
+        rows = rows[:max_samples]
 
     cfg = ChatCompletionConfig(
         model_path=model_path,

--- a/src/tools/torchtune/datasets/text_completion.py
+++ b/src/tools/torchtune/datasets/text_completion.py
@@ -106,6 +106,7 @@ def text_completion_dataset(
     input_key: str = "input",
     output_key: str = "output",
     max_length: Optional[int] = None,
+    max_samples: Optional[int] = None,
     train_on_input: bool = False,
     split: str = "train",
     packed: bool = False,  # Accepted but not used - recipe reads this for collate_fn selection
@@ -124,6 +125,7 @@ def text_completion_dataset(
           input_key: input
           output_key: output
           train_on_input: false
+          max_samples: 100  # optional: slice to first N rows after loading
 
     Note: The `tokenizer` argument is ignored. This dataset loads its own
     HuggingFace tokenizer from model_path to ensure consistent tokenization
@@ -144,7 +146,12 @@ def text_completion_dataset(
     elif isinstance(data, list):
         rows = data
     else:
-        raise ValueError(f"Unexpected JSON structure: expected list or dict with '{split}' key")
+        raise ValueError(
+            f"Unexpected JSON structure: expected list or dict with '{split}' key"
+        )
+
+    if max_samples is not None:
+        rows = rows[:max_samples]
 
     cfg = TextCompletionConfig(
         model_path=model_path,

--- a/src/tools/torchtune/setup_finetune.py
+++ b/src/tools/torchtune/setup_finetune.py
@@ -26,7 +26,7 @@ SLURM_ONLY = [
     "cpus_per_task",
 ]
 # Meta-arguments that are not torchtune config parameters
-META_ARGS = ["training_samples"]
+META_ARGS = []
 
 # Maps torchtune recipe config paths to setup_finetune.py argument names
 RECIPE_PARAM_MAPPING = {
@@ -612,7 +612,9 @@ def create_parser():
         "--training_samples",
         type=int,
         default=None,
-        help="Number of training samples. When provided, computes and reports total training steps and warns if dangerously low.",
+        help="Cap the number of rows loaded for training (slices dataset[:training_samples]). "
+        "When provided, also computes total training steps and warns if dangerously low. "
+        "Validation set is unaffected.",
     )
 
     parser.add_argument(
@@ -934,6 +936,11 @@ def main():
             # Only emit when set; absent key → recipe falls back to cfg.batch_size.
             if value is not None:
                 config["batch_size_val"] = value
+        elif key == "training_samples":
+            # Slice the train dataset only. dataset_val stays full so val
+            # accuracy is comparable across consistency-curve runs.
+            if value is not None:
+                config["dataset"]["max_samples"] = value
         # The rest are straightforward
         else:
             config[key] = value

--- a/tests/unit/test_chat_completion_dataset.py
+++ b/tests/unit/test_chat_completion_dataset.py
@@ -1,0 +1,61 @@
+"""Regression: chat_completion_dataset must honor max_samples for training-set slicing (#447)."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cruijff_kit.tools.torchtune.datasets.chat_completion import chat_completion_dataset
+
+
+@pytest.fixture
+def small_json(tmp_path):
+    path = tmp_path / "data.json"
+    rows = {
+        "train": [{"input": str(i), "output": str(i)} for i in range(10)],
+        "validation": [{"input": "v", "output": "v"}],
+    }
+    path.write_text(json.dumps(rows))
+    return path
+
+
+@patch("transformers.AutoTokenizer.from_pretrained")
+def test_max_samples_slices_train(mock_tok, small_json):
+    mock_tok.return_value = MagicMock()
+    ds = chat_completion_dataset(
+        tokenizer=None,
+        source="json",
+        data_files=str(small_json),
+        model_path="/fake/model",
+        split="train",
+        max_samples=3,
+    )
+    assert len(ds) == 3
+
+
+@patch("transformers.AutoTokenizer.from_pretrained")
+def test_max_samples_none_loads_all(mock_tok, small_json):
+    mock_tok.return_value = MagicMock()
+    ds = chat_completion_dataset(
+        tokenizer=None,
+        source="json",
+        data_files=str(small_json),
+        model_path="/fake/model",
+        split="train",
+    )
+    assert len(ds) == 10
+
+
+@patch("transformers.AutoTokenizer.from_pretrained")
+def test_max_samples_larger_than_data_returns_full(mock_tok, small_json):
+    """Python slice semantics: rows[:999] on a 10-row list returns 10 rows."""
+    mock_tok.return_value = MagicMock()
+    ds = chat_completion_dataset(
+        tokenizer=None,
+        source="json",
+        data_files=str(small_json),
+        model_path="/fake/model",
+        split="train",
+        max_samples=999,
+    )
+    assert len(ds) == 10

--- a/tests/unit/test_setup_finetune_main.py
+++ b/tests/unit/test_setup_finetune_main.py
@@ -451,3 +451,33 @@ class TestMainDatasetTypes:
     def test_custom_prompt(self, run_main):
         config, _ = run_main(extra_args=["--prompt", "Answer: {input}"])
         assert config["dataset"]["prompt"] == "Answer: {input}"
+
+
+class TestTrainingSamples:
+    """Regression: --training_samples must slice train data, not val (#447)."""
+
+    def test_training_samples_writes_max_samples_to_dataset(self, run_main):
+        config, _ = run_main(extra_args=["--training_samples", "50"])
+        assert config["dataset"]["max_samples"] == 50
+
+    def test_training_samples_does_not_affect_dataset_val(self, run_main):
+        config, _ = run_main(extra_args=["--training_samples", "50"])
+        assert "max_samples" not in config.get("dataset_val", {}), (
+            "training_samples must NOT slice the validation set — "
+            "val must stay full across consistency-curve runs"
+        )
+
+    def test_training_samples_via_config_file(self, run_main, setup_yaml):
+        """Mirrors the consistency-curve workflow: knob set in setup_finetune.yaml, not CLI."""
+        with open(setup_yaml) as f:
+            config_data = yaml.safe_load(f)
+        config_data["training_samples"] = 50
+        with open(setup_yaml, "w") as f:
+            yaml.dump(config_data, f)
+        config, _ = run_main()
+        assert config["dataset"]["max_samples"] == 50
+        assert "max_samples" not in config.get("dataset_val", {})
+
+    def test_no_training_samples_means_no_max_samples(self, run_main):
+        config, _ = run_main()
+        assert "max_samples" not in config["dataset"]

--- a/tests/unit/test_text_completion_dataset.py
+++ b/tests/unit/test_text_completion_dataset.py
@@ -1,0 +1,61 @@
+"""Regression: text_completion_dataset must honor max_samples for training-set slicing (#447)."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cruijff_kit.tools.torchtune.datasets.text_completion import text_completion_dataset
+
+
+@pytest.fixture
+def small_json(tmp_path):
+    path = tmp_path / "data.json"
+    rows = {
+        "train": [{"input": str(i), "output": str(i)} for i in range(10)],
+        "validation": [{"input": "v", "output": "v"}],
+    }
+    path.write_text(json.dumps(rows))
+    return path
+
+
+@patch("transformers.AutoTokenizer.from_pretrained")
+def test_max_samples_slices_train(mock_tok, small_json):
+    mock_tok.return_value = MagicMock()
+    ds = text_completion_dataset(
+        tokenizer=None,
+        source="json",
+        data_files=str(small_json),
+        model_path="/fake/model",
+        split="train",
+        max_samples=3,
+    )
+    assert len(ds) == 3
+
+
+@patch("transformers.AutoTokenizer.from_pretrained")
+def test_max_samples_none_loads_all(mock_tok, small_json):
+    mock_tok.return_value = MagicMock()
+    ds = text_completion_dataset(
+        tokenizer=None,
+        source="json",
+        data_files=str(small_json),
+        model_path="/fake/model",
+        split="train",
+    )
+    assert len(ds) == 10
+
+
+@patch("transformers.AutoTokenizer.from_pretrained")
+def test_max_samples_larger_than_data_returns_full(mock_tok, small_json):
+    """Python slice semantics: rows[:999] on a 10-row list returns 10 rows."""
+    mock_tok.return_value = MagicMock()
+    ds = text_completion_dataset(
+        tokenizer=None,
+        source="json",
+        data_files=str(small_json),
+        model_path="/fake/model",
+        split="train",
+        max_samples=999,
+    )
+    assert len(ds) == 10


### PR DESCRIPTION
Closes #447

# Description

`setup_finetune.py` exposed a `--training_samples` flag (settable via `setup_finetune.yaml`), but the value never reached the generated `finetune.yaml` and the dataset factory had no slice parameter to honor. The knob was effectively cosmetic — only its companion step-count guard fired.

This PR makes the flag do what its name promises:

- `chat_completion.py` and `text_completion.py` factories take a new optional `max_samples` kwarg; after loading rows, they slice `rows[:max_samples]` if set.
- `setup_finetune.py` removes `training_samples` from `META_ARGS` (so it stops being silently dropped during YAML generation) and writes it to `config["dataset"]["max_samples"]`. **`dataset_val` is intentionally left untouched** so that consistency-curve runs (vary `N`, share a val set) are directly comparable.
- Help text updated to reflect the new slicing semantics.
- Existing step-count guard at `warn_on_low_steps` is unchanged.

Net effect: a consistency-curve experiment with N ∈ {50, 100, 500, 1000} can now use a single shared JSON and four configs differing only by `training_samples`, rather than five hand-generated JSONs.

## New Dependencies

None.

# Testing Instructions

**Unit tests** (10 new regression tests across 3 files; all pass alongside the existing 135):

```bash
pytest tests/unit/test_setup_finetune.py \
       tests/unit/test_setup_finetune_main.py \
       tests/unit/test_chat_completion_dataset.py \
       tests/unit/test_text_completion_dataset.py -v
```

Expect: `145 passed`. Coverage:
- `TestTrainingSamples` (4 tests): YAML emits `dataset.max_samples` and never `dataset_val.max_samples`; works via both CLI and config file; absent flag means no key.
- `test_chat_completion_dataset.py` (3 tests): factory honors `max_samples=N`, `max_samples=None`, and `max_samples > len(data)` (Python slice semantics return the full list).
- `test_text_completion_dataset.py` (3 tests): mirror of the chat tests for the base-model loader.

**Manual YAML inspection** (optional smoke):

```bash
mkdir -p /tmp/ts_test && cd /tmp/ts_test
# Copy any existing setup_finetune.yaml and add `training_samples: 50`
python /path/to/cruijff_kit/src/tools/torchtune/setup_finetune.py --config_file setup_finetune.yaml
grep -A 12 "^dataset:" finetune.yaml         # expect: max_samples: 50
grep -A 12 "^dataset_val:" finetune.yaml     # expect: no max_samples key
```

**Lint** (clean on all touched files):

```bash
ruff check src/tools/torchtune/setup_finetune.py \
           src/tools/torchtune/datasets/chat_completion.py \
           src/tools/torchtune/datasets/text_completion.py \
           tests/unit/test_setup_finetune_main.py \
           tests/unit/test_chat_completion_dataset.py \
           tests/unit/test_text_completion_dataset.py
ruff format --check (same file list)
```

Note: ruff format made small pre-existing-formatting fixes to long lines in `chat_completion.py` and `text_completion.py` (e.g., a long comment line and the "Unexpected JSON structure" error message). These are drive-by reformats from `ruff format` on touched files — no semantic change.

—MxC