### PR TITLE
Expose num_workers and persistent_workers in finetune scaffold

### DIFF
--- a/.claude/agents/scaffold-torchtune.md
+++ b/.claude/agents/scaffold-torchtune.md
@@ -89,6 +89,8 @@ These are *example* parameters that the user might vary. There may be other para
    - `controls.epochs` - Number of training epochs
    - `controls.batch_size` - Batch size (if not varied)
    - `controls.batch_size_val` - Optional larger batch size for validation passes. Honored by `_single_device_nightly` (the default recipe); silently ignored by `_stable` / `_distributed` recipes since their custom-recipe builds don't read the field. Recipe falls back to `controls.batch_size` when absent.
+   - `controls.num_workers` - DataLoader `num_workers`. Top-level YAML key (NOT nested under `dataset:` — the nested placement was tried and crashed at the dataset constructor; see #449 / #514). Reaches both train and val dataloaders on `_single_device_nightly`; train-only on the two `_stable` recipes (no val loop). Recipe falls back to `0` when absent.
+   - `controls.persistent_workers` - DataLoader `persistent_workers` (true/false). Top-level YAML key, same propagation as `num_workers`. Recipe falls back to `false` when absent.
    - `controls.system_prompt` - Training system prompt. 
       - Omit this field from `setup_finetune.yaml` when `dataset_type` is `text_completion` or `text_completion_dataset` (i.e. base / non-instruct models). Base models have no chat template, so the system prompt has nowhere to go — `setup_finetune.py` will drop it with a warning.
    - `controls.prompt` - Prompt template with {input} placeholder (e.g., "Capitalize: {input}\n")
@@ -242,6 +244,8 @@ gradient_accumulation_steps: {from controls.gradient_accumulation_steps, if pres
 weight_decay: {from controls.weight_decay, if present}
 lora_dropout: {from controls.lora_dropout, if present}
 batch_size_val: {from controls.batch_size_val or run.parameters.batch_size_val, if present}
+num_workers: {from controls.num_workers or run.parameters.num_workers, if present}
+persistent_workers: {from controls.persistent_workers or run.parameters.persistent_workers, if present}
 
 # Training configuration (common across runs)
 epochs: {from controls.epochs}

--- a/src/tools/torchtune/custom_recipes/lora_finetune_distributed_stable.py
+++ b/src/tools/torchtune/custom_recipes/lora_finetune_distributed_stable.py
@@ -369,6 +369,10 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                 if self._resume_from_checkpoint
                 else None
             ),
+            # !--- cruijff_kit patch ---!
+            num_workers=cfg.get("num_workers", 0),
+            persistent_workers=cfg.get("persistent_workers", False),
+            # !--- end cruijff_kit patch ---!
         )
 
         # Finally update the recipe state which can only be correctly set after all of the
@@ -635,6 +639,10 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         batch_size: int,
         collate_fn: str,
         dataloader_state_dict: Optional[Dict[str, Any]] = None,
+        # !--- cruijff_kit patch ---!
+        num_workers: int = 0,
+        persistent_workers: bool = False,
+        # !--- end cruijff_kit patch ---!
     ) -> StatefulDataLoader:
         """
         All data related setup happens here. This recipe currently supports only
@@ -678,6 +686,10 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
             ),
             # dropping last avoids shape issues with compile + flex attention
             drop_last=True,
+            # !--- cruijff_kit patch ---!
+            num_workers=num_workers,
+            persistent_workers=persistent_workers,
+            # !--- end cruijff_kit patch ---!
         )
 
         return dataloader

--- a/src/tools/torchtune/custom_recipes/lora_finetune_single_device_nightly.py
+++ b/src/tools/torchtune/custom_recipes/lora_finetune_single_device_nightly.py
@@ -384,6 +384,10 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                 if self._resume_from_checkpoint
                 else None
             ),
+            # !--- cruijff_kit patch ---!
+            num_workers=cfg.get("num_workers", 0),
+            persistent_workers=cfg.get("persistent_workers", False),
+            # !--- end cruijff_kit patch ---!
         )
 
         # Setup validation dataloader if validation dataset is provided
@@ -395,6 +399,10 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                 batch_size=batch_size_val,
                 collate_fn=collate_name,
                 shuffle=False,
+                # !--- cruijff_kit patch ---!
+                num_workers=cfg.get("num_workers", 0),
+                persistent_workers=cfg.get("persistent_workers", False),
+                # !--- end cruijff_kit patch ---!
             )
 
         # Finally update the recipe state which can only be correctly set after all of the
@@ -611,6 +619,10 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         batch_size: int,
         collate_fn: str,
         dataloader_state_dict: Optional[Dict[str, Any]] = None,
+        # !--- cruijff_kit patch ---!
+        num_workers: int = 0,
+        persistent_workers: bool = False,
+        # !--- end cruijff_kit patch ---!
     ) -> StatefulDataLoader:
         """
         All data related setup happens here. This recipe currently supports only
@@ -655,6 +667,10 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
             ),
             # dropping last avoids shape issues with compile + flex attention
             drop_last=True,
+            # !--- cruijff_kit patch ---!
+            num_workers=num_workers,
+            persistent_workers=persistent_workers,
+            # !--- end cruijff_kit patch ---!
         )
 
         return dataloader

--- a/src/tools/torchtune/custom_recipes/lora_finetune_single_device_stable.py
+++ b/src/tools/torchtune/custom_recipes/lora_finetune_single_device_stable.py
@@ -364,6 +364,10 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                 if self._resume_from_checkpoint
                 else None
             ),
