### PR TITLE
Fix GPU smoke test for cell.slurm filename

### DIFF
--- a/tests/integration/gpu/smoke_test_scaffolding.py
+++ b/tests/integration/gpu/smoke_test_scaffolding.py
@@ -93,8 +93,8 @@ def test_setup_inspect(work_dir: Path):
         print(f"STDERR: {result.stderr}")
         raise RuntimeError(f"setup_inspect.py exited with code {result.returncode}")
 
-    slurm = work_dir / "capitalization_epoch0.slurm"
-    assert slurm.exists(), "capitalization_epoch0.slurm not generated"
+    slurm = work_dir / "cell.slurm"
+    assert slurm.exists(), "cell.slurm not generated"
     print("PASS: setup_inspect.py scaffolding")
 
 


### PR DESCRIPTION
Closes #521

# Description

Updates the GPU smoke test to match the per-cell eval layout introduced in #498.

PR #498 changed `setup_inspect.py`'s default output from `{task}_epoch{N}.slurm` to `cell.slurm`. The unit tests were updated in that PR, but `tests/integration/gpu/smoke_test_scaffolding.py` was missed — only caught now because the GPU runner is on a separate (nightly) workflow.

Two-line change:

```diff
-    slurm = work_dir / "capitalization_epoch0.slurm"
-    assert slurm.exists(), "capitalization_epoch0.slurm not generated"
+    slurm = work_dir / "cell.slurm"
+    assert slurm.exists(), "cell.slurm not generated"
```

# New Dependencies

None.

# Testing Instructions

- `ruff check tests/integration/gpu/smoke_test_scaffolding.py` — passes locally
- `ruff format --check tests/integration/gpu/smoke_test_scaffolding.py` — passes locally
- The actual GPU smoke test runs on the self-hosted nightly runner; merging this PR will let the next scheduled run go green. The non-GPU CI workflows aren't gated on this test.

—MxC