### PR TITLE
Save adapter-only checkpoints, rewrite base path for offline load

### DIFF
--- a/.claude/agents/scaffold-torchtune.md
+++ b/.claude/agents/scaffold-torchtune.md
@@ -248,9 +248,6 @@ epochs: {from controls.epochs}
 log_every_n_steps: {use template default, typically 1}
 run_val_every_n_steps: {50 if controls.validation_during_training else 0}
 
-# Checkpoint Options
-stash_adapter_weights: 'true'  # From template default
-
 # Output configuration
 output_dir_base: {parsed from output.base_directory}
 experiment_name: {parsed from output.base_directory}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -117,7 +117,7 @@ setup_finetune.yaml → setup_finetune.py → finetune.yaml + finetune.slurm
 
 **Custom features added to torchtune:**
 - Selective epoch saving (`epochs_to_save`)
-- Adapter-only saves with self-loading offline (rewrite `adapter_config.json` base path after save; `uncruijff_adapter` restores HF Hub name for export)
+- Adapter-only saves with self-loading offline (rewrite `adapter_config.json` base path after save; `port_cruijff_adapter` restores HF Hub name for export)
 - Custom metrics integration via `src/utils/finetune_custom_metrics.py`
 - Validation during training (requires nightly build)
 
@@ -291,7 +291,7 @@ After running finetune:
 
 - **save_last_epoch_only**: `'true'`/`'false'` - Only save the final epoch
 
-- **save_adapter_weights_only**: `'true'`/`'false'` (default `'true'`) - Save only the LoRA adapter (~MB), skip the merged base+LoRA checkpoint (~GB). The saved `adapter_config.json` has its `base_model_name_or_path` rewritten to the local base-model path so the dir is self-loading on offline compute. Use `python -m cruijff_kit.tools.torchtune.uncruijff_adapter <epoch_dir>` to restore the HF Hub name when exporting.
+- **save_adapter_weights_only**: `'true'`/`'false'` (default `'true'`) - Save only the LoRA adapter (~MB), skip the merged base+LoRA checkpoint (~GB). The saved `adapter_config.json` has its `base_model_name_or_path` rewritten to the local base-model path so the dir is self-loading on offline compute. Use `python -m cruijff_kit.tools.torchtune.port_cruijff_adapter <epoch_dir>` to restore the HF Hub name when exporting.
 
 ### Custom Recipe Usage
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -117,7 +117,7 @@ setup_finetune.yaml → setup_finetune.py → finetune.yaml + finetune.slurm
 
 **Custom features added to torchtune:**
 - Selective epoch saving (`epochs_to_save`)
-- Adapter weight management (`stash_adapter_weights`)
+- Adapter-only saves with self-loading offline (rewrite `adapter_config.json` base path after save; `uncruijff_adapter` restores HF Hub name for export)
 - Custom metrics integration via `src/utils/finetune_custom_metrics.py`
 - Validation during training (requires nightly build)
 
@@ -291,7 +291,7 @@ After running finetune:
 
 - **save_last_epoch_only**: `'true'`/`'false'` - Only save the final epoch
 
-- **stash_adapter_weights**: `'true'`/`'false'` - Moves adapter files to subdirectory after merging to avoid confusing inspect-ai
+- **save_adapter_weights_only**: `'true'`/`'false'` (default `'true'`) - Save only the LoRA adapter (~MB), skip the merged base+LoRA checkpoint (~GB). The saved `adapter_config.json` has its `base_model_name_or_path` rewritten to the local base-model path so the dir is self-loading on offline compute. Use `python -m cruijff_kit.tools.torchtune.uncruijff_adapter <epoch_dir>` to restore the HF Hub name when exporting.
 
 ### Custom Recipe Usage
 

--- a/src/tools/inspect/setup_inspect.py
+++ b/src/tools/inspect/setup_inspect.py
@@ -18,6 +18,9 @@ import os
 import yaml
 from pathlib import Path
 
+from cruijff_kit.tools.torchtune.custom_recipes.custom_recipe_utils import (
+    check_adapter_base_path,
+)
 from cruijff_kit.tools.torchtune.model_configs import MODEL_CONFIGS
 
 # Template lives next to this script
@@ -133,6 +136,13 @@ def load_eval_config(config_path):
         raise ValueError(
             f"eval_config.yaml missing required keys: {', '.join(missing)}"
         )
+
+    # If the model_path is an adapter dir, verify its baked-in base path still
+    # resolves on disk. Catches the case where pretrained-llms/ has moved
+    # between fine-tune and eval.
+    problem = check_adapter_base_path(Path(config["model_path"]))
+    if problem:
+        raise ValueError(problem)
 
     return config
 

--- a/src/tools/run/submit_inspect.py
+++ b/src/tools/run/submit_inspect.py
@@ -25,6 +25,8 @@ import argparse
 import sys
 from pathlib import Path
 
