### PR TITLE
Fix empty report for risk_scorer-only experiments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to cruijff_kit will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- `report_generator` no longer emits an empty "Models evaluated: 0" report for `risk_scorer`-only experiments. When `*_accuracy` columns are absent but supplementary risk metrics exist, the report now renders a "Risk Metrics" section, derives `model_count` from the calibration results, and picks a best performer by AUC (or Brier) in the executive summary. `extract_calibration_metrics` also groups by `task_name` so per-task variation (e.g. cue vs no-cue) renders as separate rows. (#504)
+
 ## [0.3.1] - 2026-05-14
 
 ### Added

--- a/src/tools/inspect/report_generator.py
+++ b/src/tools/inspect/report_generator.py
@@ -50,6 +50,7 @@ class CalibrationResult:
     metrics: dict[str, Optional[float]]  # metric_name -> value (None if NA)
     sample_size: int
     epoch: Optional[int] = None
+    task_name: Optional[str] = None
 
 
 def extract_calibration_metrics(
@@ -76,8 +77,10 @@ def extract_calibration_metrics(
             sample_col = col
             break
 
-    # Group by model (and epoch if present)
+    # Group by model (and task_name / epoch if present)
     group_cols = ["model"]
+    if "task_name" in df.columns:
+        group_cols.append("task_name")
     if "epoch" in df.columns:
         group_cols.append("epoch")
 
@@ -86,8 +89,10 @@ def extract_calibration_metrics(
         # groupby with a list always returns tuple keys
         if not isinstance(group_key, tuple):
             group_key = (group_key,)
-        model_name = group_key[0]
-        epoch = group_key[1] if len(group_key) > 1 else None
+        group_dict = dict(zip(group_cols, group_key))
+        model_name = group_dict["model"]
+        task_name = group_dict.get("task_name")
+        epoch = group_dict.get("epoch")
 
         n = int(group_df[sample_col].iloc[0]) if sample_col else 0
 
@@ -110,6 +115,7 @@ def extract_calibration_metrics(
                 metrics=metric_values,
                 sample_size=n,
                 epoch=epoch,
+                task_name=task_name,
             )
         )
 
@@ -135,8 +141,13 @@ def _format_calibration_table(results: list[CalibrationResult]) -> str:
             if name not in all_metric_names:
                 all_metric_names.append(name)
 
+    show_task = any(r.task_name is not None for r in results)
+
     # Build header
-    headers = ["Model", "Epoch"]
+    headers = ["Model"]
+    if show_task:
+        headers.append("Task")
+    headers.append("Epoch")
     headers.extend(display_name(m) for m in all_metric_names)
     headers.append("Sample Size")
 
@@ -145,13 +156,23 @@ def _format_calibration_table(results: list[CalibrationResult]) -> str:
 
     lines = [header_line, separator]
 
-    # Sort by model name
-    sorted_results = sorted(results, key=lambda r: r.model_name)
+    # Sort by (model, task_name, epoch) so related rows cluster predictably
+    sorted_results = sorted(
+        results,
+        key=lambda r: (
+            r.model_name,
+            r.task_name or "",
+            r.epoch if r.epoch is not None else -1,
+        ),
+    )
 
     for r in sorted_results:
         epoch_str = str(r.epoch) if r.epoch is not None else "-"
 
-        cells = [r.model_name, epoch_str]
+        cells = [r.model_name]
+        if show_task:
+            cells.append(r.task_name if r.task_name is not None else "-")
+        cells.append(epoch_str)
         for metric_name in all_metric_names:
             val = r.metrics.get(metric_name)
             cells.append(f"{val:.3f}" if val is not None else "-")
@@ -298,33 +319,65 @@ def extract_metrics(
     return metrics
 
 
-def generate_narrative(metrics: list[ModelMetrics]) -> str:
+def generate_narrative(
+    metrics: list[ModelMetrics],
+    calibration: Optional[list[CalibrationResult]] = None,
+) -> str:
     """
     Generate executive summary narrative.
 
+    When accuracy metrics are unavailable but calibration metrics are present
+    (e.g. ``risk_scorer``-only experiments), the narrative picks a best
+    performer using AUC (higher is better) or Brier score (lower is better),
+    in that order of preference.
+
     Args:
-        metrics: List of model metrics
+        metrics: List of model metrics (accuracy-based)
+        calibration: Optional calibration results for the same models;
+            used as a fallback when ``metrics`` is empty.
 
     Returns:
         Markdown-formatted narrative string
     """
-    if not metrics:
-        return "No model metrics available for analysis."
+    if metrics:
+        best = max(metrics, key=lambda m: m.accuracy)
 
-    best = max(metrics, key=lambda m: m.accuracy)
+        lines = [
+            f"**{best.name}** achieved the highest accuracy at "
+            f"**{best.accuracy:.1%}** (95% CI: {best.ci_lower:.1%}-{best.ci_upper:.1%}).",
+            f"\n{len(metrics)} model configurations were evaluated.",
+        ]
+        return "\n".join(lines)
 
-    lines = []
+    if calibration:
+        # Find a usable supplementary metric. Prefer AUC (higher better),
+        # then Brier (lower better). Match by suffix so the registry prefix
+        # ("risk_scorer_cruijff_kit/...") doesn't matter.
+        def _value_for(r: CalibrationResult, suffix: str) -> Optional[float]:
+            for name, val in r.metrics.items():
+                if name.endswith(suffix) and val is not None:
+                    return val
+            return None
 
-    # Best performer statement
-    lines.append(
-        f"**{best.name}** achieved the highest accuracy at "
-        f"**{best.accuracy:.1%}** (95% CI: {best.ci_lower:.1%}-{best.ci_upper:.1%})."
-    )
+        for metric_suffix, label, picker in (
+            ("auc_score", "AUC", max),
+            ("brier_score", "Brier score", min),
+        ):
+            scored = [(r, _value_for(r, metric_suffix)) for r in calibration]
+            scored = [(r, v) for r, v in scored if v is not None]
+            if scored:
+                best, best_val = picker(scored, key=lambda pair: pair[1])
+                lines = [
+                    f"**{best.model_name}** achieved the best {label} at "
+                    f"**{best_val:.3f}**.",
+                    f"\n{len(calibration)} model configurations were evaluated.",
+                ]
+                return "\n".join(lines)
 
-    # Model count
-    lines.append(f"\n{len(metrics)} model configurations were evaluated.")
+        # Calibration entries exist but no comparable metric across them.
+        return f"{len(calibration)} model configurations were evaluated."
 
-    return "\n".join(lines)
+    return "No model metrics available for analysis."
 
 
 def _format_model_table(
@@ -347,14 +400,14 @@ def _format_model_table(
     """
     # Collect supplementary column names (preserving order across results)
     supp_names: list[str] = []
-    cal_lookup: dict[tuple[str, Optional[int]], CalibrationResult] = {}
+    cal_lookup: dict[tuple[str, Optional[str], Optional[int]], CalibrationResult] = {}
     if calibration:
         for r in calibration:
-            # Build lookup by (model, epoch) — epoch may be int or float
+            # Build lookup by (model, task_name, epoch) — epoch may be int or float
             epoch_key = (
                 int(r.epoch) if r.epoch is not None and not pd.isna(r.epoch) else None
             )
-            cal_lookup[(r.model_name, epoch_key)] = r
+            cal_lookup[(r.model_name, r.task_name, epoch_key)] = r
             for name in r.metrics:
                 if name not in supp_names:
                     supp_names.append(name)
@@ -392,7 +445,11 @@ def _format_model_table(
             epoch_key = (
                 int(m.epoch) if m.epoch is not None and not pd.isna(m.epoch) else None
             )
-            cal = cal_lookup.get((m.name, epoch_key))
+            cal = cal_lookup.get((m.name, m.task_name, epoch_key))
+            # Fall back to task-agnostic lookup so calibration data without
+            # task_name still attaches to accuracy rows (e.g. older callers).
+            if cal is None:
+                cal = cal_lookup.get((m.name, None, epoch_key))
             for s in supp_names:
                 val = cal.metrics.get(s) if cal else None
                 cells.append(f"{val:.3f}" if val is not None else "-")
@@ -636,12 +693,26 @@ def generate_report(
     # Extract metrics
     metrics = extract_metrics(df)
 
-    # Generate narrative
-    narrative = generate_narrative(metrics)
+    # Detect supplementary metrics and extract calibration results up front so
+    # the narrative / model_count / table-selection logic can all see them.
+    detected = detect_metrics(df)
+    calibration_results = None
+    if detected.supplementary:
+        calibration_results = (
+            extract_calibration_metrics(df, detected.supplementary) or None
+        )
+
+    # Generate narrative (falls back to calibration when accuracy is absent)
+    narrative = generate_narrative(metrics, calibration_results)
 
     # Build report
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
-    model_count = len(set(m.name for m in metrics))
+    if metrics:
+        model_count = len(set(m.name for m in metrics))
+    elif calibration_results:
+        model_count = len(set(r.model_name for r in calibration_results))
+    else:
+        model_count = 0
 
     header_parts = [
         f"**Experiment:** {experiment_name}",
@@ -687,28 +758,39 @@ def generate_report(
     if research_question:
         report_lines.append(research_question)
 
-    # Detect supplementary metrics and extract calibration results
-    detected = detect_metrics(df)
-    calibration_results = None
-    if detected.supplementary:
-        calibration_results = (
-            extract_calibration_metrics(df, detected.supplementary) or None
-        )
-
     # Evals run on the test split by convention
     eval_split_name = "test" if splits.get("test") else None
 
-    model_table, footnotes = _format_model_table(
-        metrics,
-        calibration_results,
-        eval_split_name=eval_split_name,
-    )
+    # When accuracy is absent but calibration is present (e.g. risk_scorer-only
+    # experiments), render a calibration-only table instead of an empty
+    # accuracy table.
+    calibration_only = not metrics and bool(calibration_results)
+
+    if calibration_only:
+        section_heading = "## Risk Metrics\n"
+        model_table = _format_calibration_table(calibration_results)
+        footnotes = []
+        sizes = {r.sample_size for r in calibration_results}
+        if len(sizes) == 1:
+            uniform_n = sizes.pop()
+            split_note = f" ({eval_split_name} split)" if eval_split_name else ""
+            footnotes.append(f"*Sample size: {uniform_n:,} per model{split_note}*")
+        footnotes.append(
+            '*C-ECE (Confidence ECE): "when I\'m X% confident, am I right X% of the time?" R-ECE (Risk ECE): "when I say P(Y=1)=X, is Y=1 X% of the time?" Both ECE and Brier: lower is better. AUC: higher is better.*'
+        )
+    else:
+        section_heading = "## Model Comparison\n"
+        model_table, footnotes = _format_model_table(
+            metrics,
+            calibration_results,
+            eval_split_name=eval_split_name,
+        )
 
     report_lines.extend(
         [
             "## Executive Summary\n",
             narrative + "\n",
-            "## Model Comparison\n",
+            section_heading,
             model_table + "\n",
         ]
     )

--- a/src/tools/inspect/report_generator.py
+++ b/src/tools/inspect/report_generator.py
@@ -156,18 +156,24 @@ def _format_calibration_table(results: list[CalibrationResult]) -> str:
 
     lines = [header_line, separator]
 
+    def _epoch_sort_key(r: CalibrationResult) -> float:
+        if r.epoch is None or pd.isna(r.epoch):
+            return -1.0
+        return float(r.epoch)
+
     # Sort by (model, task_name, epoch) so related rows cluster predictably
     sorted_results = sorted(
         results,
-        key=lambda r: (
-            r.model_name,
-            r.task_name or "",
-            r.epoch if r.epoch is not None else -1,
-        ),
+        key=lambda r: (r.model_name, r.task_name or "", _epoch_sort_key(r)),
     )
 
     for r in sorted_results:
-        epoch_str = str(r.epoch) if r.epoch is not None else "-"
+        if r.epoch is None or pd.isna(r.epoch):
+            epoch_str = "-"
+        elif float(r.epoch).is_integer():
+            epoch_str = str(int(r.epoch))
+        else:
+            epoch_str = str(r.epoch)
 
         cells = [r.model_name]
         if show_task:

--- a/tests/unit/test_report_generator.py
+++ b/tests/unit/test_report_generator.py
@@ -311,6 +311,92 @@ class TestFormatModelTableCombined:
 
 
 # =============================================================================
+# Calibration-only report path (#504)
+# =============================================================================
+
+
+class TestCalibrationOnlyReport:
+    """When accuracy columns are absent but risk_scorer supplementary columns
+    are present, generate_report should fall through to the calibration table
+    rather than emit an empty 'Models evaluated: 0' report.
+    """
+
+    def _make_risk_only_df(self):
+        """DataFrame with only risk_scorer supplementary columns, no *_accuracy."""
+        return pd.DataFrame(
+            {
+                "model": ["model_a", "model_b"],
+                "results_total_samples": [500, 500],
+                "score_risk_scorer_cruijff_kit/auc_score": [0.85, 0.72],
+                "score_risk_scorer_cruijff_kit/brier_score": [0.15, 0.22],
+                "score_risk_scorer_cruijff_kit/ece": [0.05, 0.09],
+            }
+        )
+
+    def test_model_count_nonzero(self, tmp_path):
+        """Header reports the calibration model count, not 0."""
+        df = self._make_risk_only_df()
+        assert not any(c.endswith("_accuracy") for c in df.columns)
+
+        report = generate_report(
+            df=df,
+            experiment_name="risk_only",
+            output_path=tmp_path / "report.md",
+        )
+        assert "**Models evaluated:** 2" in report
+        assert "**Models evaluated:** 0" not in report
+
+    def test_renders_risk_metrics_section(self, tmp_path):
+        """The calibration table is rendered instead of an empty Model Comparison."""
+        report = generate_report(
+            df=self._make_risk_only_df(),
+            experiment_name="risk_only",
+            output_path=tmp_path / "report.md",
+        )
+        assert "## Risk Metrics" in report
+        # Both models present in the body of the table
+        assert "model_a" in report
+        assert "model_b" in report
+        # AUC + Brier values from the dataframe show up
+        assert "0.850" in report
+        assert "0.150" in report
+
+    def test_narrative_picks_auc_best(self, tmp_path):
+        """Executive summary names the AUC winner when no accuracy is available."""
+        report = generate_report(
+            df=self._make_risk_only_df(),
+            experiment_name="risk_only",
+            output_path=tmp_path / "report.md",
+        )
+        # model_a has the higher AUC (0.85 vs 0.72)
+        assert "**model_a** achieved the best AUC" in report
+        assert "No model metrics available for analysis." not in report
+
+    def test_task_name_preserved_in_groupby(self, tmp_path):
+        """Cells differing in task_name don't collapse: per-task rows render
+        separately so cue vs no_cue (etc.) variation is visible.
+        """
+        df = pd.DataFrame(
+            {
+                "model": ["model_a", "model_a"],
+                "task_name": ["with_cue", "no_cue"],
+                "results_total_samples": [500, 500],
+                "score_risk_scorer_cruijff_kit/auc_score": [0.85, 0.72],
+            }
+        )
+        report = generate_report(
+            df=df,
+            experiment_name="risk_only_per_task",
+            output_path=tmp_path / "report.md",
+        )
+        assert "with_cue" in report
+        assert "no_cue" in report
+        # Both AUC values should appear (no collapse onto one row)
+        assert "0.850" in report
+        assert "0.720" in report
+
+
+# =============================================================================
 # Provenance metadata
 # =============================================================================
 

--- a/tests/unit/test_report_generator.py
+++ b/tests/unit/test_report_generator.py
@@ -225,6 +225,27 @@ class TestFormatCalibrationTable:
         epoch_idx = next(i for i, h in enumerate(header_cells) if "Epoch" in h)
         assert data_cells[epoch_idx] == "-"
 
+    def test_epoch_nan_renders_as_dash(self):
+        """pd.NA / nan epoch (from groupby on a column with missing values) renders as '-', not 'nan'."""
+        import numpy as np
+
+        results = [
+            CalibrationResult(
+                model_name="m",
+                metrics={"risk_scorer_cruijff_kit/ece": 0.2},
+                sample_size=100,
+                epoch=np.nan,
+            ),
+        ]
+        table = _format_calibration_table(results)
+        assert "nan" not in table
+        lines = table.strip().split("\n")
+        data_row = lines[-1]
+        header_cells = [c.strip() for c in lines[0].split("|") if c.strip()]
+        data_cells = [c.strip() for c in data_row.split("|") if c.strip()]
+        epoch_idx = next(i for i, h in enumerate(header_cells) if "Epoch" in h)
+        assert data_cells[epoch_idx] == "-"
+
 
 # =============================================================================
 # _format_model_table() with calibration


### PR DESCRIPTION
Closes #504

# Description

`report_generator.generate_report()` previously produced a syntactically-fine but semantically-empty markdown report when an experiment had no `*_accuracy` score columns — even when supplementary `risk_scorer` metrics were sitting in `cal_lookup` ready to render. The report claimed `Models evaluated: 0` and the rich calibration data was silently dropped.

This change wires the four acceptance criteria from the issue:

1. **Fallthrough to `_format_calibration_table()`** — when `extract_metrics(df)` returns empty but `extract_calibration_metrics()` returns results, the report now emits a "Risk Metrics" section instead of an empty "Model Comparison" table. Footnotes (uniform sample-size + ECE/Brier/AUC definitions) are preserved.
2. **`model_count` follows the active metric path** — derived from `calibration_results` when accuracy is absent, instead of always counting `ModelMetrics`.
3. **`generate_narrative()` handles calibration-only** — picks the best performer by AUC (higher is better) with Brier as a fallback (lower is better), and names the metric. Returns the original "No model metrics available" sentinel only when both paths are empty.
4. **`task_name` added to `extract_calibration_metrics` groupby** — cells differing only in `task_name` (e.g. cue vs no-cue eval condition) no longer collapse onto a single row. `CalibrationResult` gains an optional `task_name` field; `_format_model_table`'s `cal_lookup` is now keyed by `(model, task_name, epoch)` with a task-agnostic fallback so older callers without `task_name` still attach calibration to accuracy rows.

## New Dependencies

None.

# Testing Instructions

Unit tests added (`tests/unit/test_report_generator.py::TestCalibrationOnlyReport`, 4 new cases):

- `test_model_count_nonzero` — risk-scorer-only df produces `Models evaluated: 2`, not 0.
- `test_renders_risk_metrics_section` — output contains `## Risk Metrics`, both model names, and the AUC/Brier values from the source df.
- `test_narrative_picks_auc_best` — executive summary names the higher-AUC model and the metric used.
- `test_task_name_preserved_in_groupby` — two rows differing only in `task_name` render as two rows, not one collapsed entry.

Full suite (1140 tests, including the new four) passes locally:

```bash
conda activate cruijff
pytest tests/unit/
ruff check src/tools/inspect/report_generator.py tests/unit/test_report_generator.py
ruff format --check src/tools/inspect/report_generator.py tests/unit/test_report_generator.py
```

To exercise the path on a real risk-scorer-only experiment, point `analyze-experiment` at one (e.g. `coling_cue_acs_income_2026-05-13` from the issue body) and verify `report.md` now has a populated `## Risk Metrics` table and a non-zero `Models evaluated:` header.

—MxC