+            # !--- cruijff_kit patch ---!
+            num_workers=cfg.get("num_workers", 0),
+            persistent_workers=cfg.get("persistent_workers", False),
+            # !--- end cruijff_kit patch ---!
         )
 
         # Finally update the recipe state which can only be correctly set after all of the
@@ -573,6 +577,10 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         batch_size: int,
         collate_fn: str,
         dataloader_state_dict: Optional[Dict[str, Any]] = None,
+        # !--- cruijff_kit patch ---!
+        num_workers: int = 0,
+        persistent_workers: bool = False,
+        # !--- end cruijff_kit patch ---!
     ) -> StatefulDataLoader:
         """
         All data related setup happens here. This recipe currently supports only
@@ -617,6 +625,10 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
             ),
             # dropping last avoids shape issues with compile + flex attention
             drop_last=True,
+            # !--- cruijff_kit patch ---!
+            num_workers=num_workers,
+            persistent_workers=persistent_workers,
+            # !--- end cruijff_kit patch ---!
         )
 
         return dataloader

--- a/src/tools/torchtune/setup_finetune.py
+++ b/src/tools/torchtune/setup_finetune.py
@@ -446,6 +446,21 @@ def create_parser():
         "Honored by the _single_device_nightly recipe; ignored by stable recipes.",
     )
     parser.add_argument(
+        "--num_workers",
+        type=int,
+        default=None,
+        help="DataLoader num_workers for train (and val on _single_device_nightly). "
+        "Default 0 (single-process). Higher values can improve throughput on CPU-bound "
+        "pipelines but add multiprocessing overhead.",
+    )
+    parser.add_argument(
+        "--persistent_workers",
+        type=parse_bool,
+        default=None,
+        help="Keep DataLoader workers alive between epochs (true/false). "
+        "Default false. Setting true saves worker-startup cost on multi-epoch runs.",
+    )
+    parser.add_argument(
         "--epochs", type=int, default=1, help="Number of epochs to train for"
     )
     parser.add_argument(
@@ -943,6 +958,14 @@ def main():
             # Only emit when set; absent key → recipe falls back to cfg.batch_size.
             if value is not None:
                 config["batch_size_val"] = value
+        elif key == "num_workers":
+            # Only emit when set; absent key → recipe falls back to 0.
+            if value is not None:
+                config["num_workers"] = value
+        elif key == "persistent_workers":
+            # Only emit when set; absent key → recipe falls back to False.
+            if value is not None:
+                config["persistent_workers"] = value
         elif key == "training_samples":
             # Slice the train dataset only. dataset_val stays full so val
             # accuracy is comparable across consistency-curve runs.

--- a/tests/unit/test_setup_finetune_main.py
+++ b/tests/unit/test_setup_finetune_main.py
@@ -108,6 +108,20 @@ class TestMainYamlGeneration:
         config, _ = run_main()
         assert config["batch_size_val"] == 64
 
+    def test_num_workers_and_persistent_workers_absent_by_default(self, run_main):
+        # No flags → neither key emitted. Recipes fall back to 0 / False.
+        config, _ = run_main()
+        assert "num_workers" not in config
+        assert "persistent_workers" not in config
+
+    def test_num_workers_via_cli(self, run_main):
+        config, _ = run_main(extra_args=["--num_workers", "4"])
+        assert config["num_workers"] == 4
+
+    def test_persistent_workers_via_cli(self, run_main):
+        config, _ = run_main(extra_args=["--persistent_workers", "true"])
+        assert config["persistent_workers"] is True
+
     def test_seed_default(self, run_main):
         """When seed is not specified, the default (14 — Cruijff's number) is used."""
         config, _ = run_main()


### PR DESCRIPTION
Closes #514

## Description

Exposes `num_workers` and `persistent_workers` as CLI flags on `setup_finetune.py`, propagating them through the generated `finetune.yaml` to the DataLoader construction in all 3 custom recipes. Follows the `batch_size_val` precedent (top-level YAML key, inject-only-if-set, recipe `cfg.get(...)` for absence).

Resolves the deferred half of #449 under the policy framing from #465 (audit-based: `_setup_data` is setup-time, not train-loop, → MEDIUM risk, permitted).

**Empirical note:** Mattie's pipeline-balance experiment (#449 comment, 2026-05-08) found GPU is rarely starved on realistic workloads. This PR exposes the knobs because users will ask, not because it fixes a measured bottleneck. Default behavior unchanged.

## Files touched

- `src/tools/torchtune/setup_finetune.py` — two CLI args, two emit blocks
- `src/tools/torchtune/custom_recipes/lora_finetune_single_device_stable.py` — `_setup_data` signature + call site + StatefulDataLoader forward
- `src/tools/torchtune/custom_recipes/lora_finetune_single_device_nightly.py` — same, also patches `val_dataloader` call
- `src/tools/torchtune/custom_recipes/lora_finetune_distributed_stable.py` — same as stable
- `.claude/agents/scaffold-torchtune.md` — docs for the two new knobs
- `tests/unit/test_setup_finetune_main.py` — three regression tests

All recipe edits are inside marked `# !--- cruijff_kit patch ---!` blocks.

## New Dependencies

None.

## Testing Instructions

```bash
ruff check .
ruff format --check .
pytest tests/
```

All 1204 unit tests pass.

**Smoke run completed:** Llama-3.2-1B-Instruct + `words_5L_80P_1000.json`, single-device-nightly recipe, `--num_workers 4 --persistent_workers true` (SLURM job `8525746`). Exit 0, 54s elapsed, train loss 0.04 / val loss 0.04. DataLoader warned about 4 worker processes (expected; only 1 logical CPU was allocated for the smoke), confirming the kwargs reached `StatefulDataLoader` cleanly — no repeat of the in-block constructor crash that killed the original #449 attempt.

—MxC