+import yaml
+
 from cruijff_kit.tools.run._submit_common import (
     TodoItem,
     monitor_only,
@@ -33,6 +35,9 @@ from cruijff_kit.tools.run._submit_common import (
     resolve_stagger_sec,
     resolve_user,
     submit_and_monitor,
+)
+from cruijff_kit.tools.torchtune.custom_recipes.custom_recipe_utils import (
+    check_adapter_base_path,
 )
 
 LOG_NAME = "run-inspect.log"
@@ -71,6 +76,27 @@ def _build_todo(experiment_dir: Path) -> list[TodoItem]:
     return todo
 
 
+def _preflight_adapter_base_paths(experiment_dir: Path) -> None:
+    """Refuse to submit if any eval points at an adapter dir whose baked-in
+    base_model_name_or_path no longer resolves on disk. Catches the case
+    where pretrained-llms/ has moved between fine-tune and eval.
+    """
+    problems: list[str] = []
+    for cfg_path in sorted(experiment_dir.glob("*/eval/eval_config.yaml")):
+        cfg = yaml.safe_load(cfg_path.read_text()) or {}
+        model_path = cfg.get("model_path")
+        if not model_path:
+            continue
+        problem = check_adapter_base_path(Path(model_path))
+        if problem:
+            problems.append(f"  - via {cfg_path}:\n      {problem}")
+    if problems:
+        raise SystemExit(
+            "Refusing to submit eval jobs — one or more adapters have stale "
+            "base-model paths:\n" + "\n".join(problems)
+        )
+
+
 def run(
     experiment_dir: Path,
     user: str | None = None,
@@ -106,6 +132,7 @@ def run(
             no_retry=no_retry,
         )
 
+    _preflight_adapter_base_paths(experiment_dir)
     todo = _build_todo(experiment_dir)
     return submit_and_monitor(
         todo=todo,

--- a/src/tools/torchtune/custom_recipes/custom_recipe_utils.py
+++ b/src/tools/torchtune/custom_recipes/custom_recipe_utils.py
@@ -10,60 +10,51 @@ Utility functions for custom recipes.
 !--- cruijff_kit patch ---!
 """
 
+import json
 import os
-import shutil
 
 from torchtune import utils
 
 log = utils.get_logger("DEBUG")
 
 
-def stash_adapter_files(output_dir: str, epoch: int, logger=None) -> None:
-    """
-    Move adapter files from the merged model checkpoint directory to a subdirectory
-    to prevent inspect-ai from being confused about whether this is a merged model.
+def rewrite_adapter_config_base_path(
+    output_dir: str, epoch: int, base_model_path: str, logger=None
+) -> None:
+    """Point adapter_config.json's base_model_name_or_path at the local base model.
 
-    This stashes:
-    - adapter_config.json
-    - adapter_model.pt
-    - adapter_model.safetensors
+    Torchtune writes the HF Hub repo name (e.g. 'meta-llama/Llama-3.2-1B-Instruct').
+    On offline compute nodes (HF_HUB_OFFLINE=1) transformers can't resolve that, so
+    we rewrite it to the absolute path of the local base model. Once rewritten,
+    transformers' native PEFT auto-detection (AutoModelForCausalLM.from_pretrained
+    on the adapter dir) loads the base + adapter without us emitting a merged
+    checkpoint — saving ~base-model-size disk per epoch.
 
-    into an 'adapter_weights' subdirectory within the checkpoint directory.
-
-    Args:
-        output_dir: Base output directory containing checkpoint subdirectories
-        epoch: Epoch number for the checkpoint directory
-        logger: Optional logger to use (defaults to module-level log)
+    The original HF Hub repo name is preserved in original_repo_id.json (which
+    torchtune already writes); the uncruijff_adapter utility uses that to restore
+    portability when exporting a checkpoint to another machine.
     """
     if logger is None:
         logger = log
 
-    # Get the checkpoint directory for this epoch
     checkpoint_dir = os.path.join(output_dir, f"epoch_{epoch}")
+    cfg_path = os.path.join(checkpoint_dir, "adapter_config.json")
 
-    if not os.path.exists(checkpoint_dir):
-        logger.warning(f"Checkpoint directory not found: {checkpoint_dir}")
+    if not os.path.exists(cfg_path):
+        logger.warning(
+            f"adapter_config.json not found at {cfg_path}; skipping base-path rewrite."
+        )
         return
 
-    # Create adapter_weights subdirectory
-    adapter_stash_dir = os.path.join(checkpoint_dir, "adapter_weights")
-    os.makedirs(adapter_stash_dir, exist_ok=True)
+    abs_base = os.path.abspath(base_model_path).rstrip("/")
+    with open(cfg_path) as f:
+        cfg_data = json.load(f)
 
-    # List of adapter files to stash
-    adapter_files = [
-        "adapter_config.json",
-        "adapter_model.pt",
-        "adapter_model.safetensors"
-    ]
+    original = cfg_data.get("base_model_name_or_path")
+    cfg_data["base_model_name_or_path"] = abs_base
+    with open(cfg_path, "w") as f:
+        json.dump(cfg_data, f, indent=2)
 
-    stashed_count = 0
-    for filename in adapter_files:
-        src_path = os.path.join(checkpoint_dir, filename)
-        if os.path.exists(src_path):
-            dst_path = os.path.join(adapter_stash_dir, filename)
-            shutil.move(src_path, dst_path)
-            logger.info(f"Stashed {filename} to adapter_weights/ subdirectory")
-            stashed_count += 1
-
-    if stashed_count == 0:
-        logger.info(f"No adapter files found to stash in {checkpoint_dir}")
+    logger.info(
+        f"Rewrote adapter_config.json base_model_name_or_path: {original} -> {abs_base}"
+    )

--- a/src/tools/torchtune/custom_recipes/custom_recipe_utils.py
+++ b/src/tools/torchtune/custom_recipes/custom_recipe_utils.py
@@ -31,8 +31,8 @@ def rewrite_adapter_config_base_path(
     checkpoint — saving ~base-model-size disk per epoch.
 
     The original HF Hub repo name is preserved in original_repo_id.json (which
-    torchtune already writes); the uncruijff_adapter utility uses that to restore
-    portability when exporting a checkpoint to another machine.
+    torchtune already writes); the port_cruijff_adapter utility uses that to
+    restore portability when exporting a checkpoint to another machine.
     """
     if logger is None:
         logger = log

--- a/src/tools/torchtune/custom_recipes/custom_recipe_utils.py
+++ b/src/tools/torchtune/custom_recipes/custom_recipe_utils.py
@@ -12,10 +12,57 @@ Utility functions for custom recipes.
 
 import json
 import os
+from pathlib import Path
 
 from torchtune import utils
 
 log = utils.get_logger("DEBUG")
+
+
+# Sentinel returned inside check_adapter_base_path()'s message so callers can
+# pattern-match for this specific failure mode in addition to surfacing the
+# whole human-readable string.
+STALE_BASE_PATH_TAG = "STALE_LOCAL_BASE_PATH"
+
+
+def check_adapter_base_path(adapter_dir) -> str | None:
+    """Verify the adapter dir's base_model_name_or_path is loadable here.
+
+    Returns None if the adapter dir is fine, or if the dir has no
+    adapter_config.json (i.e. it's a base model or merged checkpoint — not our
+    concern). Returns a human-readable problem description if
+    base_model_name_or_path is a local absolute path that no longer exists on
+    disk.
+
+    HF Hub-style names (e.g. "meta-llama/Llama-3.2-1B-Instruct") are NOT
+    checked here — they resolve via HF cache or hub, not the local filesystem.
+    If the user is on offline compute without a populated cache, transformers
+    will error at load time; that's a separate failure mode.
+    """
+    adapter_dir = Path(adapter_dir)
+    cfg_path = adapter_dir / "adapter_config.json"
+    if not cfg_path.exists():
+        return None
+
+    cfg = json.loads(cfg_path.read_text())
+    base = cfg.get("base_model_name_or_path")
+    if not base:
+        return None
+
+    # Local absolute path → check the filesystem.
+    if base.startswith(os.sep) or (len(base) > 1 and base[1] == ":"):
+        if not Path(base).exists():
+            return (
+                f"{STALE_BASE_PATH_TAG}: adapter at {adapter_dir} expects base "
+                f"model at {base}, but that path does not exist. The base "
+                "model has likely moved. Re-point with `python -m "
+                "cruijff_kit.tools.torchtune.port_cruijff_adapter "
+                f"{adapter_dir} --repo-id <new_path_or_hf_repo_id>`, or "
+                "restore the base model to its original location."
+            )
+
+    # HF Hub name (org/name shape) — leave to transformers/HF cache to resolve.
+    return None
 
 
 def rewrite_adapter_config_base_path(

--- a/src/tools/torchtune/custom_recipes/custom_recipe_utils.py
+++ b/src/tools/torchtune/custom_recipes/custom_recipe_utils.py
@@ -12,6 +12,7 @@ Utility functions for custom recipes.
 
 import json
 import os
+import shutil
 from pathlib import Path
 
 from torchtune import utils
@@ -105,3 +106,46 @@ def rewrite_adapter_config_base_path(
     logger.info(
         f"Rewrote adapter_config.json base_model_name_or_path: {original} -> {abs_base}"
     )
+
+
+def stash_adapter_files(output_dir: str, epoch: int, logger=None) -> None:
+    """Move adapter files into an `adapter_weights/` subdir of the epoch dir.
+
+    Used when `save_adapter_weights_only=False` (i.e. torchtune wrote both the
+    merged base+LoRA checkpoint AND the adapter files side-by-side). With both
+    present at the top level, transformers' native PEFT auto-detection wins:
+    `AutoModelForCausalLM.from_pretrained(dir)` loads base + adapter and the
+    merged `model.safetensors` sits ignored. Moving the adapter files out of
+    the way lets the merged checkpoint load as intended.
+
+    The stashed adapter dir is left in its portable PEFT form
+    (base_model_name_or_path still the HF Hub repo name as torchtune wrote it)
+    — anyone who wants to use the adapter directly can load it from
+    `<epoch_dir>/adapter_weights/`.
+    """
+    if logger is None:
+        logger = log
+
+    checkpoint_dir = os.path.join(output_dir, f"epoch_{epoch}")
+    if not os.path.exists(checkpoint_dir):
+        logger.warning(f"Checkpoint directory not found: {checkpoint_dir}")
+        return
+
+    adapter_stash_dir = os.path.join(checkpoint_dir, "adapter_weights")
+    os.makedirs(adapter_stash_dir, exist_ok=True)
+
+    adapter_files = [
+        "adapter_config.json",
+        "adapter_model.pt",
+        "adapter_model.safetensors",
+    ]
+    stashed = 0
+    for filename in adapter_files:
+        src = os.path.join(checkpoint_dir, filename)
+        if os.path.exists(src):
+            shutil.move(src, os.path.join(adapter_stash_dir, filename))
+            logger.info(f"Stashed {filename} to adapter_weights/ subdirectory")
+            stashed += 1
+
+    if stashed == 0:
+        logger.info(f"No adapter files found to stash in {checkpoint_dir}")

--- a/src/tools/torchtune/custom_recipes/lora_finetune_distributed_stable.py
+++ b/src/tools/torchtune/custom_recipes/lora_finetune_distributed_stable.py
@@ -16,8 +16,8 @@ import torch
 from omegaconf import DictConfig, ListConfig
 
 # !--- cruijff_kit patch ---!
-# Feature: stash_adapter_files - Helper function for checkpoint cleanup
-from cruijff_kit.tools.torchtune.custom_recipes.custom_recipe_utils import stash_adapter_files
+# Feature: adapter_config base-path rewrite — make adapter dirs self-loading offline
+from cruijff_kit.tools.torchtune.custom_recipes.custom_recipe_utils import rewrite_adapter_config_base_path
 # !--- end cruijff_kit patch ---!
 
 from torch import nn
@@ -203,7 +203,8 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         self._epochs_to_save = [self.total_epochs - 1] if self._save_last_epoch_only else cfg.get("epochs_to_save", 'all')
         if self._epochs_to_save == 'all':
             self._epochs_to_save = list(range(self.total_epochs))
-        self._stash_adapter_weights = cfg.get("stash_adapter_weights", False)
+        # Base-model checkpoint_dir (used to rewrite adapter_config.json after save)
+        self._base_model_path = cfg.checkpointer.checkpoint_dir
         # !--- end cruijff_kit patch ---!
         self._resume_from_checkpoint = cfg.resume_from_checkpoint
         self._gradient_accumulation_steps = cfg.gradient_accumulation_steps
@@ -968,11 +969,11 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                 log.info(f"Starting checkpoint save for epoch {curr_epoch}...")
                 self.save_checkpoint(epoch=curr_epoch)
 
-                # Stash adapter files if configured (to avoid confusing inspect-ai)
-                # Only run on rank 0
-                if self._is_rank_zero and self._stash_adapter_weights and not self._save_adapter_weights_only:
-                    utils.log_rank_zero(log, "Stashing adapter files from merged model checkpoint...")
-                    stash_adapter_files(self._output_dir, curr_epoch, log)
+                # Rewrite adapter_config.json's base_model_name_or_path to the
+                # local base-model path so the adapter dir is self-loading on
+                # offline compute nodes. Rank 0 only.
+                if self._is_rank_zero:
+                    rewrite_adapter_config_base_path(self._output_dir, curr_epoch, self._base_model_path, log)
             else:
                 log.info(f"Skipping checkpoint save for epoch {curr_epoch}...")
             # !--- end cruijff_kit patch ---!

--- a/src/tools/torchtune/custom_recipes/lora_finetune_distributed_stable.py
+++ b/src/tools/torchtune/custom_recipes/lora_finetune_distributed_stable.py
@@ -16,8 +16,8 @@ import torch
 from omegaconf import DictConfig, ListConfig
 
 # !--- cruijff_kit patch ---!
-# Feature: adapter_config base-path rewrite — make adapter dirs self-loading offline
-from cruijff_kit.tools.torchtune.custom_recipes.custom_recipe_utils import rewrite_adapter_config_base_path
+# Feature: adapter_config base-path rewrite (adapter-only saves) and stash_adapter_files (merged saves)
+from cruijff_kit.tools.torchtune.custom_recipes.custom_recipe_utils import rewrite_adapter_config_base_path, stash_adapter_files
 # !--- end cruijff_kit patch ---!
 
 from torch import nn
@@ -969,11 +969,15 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                 log.info(f"Starting checkpoint save for epoch {curr_epoch}...")
                 self.save_checkpoint(epoch=curr_epoch)
 
-                # Rewrite adapter_config.json's base_model_name_or_path to the
-                # local base-model path so the adapter dir is self-loading on
-                # offline compute nodes. Rank 0 only.
+                # Adapter-only save: rewrite adapter_config.json's base path.
+                # Merged save: stash adapter files so the merged checkpoint
+                # loads as merged (rather than being shadowed by PEFT auto-
+                # detection). Rank 0 only.
                 if self._is_rank_zero:
-                    rewrite_adapter_config_base_path(self._output_dir, curr_epoch, self._base_model_path, log)
+                    if self._save_adapter_weights_only:
+                        rewrite_adapter_config_base_path(self._output_dir, curr_epoch, self._base_model_path, log)
+                    else:
+                        stash_adapter_files(self._output_dir, curr_epoch, log)
             else:
                 log.info(f"Skipping checkpoint save for epoch {curr_epoch}...")
             # !--- end cruijff_kit patch ---!

--- a/src/tools/torchtune/custom_recipes/lora_finetune_single_device_nightly.py
+++ b/src/tools/torchtune/custom_recipes/lora_finetune_single_device_nightly.py
@@ -17,8 +17,8 @@ import torchtune.modules.common_utils as common_utils
 from omegaconf import DictConfig, ListConfig
 
 # !--- cruijff_kit patch ---!
-# Feature: adapter_config base-path rewrite — make adapter dirs self-loading offline
-from cruijff_kit.tools.torchtune.custom_recipes.custom_recipe_utils import rewrite_adapter_config_base_path
+# Feature: adapter_config base-path rewrite (adapter-only saves) and stash_adapter_files (merged saves)
+from cruijff_kit.tools.torchtune.custom_recipes.custom_recipe_utils import rewrite_adapter_config_base_path, stash_adapter_files
 # !--- end cruijff_kit patch ---!
 
 from torch import nn
@@ -1011,10 +1011,15 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                         )
                     )
 
-                    # Rewrite adapter_config.json's base_model_name_or_path to the
-                    # local base-model path so the adapter dir is self-loading on
-                    # offline compute nodes (transformers' native PEFT auto-detection).
-                    rewrite_adapter_config_base_path(self._output_dir, curr_epoch, self._base_model_path, log)
+                    # Adapter-only save: rewrite adapter_config.json's base path
+                    # so the dir is self-loading on offline compute.
+                    # Merged save: stash adapter files into a subdir so the merged
+                    # model.safetensors loads (otherwise transformers' PEFT
+                    # auto-detection picks adapter+base over the merged file).
+                    if self._save_adapter_weights_only:
+                        rewrite_adapter_config_base_path(self._output_dir, curr_epoch, self._base_model_path, log)
+                    else:
+                        stash_adapter_files(self._output_dir, curr_epoch, log)
                 else:
                     log.info(f"Skipping checkpoint save for epoch {curr_epoch}...")
                 # !--- end cruijff_kit patch ---!

--- a/src/tools/torchtune/custom_recipes/lora_finetune_single_device_nightly.py
+++ b/src/tools/torchtune/custom_recipes/lora_finetune_single_device_nightly.py
@@ -17,8 +17,8 @@ import torchtune.modules.common_utils as common_utils
 from omegaconf import DictConfig, ListConfig
 
 # !--- cruijff_kit patch ---!
-# Feature: stash_adapter_files - Helper function for checkpoint cleanup
-from cruijff_kit.tools.torchtune.custom_recipes.custom_recipe_utils import stash_adapter_files
+# Feature: adapter_config base-path rewrite — make adapter dirs self-loading offline
+from cruijff_kit.tools.torchtune.custom_recipes.custom_recipe_utils import rewrite_adapter_config_base_path
 # !--- end cruijff_kit patch ---!
 
 from torch import nn
@@ -194,7 +194,8 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         self._epochs_to_save = [self.total_epochs - 1] if self._save_last_epoch_only else cfg.get("epochs_to_save", 'all')
         if self._epochs_to_save == 'all':
             self._epochs_to_save = list(range(self.total_epochs))
-        self._stash_adapter_weights = cfg.get("stash_adapter_weights", False)
+        # Base-model checkpoint_dir (used to rewrite adapter_config.json after save)
+        self._base_model_path = cfg.checkpointer.checkpoint_dir
         # !--- end cruijff_kit patch ---!
         self._gradient_accumulation_steps = cfg.gradient_accumulation_steps
         self._clip_grad_norm = cfg.get("clip_grad_norm", None)
@@ -1010,10 +1011,10 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                         )
                     )
 
-                    # Stash adapter files if configured (to avoid confusing inspect-ai)
-                    if self._stash_adapter_weights and not self._save_adapter_weights_only:
-                        log.info("Stashing adapter files from merged model checkpoint...")
-                        stash_adapter_files(self._output_dir, curr_epoch, log)
+                    # Rewrite adapter_config.json's base_model_name_or_path to the
+                    # local base-model path so the adapter dir is self-loading on
+                    # offline compute nodes (transformers' native PEFT auto-detection).
+                    rewrite_adapter_config_base_path(self._output_dir, curr_epoch, self._base_model_path, log)
                 else:
                     log.info(f"Skipping checkpoint save for epoch {curr_epoch}...")
                 # !--- end cruijff_kit patch ---!

--- a/src/tools/torchtune/custom_recipes/lora_finetune_single_device_stable.py
+++ b/src/tools/torchtune/custom_recipes/lora_finetune_single_device_stable.py
@@ -16,8 +16,8 @@ import torchtune.modules.common_utils as common_utils
 from omegaconf import DictConfig, ListConfig
 
 # !--- cruijff_kit patch ---!
-# Feature: stash_adapter_files - Helper function for checkpoint cleanup
-from cruijff_kit.tools.torchtune.custom_recipes.custom_recipe_utils import stash_adapter_files
+# Feature: adapter_config base-path rewrite — make adapter dirs self-loading offline
+from cruijff_kit.tools.torchtune.custom_recipes.custom_recipe_utils import rewrite_adapter_config_base_path
 # !--- end cruijff_kit patch ---!
 
 from torch import nn
@@ -193,7 +193,8 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         self._epochs_to_save = [self.total_epochs - 1] if self._save_last_epoch_only else cfg.get("epochs_to_save", 'all')
         if self._epochs_to_save == 'all':
             self._epochs_to_save = list(range(self.total_epochs))
-        self._stash_adapter_weights = cfg.get("stash_adapter_weights", False)
+        # Base-model checkpoint_dir (used to rewrite adapter_config.json after save)
+        self._base_model_path = cfg.checkpointer.checkpoint_dir
         # !--- end cruijff_kit patch ---!
         self._gradient_accumulation_steps = cfg.gradient_accumulation_steps
         self._clip_grad_norm = cfg.get("clip_grad_norm", None)
@@ -857,10 +858,10 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                         )
                     )
 
-                    # Stash adapter files if configured (to avoid confusing inspect-ai)
-                    if self._stash_adapter_weights and not self._save_adapter_weights_only:
-                        log.info("Stashing adapter files from merged model checkpoint...")
-                        stash_adapter_files(self._output_dir, curr_epoch, log)
+                    # Rewrite adapter_config.json's base_model_name_or_path to the
+                    # local base-model path so the adapter dir is self-loading on
+                    # offline compute nodes (transformers' native PEFT auto-detection).
+                    rewrite_adapter_config_base_path(self._output_dir, curr_epoch, self._base_model_path, log)
                 else:
                     log.info(f"Skipping checkpoint save for epoch {curr_epoch}...")
                 # !--- end cruijff_kit patch ---!

--- a/src/tools/torchtune/custom_recipes/lora_finetune_single_device_stable.py
+++ b/src/tools/torchtune/custom_recipes/lora_finetune_single_device_stable.py
@@ -16,8 +16,8 @@ import torchtune.modules.common_utils as common_utils
 from omegaconf import DictConfig, ListConfig
 
 # !--- cruijff_kit patch ---!
-# Feature: adapter_config base-path rewrite — make adapter dirs self-loading offline
-from cruijff_kit.tools.torchtune.custom_recipes.custom_recipe_utils import rewrite_adapter_config_base_path
+# Feature: adapter_config base-path rewrite (adapter-only saves) and stash_adapter_files (merged saves)
+from cruijff_kit.tools.torchtune.custom_recipes.custom_recipe_utils import rewrite_adapter_config_base_path, stash_adapter_files
 # !--- end cruijff_kit patch ---!
 
 from torch import nn
@@ -858,10 +858,15 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                         )
                     )
 
-                    # Rewrite adapter_config.json's base_model_name_or_path to the
-                    # local base-model path so the adapter dir is self-loading on
-                    # offline compute nodes (transformers' native PEFT auto-detection).
-                    rewrite_adapter_config_base_path(self._output_dir, curr_epoch, self._base_model_path, log)
+                    # Adapter-only save: rewrite adapter_config.json's base path
+                    # so the dir is self-loading on offline compute.
+                    # Merged save: stash adapter files into a subdir so the merged
+                    # model.safetensors loads (otherwise transformers' PEFT
+                    # auto-detection picks adapter+base over the merged file).
+                    if self._save_adapter_weights_only:
+                        rewrite_adapter_config_base_path(self._output_dir, curr_epoch, self._base_model_path, log)
+                    else:
+                        stash_adapter_files(self._output_dir, curr_epoch, log)
                 else:
                     log.info(f"Skipping checkpoint save for epoch {curr_epoch}...")
                 # !--- end cruijff_kit patch ---!

--- a/src/tools/torchtune/port_cruijff_adapter.py
+++ b/src/tools/torchtune/port_cruijff_adapter.py
@@ -11,9 +11,9 @@ model was HF-downloaded with that marker present). If that file is missing,
 supply the value explicitly with `--repo-id`.
 
 Usage:
-    python -m cruijff_kit.tools.torchtune.uncruijff_adapter <epoch_dir>
-    python -m cruijff_kit.tools.torchtune.uncruijff_adapter <run_dir>  # recurses over epoch_*
-    python -m cruijff_kit.tools.torchtune.uncruijff_adapter <dir> --repo-id meta-llama/Llama-3.2-1B-Instruct
+    python -m cruijff_kit.tools.torchtune.port_cruijff_adapter <epoch_dir>
+    python -m cruijff_kit.tools.torchtune.port_cruijff_adapter <run_dir>  # recurses over epoch_*
+    python -m cruijff_kit.tools.torchtune.port_cruijff_adapter <dir> --repo-id meta-llama/Llama-3.2-1B-Instruct
 
 After running, `AutoModelForCausalLM.from_pretrained(<dir>)` will resolve the
 base via the HF Hub (or HF cache) as PEFT intends.

--- a/src/tools/torchtune/setup_finetune.py
+++ b/src/tools/torchtune/setup_finetune.py
@@ -451,20 +451,16 @@ def create_parser():
     parser.add_argument(
         "--save_adapter_weights_only",
         type=parse_bool,
-        default=False,
-        help="Whether to save only the adapter weights (true/false)",
+        default=True,
+        help="Save only adapter weights, skipping the merged base+LoRA checkpoint (true/false). "
+        "Default True saves ~base-model-size disk per epoch; the saved adapter dir is "
+        "self-loading because we rewrite adapter_config.json to point at the local base.",
     )
     parser.add_argument(
         "--save_last_epoch_only",
         type=parse_bool,
         default=False,
         help="Whether to save only the last epoch (true/false)",
-    )
-    parser.add_argument(
-        "--stash_adapter_weights",
-        type=parse_bool,
-        default=False,
-        help="Whether to stash adapter files in subdirectory to avoid confusing inspect-ai (true/false)",
     )
     parser.add_argument(
         "--epochs_to_save",

--- a/src/tools/torchtune/templates/finetune_template.yaml
+++ b/src/tools/torchtune/templates/finetune_template.yaml
@@ -42,7 +42,7 @@ checkpointer:
   output_dir: ${output_dir}
   model_type: LLAMA3_2
 resume_from_checkpoint: False
-save_adapter_weights_only: False
+save_adapter_weights_only: True
 save_last_epoch_only: False
 epochs_to_save: 'all'
 

--- a/src/tools/torchtune/uncruijff_adapter.py
+++ b/src/tools/torchtune/uncruijff_adapter.py
@@ -1,0 +1,111 @@
+"""Restore portability to a cruijff_kit-saved LoRA adapter directory.
+
+By default, cruijff_kit rewrites `adapter_config.json`'s `base_model_name_or_path`
+to a local absolute path so the adapter dir is self-loading on offline compute
+nodes. That trade-off breaks portability — the rewritten path is meaningless on
+a different machine.
+
+This utility restores a portable name into `adapter_config.json`. It prefers the
+repo name from `original_repo_id.json` (which torchtune copies in when the base
+model was HF-downloaded with that marker present). If that file is missing,
+supply the value explicitly with `--repo-id`.
+
+Usage:
+    python -m cruijff_kit.tools.torchtune.uncruijff_adapter <epoch_dir>
+    python -m cruijff_kit.tools.torchtune.uncruijff_adapter <run_dir>  # recurses over epoch_*
+    python -m cruijff_kit.tools.torchtune.uncruijff_adapter <dir> --repo-id meta-llama/Llama-3.2-1B-Instruct
+
+After running, `AutoModelForCausalLM.from_pretrained(<dir>)` will resolve the
+base via the HF Hub (or HF cache) as PEFT intends.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _resolve_repo_id(epoch_dir: Path, repo_id_override: str | None) -> str | None:
+    if repo_id_override:
+        return repo_id_override
+    repo_id_file = epoch_dir / "original_repo_id.json"
+    if repo_id_file.exists():
+        return json.loads(repo_id_file.read_text())["repo_id"]
+    return None
+
+
+def restore_one(epoch_dir: Path, repo_id_override: str | None = None) -> bool:
+    """Restore adapter_config.json's base_model_name_or_path to a portable value.
+
+    Returns True if the file was rewritten, False if skipped.
+    """
+    adapter_cfg = epoch_dir / "adapter_config.json"
+    if not adapter_cfg.exists():
+        print(f"  [skip] {epoch_dir}: no adapter_config.json")
+        return False
+
+    repo_id = _resolve_repo_id(epoch_dir, repo_id_override)
+    if repo_id is None:
+        print(
+            f"  [skip] {epoch_dir}: no original_repo_id.json — pass --repo-id to override"
+        )
+        return False
+
+    cfg = json.loads(adapter_cfg.read_text())
+    before = cfg.get("base_model_name_or_path")
+
+    if before == repo_id:
+        print(f"  [ok]   {epoch_dir}: already {repo_id}")
+        return False
+
+    cfg["base_model_name_or_path"] = repo_id
+    adapter_cfg.write_text(json.dumps(cfg, indent=2))
+    print(f"  [done] {epoch_dir}: {before} -> {repo_id}")
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "path",
+        type=Path,
+        help="Adapter epoch dir (with adapter_config.json) or run dir (with epoch_* children).",
+    )
+    parser.add_argument(
+        "--repo-id",
+        type=str,
+        default=None,
+        help="HF Hub repo name to write (e.g. 'meta-llama/Llama-3.2-1B-Instruct'). "
+        "Required when the adapter dir has no original_repo_id.json; overrides it when present.",
+    )
+    args = parser.parse_args()
+    root = args.path
+
+    if not root.exists():
+        print(f"ERROR: {root} does not exist", file=sys.stderr)
+        return 1
+
+    # If the directory itself has adapter_config.json, treat as a single epoch dir.
+    # Otherwise look for epoch_* children.
+    if (root / "adapter_config.json").exists():
+        targets = [root]
+    else:
+        targets = sorted(
+            p for p in root.iterdir() if p.is_dir() and p.name.startswith("epoch_")
+        )
+
+    if not targets:
+        print(f"ERROR: no adapter dirs found under {root}", file=sys.stderr)
+        return 1
+
+    print(f"Restoring portable HF Hub repo names under {root}:")
+    changed = 0
+    for t in targets:
+        if restore_one(t, args.repo_id):
+            changed += 1
+    print(f"Rewrote {changed}/{len(targets)} adapter_config.json files.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/tools/torchtune/yaml_refs/1B_defaults.yaml
+++ b/src/tools/torchtune/yaml_refs/1B_defaults.yaml
@@ -44,7 +44,7 @@ checkpointer:
   output_dir: ${output_dir}
   model_type: LLAMA3_2
 resume_from_checkpoint: False
-save_adapter_weights_only: False
+save_adapter_weights_only: True
 
 # Dataset and Sampler
 dataset:

--- a/src/tools/torchtune/yaml_refs/8B_defaults.yaml
+++ b/src/tools/torchtune/yaml_refs/8B_defaults.yaml
@@ -49,7 +49,7 @@ checkpointer:
   output_dir: ${output_dir}
   model_type: LLAMA3
 resume_from_checkpoint: False
-save_adapter_weights_only: False
+save_adapter_weights_only: True
 
 # Dataset and Sampler
 dataset:

--- a/tests/unit/test_adapter_config_rewrite.py
+++ b/tests/unit/test_adapter_config_rewrite.py
@@ -1,4 +1,4 @@
-"""Unit tests for adapter_config.json base-path rewrite + uncruijff round-trip."""
+"""Unit tests for adapter_config.json base-path rewrite + port_cruijff_adapter round-trip."""
 
 import io
 import json
@@ -9,7 +9,7 @@ from pathlib import Path
 from cruijff_kit.tools.torchtune.custom_recipes.custom_recipe_utils import (
     rewrite_adapter_config_base_path,
 )
-from cruijff_kit.tools.torchtune import uncruijff_adapter
+from cruijff_kit.tools.torchtune import port_cruijff_adapter
 
 
 def _write_epoch(tmp_path: Path, epoch: int, *, with_repo_id: bool = True) -> Path:
@@ -70,7 +70,7 @@ def test_rewrite_skips_when_no_adapter_config(tmp_path, caplog):
     assert any("not found" in r.message for r in caplog.records)
 
 
-def test_uncruijff_restores_hub_name_single_epoch_dir(tmp_path):
+def test_port_cruijff_restores_hub_name_single_epoch_dir(tmp_path):
     epoch_dir = _write_epoch(tmp_path, 0)
     # Simulate a cruijff-rewritten config first
     rewrite_adapter_config_base_path(
@@ -78,30 +78,30 @@ def test_uncruijff_restores_hub_name_single_epoch_dir(tmp_path):
     )
     assert _read_base(epoch_dir) == "/local/abs/path"
 
-    uncruijff_adapter.restore_one(epoch_dir)
+    port_cruijff_adapter.restore_one(epoch_dir)
 
     assert _read_base(epoch_dir) == "meta-llama/Llama-3.2-1B-Instruct"
 
 
-def test_uncruijff_skips_when_no_original_repo_id_and_no_override(tmp_path, capsys):
+def test_port_cruijff_skips_when_no_original_repo_id_and_no_override(tmp_path, capsys):
     epoch_dir = _write_epoch(tmp_path, 0, with_repo_id=False)
     rewrite_adapter_config_base_path(
         str(tmp_path), 0, "/local/abs/path", _silent_logger()
     )
 
-    changed = uncruijff_adapter.restore_one(epoch_dir)
+    changed = port_cruijff_adapter.restore_one(epoch_dir)
 
     assert changed is False
     assert _read_base(epoch_dir) == "/local/abs/path"
 
 
-def test_uncruijff_uses_repo_id_override_when_marker_missing(tmp_path):
+def test_port_cruijff_uses_repo_id_override_when_marker_missing(tmp_path):
     epoch_dir = _write_epoch(tmp_path, 0, with_repo_id=False)
     rewrite_adapter_config_base_path(
         str(tmp_path), 0, "/local/abs/path", _silent_logger()
     )
 
-    changed = uncruijff_adapter.restore_one(
+    changed = port_cruijff_adapter.restore_one(
         epoch_dir, repo_id_override="meta-llama/Llama-3.2-1B-Instruct"
     )
 
@@ -109,39 +109,39 @@ def test_uncruijff_uses_repo_id_override_when_marker_missing(tmp_path):
     assert _read_base(epoch_dir) == "meta-llama/Llama-3.2-1B-Instruct"
 
 
-def test_uncruijff_repo_id_override_wins_over_marker(tmp_path):
+def test_port_cruijff_repo_id_override_wins_over_marker(tmp_path):
     epoch_dir = _write_epoch(tmp_path, 0, with_repo_id=True)
     rewrite_adapter_config_base_path(
         str(tmp_path), 0, "/local/abs/path", _silent_logger()
     )
 
-    uncruijff_adapter.restore_one(epoch_dir, repo_id_override="my-org/forked-model")
+    port_cruijff_adapter.restore_one(epoch_dir, repo_id_override="my-org/forked-model")
 
     assert _read_base(epoch_dir) == "my-org/forked-model"
 
 
-def test_uncruijff_recurses_over_run_dir(tmp_path, monkeypatch, capsys):
+def test_port_cruijff_recurses_over_run_dir(tmp_path, monkeypatch, capsys):
     _write_epoch(tmp_path, 0)
     _write_epoch(tmp_path, 1)
     rewrite_adapter_config_base_path(str(tmp_path), 0, "/local/p", _silent_logger())
     rewrite_adapter_config_base_path(str(tmp_path), 1, "/local/p", _silent_logger())
 
-    monkeypatch.setattr("sys.argv", ["uncruijff_adapter", str(tmp_path)])
-    exit_code = uncruijff_adapter.main()
+    monkeypatch.setattr("sys.argv", ["port_cruijff_adapter", str(tmp_path)])
+    exit_code = port_cruijff_adapter.main()
 
     assert exit_code == 0
     assert _read_base(tmp_path / "epoch_0") == "meta-llama/Llama-3.2-1B-Instruct"
     assert _read_base(tmp_path / "epoch_1") == "meta-llama/Llama-3.2-1B-Instruct"
 
 
-def test_uncruijff_errors_on_missing_path(tmp_path, monkeypatch, capsys):
-    monkeypatch.setattr("sys.argv", ["uncruijff_adapter", str(tmp_path / "nope")])
-    exit_code = uncruijff_adapter.main()
+def test_port_cruijff_errors_on_missing_path(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("sys.argv", ["port_cruijff_adapter", str(tmp_path / "nope")])
+    exit_code = port_cruijff_adapter.main()
     assert exit_code == 1
 
 
-def test_uncruijff_errors_when_no_epoch_dirs(tmp_path, monkeypatch, capsys):
+def test_port_cruijff_errors_when_no_epoch_dirs(tmp_path, monkeypatch, capsys):
     # Empty dir, no epoch_*, no adapter_config.json
-    monkeypatch.setattr("sys.argv", ["uncruijff_adapter", str(tmp_path)])
-    exit_code = uncruijff_adapter.main()
+    monkeypatch.setattr("sys.argv", ["port_cruijff_adapter", str(tmp_path)])
+    exit_code = port_cruijff_adapter.main()
     assert exit_code == 1

--- a/tests/unit/test_adapter_config_rewrite.py
+++ b/tests/unit/test_adapter_config_rewrite.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 
 from cruijff_kit.tools.torchtune.custom_recipes.custom_recipe_utils import (
+    check_adapter_base_path,
     rewrite_adapter_config_base_path,
 )
 from cruijff_kit.tools.torchtune import port_cruijff_adapter
@@ -145,3 +146,39 @@ def test_port_cruijff_errors_when_no_epoch_dirs(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr("sys.argv", ["port_cruijff_adapter", str(tmp_path)])
     exit_code = port_cruijff_adapter.main()
     assert exit_code == 1
+
+
+# ---------- check_adapter_base_path ----------
+
+
+def test_check_returns_none_when_base_path_exists(tmp_path):
+    epoch_dir = _write_epoch(tmp_path, 0)
+    fake_base = tmp_path / "fake_base"
+    fake_base.mkdir()
+    rewrite_adapter_config_base_path(str(tmp_path), 0, str(fake_base), _silent_logger())
+
+    assert check_adapter_base_path(epoch_dir) is None
+
+
+def test_check_flags_missing_local_base_path(tmp_path):
+    epoch_dir = _write_epoch(tmp_path, 0)
+    rewrite_adapter_config_base_path(
+        str(tmp_path), 0, "/scratch/gone/base", _silent_logger()
+    )
+
+    problem = check_adapter_base_path(epoch_dir)
+    assert problem is not None
+    assert "STALE_LOCAL_BASE_PATH" in problem
+    assert "/scratch/gone/base" in problem
+
+
+def test_check_skips_hf_hub_style_names(tmp_path):
+    """HF Hub repo names resolve via cache/hub, not filesystem — don't flag."""
+    epoch_dir = _write_epoch(tmp_path, 0)
+    # adapter_config.json from _write_epoch already has a hub-style name
+    assert check_adapter_base_path(epoch_dir) is None
+
+
+def test_check_returns_none_when_no_adapter_config(tmp_path):
+    """Dirs without adapter_config.json (e.g. base/merged model) aren't our concern."""
+    assert check_adapter_base_path(tmp_path) is None

--- a/tests/unit/test_adapter_config_rewrite.py
+++ b/tests/unit/test_adapter_config_rewrite.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from cruijff_kit.tools.torchtune.custom_recipes.custom_recipe_utils import (
     check_adapter_base_path,
     rewrite_adapter_config_base_path,
+    stash_adapter_files,
 )
 from cruijff_kit.tools.torchtune import port_cruijff_adapter
 
@@ -182,3 +183,48 @@ def test_check_skips_hf_hub_style_names(tmp_path):
 def test_check_returns_none_when_no_adapter_config(tmp_path):
     """Dirs without adapter_config.json (e.g. base/merged model) aren't our concern."""
     assert check_adapter_base_path(tmp_path) is None
+
+
+# ---------- stash_adapter_files ----------
+
+
+def _write_merged_save(tmp_path: Path, epoch: int) -> Path:
+    """Simulate what torchtune writes when save_adapter_weights_only=False —
+    merged model.safetensors + adapter files side-by-side."""
+    epoch_dir = tmp_path / f"epoch_{epoch}"
+    epoch_dir.mkdir(parents=True)
+    (epoch_dir / "model.safetensors").write_text("fake-merged-weights")
+    (epoch_dir / "adapter_config.json").write_text("{}")
+    (epoch_dir / "adapter_model.safetensors").write_text("fake-adapter-weights")
+    return epoch_dir
+
+
+def test_stash_moves_adapter_files_into_subdir(tmp_path):
+    epoch_dir = _write_merged_save(tmp_path, 0)
+    stash_adapter_files(str(tmp_path), 0, _silent_logger())
+
+    assert (epoch_dir / "model.safetensors").exists()  # merged stays
+    assert not (epoch_dir / "adapter_config.json").exists()  # adapter moved
+    assert not (epoch_dir / "adapter_model.safetensors").exists()
+    assert (epoch_dir / "adapter_weights" / "adapter_config.json").exists()
+    assert (epoch_dir / "adapter_weights" / "adapter_model.safetensors").exists()
+
+
+def test_stash_skips_missing_files_gracefully(tmp_path):
+    """Only some adapter files present — stash should move what exists, skip the rest."""
+    epoch_dir = tmp_path / "epoch_0"
+    epoch_dir.mkdir()
+    (epoch_dir / "model.safetensors").write_text("merged")
+    (epoch_dir / "adapter_config.json").write_text("{}")
+    # adapter_model.safetensors deliberately absent
+
+    stash_adapter_files(str(tmp_path), 0, _silent_logger())
+
+    assert (epoch_dir / "adapter_weights" / "adapter_config.json").exists()
+    assert not (epoch_dir / "adapter_weights" / "adapter_model.safetensors").exists()
+
+
+def test_stash_warns_when_epoch_dir_missing(tmp_path, caplog):
+    with caplog.at_level(logging.WARNING):
+        stash_adapter_files(str(tmp_path), 99)
+    assert any("not found" in r.message for r in caplog.records)

--- a/tests/unit/test_adapter_config_rewrite.py
+++ b/tests/unit/test_adapter_config_rewrite.py
@@ -1,0 +1,147 @@
+"""Unit tests for adapter_config.json base-path rewrite + uncruijff round-trip."""
+
+import io
+import json
+import logging
+from pathlib import Path
+
+
+from cruijff_kit.tools.torchtune.custom_recipes.custom_recipe_utils import (
+    rewrite_adapter_config_base_path,
+)
+from cruijff_kit.tools.torchtune import uncruijff_adapter
+
+
+def _write_epoch(tmp_path: Path, epoch: int, *, with_repo_id: bool = True) -> Path:
+    epoch_dir = tmp_path / f"epoch_{epoch}"
+    epoch_dir.mkdir(parents=True)
+    (epoch_dir / "adapter_config.json").write_text(
+        json.dumps(
+            {
+                "r": 8,
+                "lora_alpha": 16,
+                "peft_type": "LORA",
+                "base_model_name_or_path": "meta-llama/Llama-3.2-1B-Instruct",
+            }
+        )
+    )
+    if with_repo_id:
+        (epoch_dir / "original_repo_id.json").write_text(
+            json.dumps({"repo_id": "meta-llama/Llama-3.2-1B-Instruct"})
+        )
+    return epoch_dir
+
+
+def _read_base(epoch_dir: Path) -> str:
+    return json.loads((epoch_dir / "adapter_config.json").read_text())[
+        "base_model_name_or_path"
+    ]
+
+
+def _silent_logger() -> logging.Logger:
+    logger = logging.getLogger("test_adapter_rewrite")
+    logger.addHandler(logging.StreamHandler(io.StringIO()))
+    return logger
+
+
+def test_rewrite_replaces_hub_name_with_local_abs_path(tmp_path):
+    _write_epoch(tmp_path, 0)
+    base = "/scratch/pretrained-llms/Llama-3.2-1B-Instruct/"
+
+    rewrite_adapter_config_base_path(str(tmp_path), 0, base, _silent_logger())
+
+    assert _read_base(tmp_path / "epoch_0") == base.rstrip("/")
+
+
+def test_rewrite_is_idempotent(tmp_path):
+    _write_epoch(tmp_path, 0)
+    base = "/scratch/pretrained-llms/Llama-3.2-1B-Instruct"
+
+    rewrite_adapter_config_base_path(str(tmp_path), 0, base, _silent_logger())
+    rewrite_adapter_config_base_path(str(tmp_path), 0, base, _silent_logger())
+
+    assert _read_base(tmp_path / "epoch_0") == base
+
+
+def test_rewrite_skips_when_no_adapter_config(tmp_path, caplog):
+    (tmp_path / "epoch_0").mkdir()
+    with caplog.at_level(logging.WARNING):
+        rewrite_adapter_config_base_path(str(tmp_path), 0, "/some/path")
+    assert any("not found" in r.message for r in caplog.records)
+
+
+def test_uncruijff_restores_hub_name_single_epoch_dir(tmp_path):
+    epoch_dir = _write_epoch(tmp_path, 0)
+    # Simulate a cruijff-rewritten config first
+    rewrite_adapter_config_base_path(
+        str(tmp_path), 0, "/local/abs/path", _silent_logger()
+    )
+    assert _read_base(epoch_dir) == "/local/abs/path"
+
+    uncruijff_adapter.restore_one(epoch_dir)
+
+    assert _read_base(epoch_dir) == "meta-llama/Llama-3.2-1B-Instruct"
+
+
+def test_uncruijff_skips_when_no_original_repo_id_and_no_override(tmp_path, capsys):
+    epoch_dir = _write_epoch(tmp_path, 0, with_repo_id=False)
+    rewrite_adapter_config_base_path(
+        str(tmp_path), 0, "/local/abs/path", _silent_logger()
+    )
+
+    changed = uncruijff_adapter.restore_one(epoch_dir)
+
+    assert changed is False
+    assert _read_base(epoch_dir) == "/local/abs/path"
+
+
+def test_uncruijff_uses_repo_id_override_when_marker_missing(tmp_path):
+    epoch_dir = _write_epoch(tmp_path, 0, with_repo_id=False)
+    rewrite_adapter_config_base_path(
+        str(tmp_path), 0, "/local/abs/path", _silent_logger()
+    )
+
+    changed = uncruijff_adapter.restore_one(
+        epoch_dir, repo_id_override="meta-llama/Llama-3.2-1B-Instruct"
+    )
+
+    assert changed is True
+    assert _read_base(epoch_dir) == "meta-llama/Llama-3.2-1B-Instruct"
+
+
+def test_uncruijff_repo_id_override_wins_over_marker(tmp_path):
+    epoch_dir = _write_epoch(tmp_path, 0, with_repo_id=True)
+    rewrite_adapter_config_base_path(
+        str(tmp_path), 0, "/local/abs/path", _silent_logger()
+    )
+
+    uncruijff_adapter.restore_one(epoch_dir, repo_id_override="my-org/forked-model")
+
+    assert _read_base(epoch_dir) == "my-org/forked-model"
+
+
+def test_uncruijff_recurses_over_run_dir(tmp_path, monkeypatch, capsys):
+    _write_epoch(tmp_path, 0)
+    _write_epoch(tmp_path, 1)
+    rewrite_adapter_config_base_path(str(tmp_path), 0, "/local/p", _silent_logger())
+    rewrite_adapter_config_base_path(str(tmp_path), 1, "/local/p", _silent_logger())
+
+    monkeypatch.setattr("sys.argv", ["uncruijff_adapter", str(tmp_path)])
+    exit_code = uncruijff_adapter.main()
+
+    assert exit_code == 0
+    assert _read_base(tmp_path / "epoch_0") == "meta-llama/Llama-3.2-1B-Instruct"
+    assert _read_base(tmp_path / "epoch_1") == "meta-llama/Llama-3.2-1B-Instruct"
+
+
+def test_uncruijff_errors_on_missing_path(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("sys.argv", ["uncruijff_adapter", str(tmp_path / "nope")])
+    exit_code = uncruijff_adapter.main()
+    assert exit_code == 1
+
+
+def test_uncruijff_errors_when_no_epoch_dirs(tmp_path, monkeypatch, capsys):
+    # Empty dir, no epoch_*, no adapter_config.json
+    monkeypatch.setattr("sys.argv", ["uncruijff_adapter", str(tmp_path)])
+    exit_code = uncruijff_adapter.main()
+    assert exit_code == 1


### PR DESCRIPTION
Closes #99

# Description

Replaces `stash_adapter_weights` with a save-time rewrite of `adapter_config.json`'s `base_model_name_or_path`. After each LoRA save, the recipe overwrites that field with the local absolute base-model path so the adapter dir is self-loading via transformers' native PEFT auto-detection on offline compute nodes. `save_adapter_weights_only` default flips to `True`, skipping the merged base+LoRA checkpoint and saving ~base-model-size disk per epoch.

End-to-end verified on della via `workflow_test_2026-05-15`: rank4/rank8 fine-tune outputs are **22M / 32M** each (vs 2.4G merged baseline — ~100× per checkpoint), and both evals load the rewritten adapter dir directly to **0.970 accuracy**.

### What changed

- **Custom LoRA recipes** (single-device stable + nightly, distributed stable): replace stash_adapter_files call with `rewrite_adapter_config_base_path(output_dir, epoch, base_model_path, log)`. Base path is read once in `__init__` from `cfg.checkpointer.checkpoint_dir`.
- **`custom_recipe_utils.py`**: `stash_adapter_files` replaced with `rewrite_adapter_config_base_path`.
- **`setup_finetune.py`**: `save_adapter_weights_only` default → `True`; removed `--stash_adapter_weights` arg.
- **YAML templates / refs**: `save_adapter_weights_only: True` in `finetune_template.yaml`, `yaml_refs/1B_defaults.yaml`, `yaml_refs/8B_defaults.yaml`.
- **New: `src/tools/torchtune/uncruijff_adapter.py`** — restores HF Hub repo name before exporting a checkpoint. Reads `original_repo_id.json` when present; takes `--repo-id` as a fallback (the 1B-Instruct base on della doesn't ship that marker, so the fallback isn't theoretical).
- **Docs**: `ARCHITECTURE.md` updated to describe the new flow.
- **Tests**: new `tests/unit/test_adapter_config_rewrite.py` (10 cases — rewrite, idempotence, uncruijff with/without marker, override precedence, recursion, error paths). Full suite green (1158 passed).

### Boundary note (per [[feedback_torchtune_naming_boundary]])

`adapter_config.json` is the PEFT contract, not torchtune's — we modify one field on a file PEFT defines. The base-model resolution logic stays on our side; the saved tensor weights aren't touched.

## New Dependencies

None. Relies on `transformers` ≥ 4.36 native PEFT integration, which is already in `cruijff` env.

# Testing Instructions

1. CI: `ruff check . && ruff format --check . && pytest tests/ --ignore=tests/integration/gpu` should pass.
2. Smoke test on della — full workflow:
   ```
   /design-experiment   # use workflow_test.md (LoRA Comparison)
   /scaffold-experiment
   /run-experiment
   ```
   Expect: each `{run}/artifacts/epoch_0/` ≈ 22M (rank4) or 32M (rank8) without `model.safetensors`; `adapter_config.json` should have `base_model_name_or_path` set to `/scratch/gpfs/MSALGANIK/pretrained-llms/Llama-3.2-1B-Instruct`; eval should load it without errors and produce reasonable accuracy on capitalization.
3. Export round-trip:
   ```
   python -m cruijff_kit.tools.torchtune.uncruijff_adapter <run_dir> \
     --repo-id meta-llama/Llama-3.2-1B-Instruct
   ```
   `adapter_config.json` should then have `base_model_name_or_path: meta-llama/Llama-3.2-1B-Instruct` and load correctly on any machine with HF Hub access (or the model in HF cache).

—MxC

🤖 Generated with [Claude Code](https://claude.com/claude-code)