### PR TITLE
Render assistant_prefix in scaffold-inspect (#511)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to cruijff_kit will be documented in this file.
 ### Fixed
 
 - `report_generator` no longer emits an empty "Models evaluated: 0" report for `risk_scorer`-only experiments. When `*_accuracy` columns are absent but supplementary risk metrics exist, the report now renders a "Risk Metrics" section, derives `model_count` from the calibration results, and picks a best performer by AUC (or Brier) in the executive summary. `extract_calibration_metrics` also groups by `task_name` so per-task variation (e.g. cue vs no-cue) renders as separate rows. (#504)
+- `scaffold-inspect` now recognizes `assistant_prefix` in `eval_config.yaml` and renders it as a `-T assistant_prefix=...` flag in the generated SLURM script. Previously, the key was warned as unknown and dropped — base / Instruct models that needed a prefill to emit option tokens (`"0"` / `"1"`) for `risk_scorer` would silently produce all-NaN risk metrics. Values are emitted with strict YAML-double-quoted inside shell-single-quoted form so common cases like `"Answer: "` survive inspect-ai's per-value YAML parse. (#511)
 
 ## [0.3.1] - 2026-05-14
 

--- a/src/tools/inspect/setup_inspect.py
+++ b/src/tools/inspect/setup_inspect.py
@@ -47,7 +47,13 @@ TASK_ARG_KEYS = [
     "top_logprobs",
     "temperature",
     "max_tokens",
+    "assistant_prefix",
 ]
+
+# Subset of TASK_ARG_KEYS whose values may contain YAML-significant characters
+# (e.g. ': ', leading '[' / '{', etc.) and so must be rendered with extra
+# quoting to survive inspect-ai's per-value YAML parse.
+YAML_PROTECTED_TASK_ARG_KEYS = {"assistant_prefix"}
 
 # Keys in eval_config.yaml that become --metadata args in the inspect command
 METADATA_ARG_KEYS = ["epoch", "finetuned", "source_model"]
@@ -211,7 +217,14 @@ def build_task_args(config):
     for key in TASK_ARG_KEYS:
         value = config.get(key)
         if value is not None:
-            lines.append(f'  -T {key}="{_format_value(value)}" \\')
+            if key in YAML_PROTECTED_TASK_ARG_KEYS:
+                # inspect-ai YAML-parses the value after -T key=, so a literal
+                # like "Answer: " would parse as {'Answer': None}. Wrap as
+                # YAML-double-quoted inside shell-single-quoted to preserve it.
+                escaped = str(value).replace('"', '\\"')
+                lines.append(f"  -T {key}='\"{escaped}\"' \\")
+            else:
+                lines.append(f'  -T {key}="{_format_value(value)}" \\')
     return "\n".join(lines) + "\n" if lines else ""
 
 

--- a/tests/unit/test_setup_inspect.py
+++ b/tests/unit/test_setup_inspect.py
@@ -163,6 +163,21 @@ class TestLoadEvalConfig:
         with pytest.raises(ValueError, match="missing required keys"):
             load_eval_config(str(config_file))
 
+    def test_assistant_prefix_not_warned_as_unknown(self, tmp_path, recwarn):
+        """assistant_prefix is in TASK_ARG_KEYS and must not trigger the
+        unknown-key warning (regression guard for #511)."""
+        config_file = tmp_path / "eval_config.yaml"
+        config_file.write_text(MINIMAL_EVAL_CONFIG + 'assistant_prefix: "Answer: "\n')
+        load_eval_config(str(config_file))
+        unknown_warnings = [
+            w
+            for w in recwarn.list
+            if "assistant_prefix" in str(w.message) and "not consumed" in str(w.message)
+        ]
+        assert unknown_warnings == [], (
+            f"assistant_prefix should not be warned as unknown; got: {unknown_warnings}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # _format_value (boolean normalization)
@@ -234,6 +249,39 @@ class TestBuildTaskArgs:
         config = make_config(use_chat_template=True)
         result = build_task_args(config)
         assert '-T use_chat_template="true"' in result
+
+    def test_assistant_prefix_renders(self):
+        """assistant_prefix appears as a -T line when present in config."""
+        config = make_config(assistant_prefix="Answer: ")
+        result = build_task_args(config)
+        assert "-T assistant_prefix=" in result
+
+    def test_assistant_prefix_yaml_protected_quoting(self):
+        """assistant_prefix uses single-quoted-double-quoted form so YAML-special
+        characters (e.g. ': ') survive inspect-ai's per-value YAML parse.
+
+        Regression guard for #511: the naive `-T key="value"` render parses
+        "Answer: " as `{'Answer': None}` because the colon-space tokenizes.
+        """
+        config = make_config(assistant_prefix="Answer: ")
+        result = build_task_args(config)
+        assert "-T assistant_prefix='\"Answer: \"' \\" in result
+
+    def test_assistant_prefix_escapes_embedded_double_quotes(self):
+        """A value containing literal double quotes is backslash-escaped."""
+        config = make_config(assistant_prefix='Say "yes": ')
+        result = build_task_args(config)
+        assert '-T assistant_prefix=\'"Say \\"yes\\": "\' \\' in result
+
+    def test_non_protected_string_keeps_legacy_quoting(self):
+        """vis_label (and other string keys not in YAML_PROTECTED_TASK_ARG_KEYS)
+        keep the current `-T key="value"` form so existing behavior is preserved.
+        """
+        config = make_config(vis_label="1B_ft")
+        result = build_task_args(config)
+        assert '-T vis_label="1B_ft"' in result
+        # And NOT the protected form
+        assert "-T vis_label='\"1B_ft\"'" not in result
 
 
 # ---------------------------------------------------------------------------
@@ -400,6 +448,16 @@ class TestRenderTemplate:
         meta_pos = script.index("--metadata epoch=")
         logdir_pos = script.index("--log-dir")
         assert task_pos < meta_pos < logdir_pos
+
+    def test_assistant_prefix_renders_in_slurm(self):
+        """End-to-end: assistant_prefix in config produces a correctly-quoted
+        -T line in the rendered SLURM script (regression guard for #511)."""
+        config = make_config(
+            data_path="/data/test.json",
+            assistant_prefix="Answer: ",
+        )
+        script = render_template(make_cli_args(), config)
+        assert "-T assistant_prefix='\"Answer: \"' \\" in script
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #511

# Description

Adds `assistant_prefix` to `TASK_ARG_KEYS` in `src/tools/inspect/setup_inspect.py` so scaffold-inspect renders it into the generated SLURM script. Without this, base / Instruct models that need a prefill to emit option tokens (`"0"` / `"1"`) for `risk_scorer` would silently produce all-NaN risk metrics — and pre-#504 that NaN would render as an empty "Models evaluated: 0" report with no indication anything had gone wrong.

The naïve render `-T assistant_prefix="Answer: "` hits inspect-ai's per-value YAML parse and ends up as `{'Answer': None}` because of the colon-space substring (this bit during the #504 smoke test — I had to hand-patch the generated slurm). To survive that parse, the value is emitted YAML-double-quoted inside shell-single-quoted form: `-T assistant_prefix='"Answer: "'`.

A new `YAML_PROTECTED_TASK_ARG_KEYS = {"assistant_prefix"}` set scopes the stricter quoting just to keys that need it. Broadening to all string-typed keys would regress `use_chat_template: "true"` (which today loads as a string but YAML-coerces to bool inside inspect — wrapping it in extra quotes would defeat that coercion). The new constant gives future keys an opt-in path without breaking that contract.

## New Dependencies

None.

# Testing Instructions

`pytest tests/unit/test_setup_inspect.py` — 68 tests pass, including 6 new ones:

- `TestBuildTaskArgs::test_assistant_prefix_renders` — key appears in the rendered `-T` block.
- `TestBuildTaskArgs::test_assistant_prefix_yaml_protected_quoting` — output is `-T assistant_prefix='"Answer: "'`.
- `TestBuildTaskArgs::test_assistant_prefix_escapes_embedded_double_quotes` — embedded `"` is backslash-escaped.
- `TestBuildTaskArgs::test_non_protected_string_keeps_legacy_quoting` — `vis_label` (and other non-protected string keys) keep the existing `-T key="value"` form.
- `TestLoadEvalConfig::test_assistant_prefix_not_warned_as_unknown` — `assistant_prefix` no longer trips the unknown-key warning.
- `TestRenderTemplate::test_assistant_prefix_renders_in_slurm` — end-to-end render produces the correctly-quoted line in the final SLURM script.

End-to-end repro (no GPU needed for the rendering check):

```bash
mkdir -p /tmp/511_check && cd /tmp/511_check
cat > eval_config.yaml <<'YAML'
task_script: blueprints/folktexts/inspect_task.py@acs_income
task_name: acs_income
model_path: /scratch/.../Llama-3.2-1B-Instruct
model_hf_name: hf/Llama-3.2-1B-Instruct_base
output_dir: /tmp/511_check/out/
data_path: /scratch/.../acs_income_verbose_1000_80P.json
assistant_prefix: "Answer: "
YAML
python setup_inspect.py --config eval_config.yaml --model_name Llama-3.2-1B-Instruct
grep assistant_prefix acs_income.slurm
# Expected: -T assistant_prefix='"Answer: "' \
```

The emitted form is byte-identical to the hand-patched line that yielded non-NaN risk metrics during the #504 smoke test (`risk_only_smoke_2026-05-19`, AUC 0.400 / Brier 0.377 / ECE 0.720).

—MxC