### PR TITLE
Warn on unknown keys in setup_finetune.yaml

### DIFF
--- a/src/tools/torchtune/setup_finetune.py
+++ b/src/tools/torchtune/setup_finetune.py
@@ -655,6 +655,17 @@ def main():
         with open(args.config_file, "r") as f:
             config_data = yaml.safe_load(f) or {}
 
+        # Warn on keys we don't know what to do with — the merge loop below
+        # silently drops anything that isn't an argparse dest, which hides typos.
+        unknown = sorted(k for k in config_data.keys() if not hasattr(args, k))
+        if unknown:
+            warnings.warn(
+                f"setup_finetune.yaml has keys not consumed by setup_finetune.py: "
+                f"{unknown}. They will not affect the fine-tune. If these should "
+                f"propagate, add a matching argparse argument.",
+                stacklevel=2,
+            )
+
     # Load torchtune recipe hyperparameter defaults if base_recipe is specified
     recipe_defaults = {}
     recipe_config = None

--- a/tests/unit/test_setup_finetune_main.py
+++ b/tests/unit/test_setup_finetune_main.py
@@ -189,6 +189,28 @@ class TestMainYamlGeneration:
         assert config["run_val_every_n_steps"] == 50
         assert "dataset_val" in config
 
+    def test_unknown_key_warns(self, run_main, setup_yaml):
+        """A setup_finetune.yaml key with no matching argparse arg should warn."""
+        with open(setup_yaml) as f:
+            cfg = yaml.safe_load(f)
+        cfg["lora_ranl"] = 42  # typo of lora_rank
+        cfg["evaluation_temperature"] = 0.5  # wrong namespace
+        with open(setup_yaml, "w") as f:
+            yaml.dump(cfg, f)
+
+        with pytest.warns(UserWarning, match="setup_finetune.yaml has keys"):
+            run_main()
+
+    def test_known_keys_do_not_warn(self, run_main, setup_yaml):
+        """Default fixture has only argparse-known keys; no unknown-key warning."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            run_main()
+        unknown_warnings = [
+            w for w in caught if "setup_finetune.yaml has keys" in str(w.message)
+        ]
+        assert not unknown_warnings, [str(w.message) for w in unknown_warnings]
+
 
 class TestMainSlurmGeneration:
     """Tests for SLURM script generation."""


### PR DESCRIPTION
Closes #501

# Description

`setup_finetune.py` silently dropped any `setup_finetune.yaml` key without a matching argparse argument. A typo like `lora_ranl: 4` would fail open — the run would launch with the default `lora_rank` and the user would never know.

This mirrors PR #496's `load_eval_config` check on the torchtune side. After loading `setup_finetune.yaml`, warn naming any keys that aren't argparse dests. Same drift class (writer/consumer divergence), same alarm.

`setup_finetune.yaml` maps 1:1 onto argparse args (no structural-only keys like `eval_config.yaml` has), so the implementation is simpler than `setup_inspect.py`'s: `hasattr(args, key)` is the entire "known" filter — the same predicate the existing merge loop uses to decide whether to apply a value.

## New Dependencies

None.

# Testing Instructions

Manual reproduction in `/tmp`:

```bash
# Known-good rank4 fixture → silent
python -m cruijff_kit.tools.torchtune.setup_finetune --config_file <good>.yaml

# With a planted typo → warns and names the offending key(s)
echo "lora_ranl: 42" >> typo.yaml
python -m cruijff_kit.tools.torchtune.setup_finetune --config_file typo.yaml
# UserWarning: setup_finetune.yaml has keys not consumed by setup_finetune.py:
# ['lora_ranl']. They will not affect the fine-tune. ...
```

Unit tests added to `tests/unit/test_setup_finetune_main.py`:

- `test_unknown_key_warns` — planted typo triggers `UserWarning`
- `test_known_keys_do_not_warn` — default fixture stays silent

`pytest tests/unit/test_setup_finetune.py tests/unit/test_setup_finetune_main.py` → 141 passed.

—MxC