### PR TITLE
Hoist risk scorer METRIC_NAMES into canonical module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,17 @@ All use Llama-3.2-1B-Instruct with `{ck_data_dir}/capitalization/words_5L_80P_10
 
 **Purpose:** Catch regressions in skills, ensure documentation changes don't break workflows, validate end-to-end integration.
 
+## Code Conventions
+
+### Code Comments
+
+- **No issue/PR numbers in code comments.** Comments must explain the code as it
+  stands, self-contained. Provenance ("why did this change?") belongs in the
+  commit message and PR description — `git blame` recovers it when needed.
+  - ❌ `# Exported so viz_helpers (#534) can classify columns without re-listing.`
+  - ✅ `# Exported so viz_helpers can classify columns without re-listing.`
+  - Pointers to code that still exists are fine (e.g. `# See src/tools/.../inspect_task.py`) — those reference live structure, not ephemeral tracker state.
+
 ## Git Workflow
 
 ### Issue Management

--- a/src/tools/inspect/report_generator.py
+++ b/src/tools/inspect/report_generator.py
@@ -32,7 +32,7 @@ from cruijff_kit.tools.inspect.viz_helpers import detect_metrics, display_name
 # Supplementary metric names have the form "{scorer_name}/{metric_name}" (e.g.
 # "risk_scorer_cruijff_kit/auc_score", "continuous_scorer/mae"); we classify
 # by the part after the last "/" against the set the continuous_scorer module
-# itself exports, so adding a new metric there auto-classifies here (#519).
+# itself exports, so adding a new metric there auto-classifies here.
 
 _RISK_FOOTNOTE = (
     '*C-ECE (Confidence ECE): "when I\'m X% confident, am I right X% of the time?" '
@@ -526,7 +526,7 @@ def _format_model_table(
     if calibration:
         # Emit only the footnote(s) matching the metric categories actually
         # present, so a continuous-only experiment doesn't render the
-        # misleading C-ECE/R-ECE explanation (#519).
+        # misleading C-ECE/R-ECE explanation.
         has_risk = any(not _is_continuous_metric(n) for n in supp_names)
         has_continuous = any(_is_continuous_metric(n) for n in supp_names)
         if has_risk:
@@ -830,7 +830,7 @@ def generate_report(
     calibration_only = not metrics and bool(calibration_results)
 
     # sections is a list of (heading, table_markdown, footnotes) tuples so the
-    # mixed case (#519) can emit a Risk Metrics sub-section followed by a
+    # mixed case can emit a Risk Metrics sub-section followed by a
     # Regression Metrics sub-section under the same Executive Summary.
     sections: list[tuple[str, str, list[str]]] = []
 

--- a/src/tools/inspect/scorers/continuous_scorer.py
+++ b/src/tools/inspect/scorers/continuous_scorer.py
@@ -122,7 +122,7 @@ _METRICS: list[tuple[str, callable]] = [
     ("parse_rate", parse_rate),
 ]
 
-# Exported so report_generator (#519) can classify columns by scorer category
+# Exported so report_generator can classify columns by scorer category
 # without re-listing names.
 METRIC_NAMES: frozenset[str] = frozenset(name for name, _ in _METRICS)
 

--- a/src/tools/inspect/scorers/numeric_risk_scorer.py
+++ b/src/tools/inspect/scorers/numeric_risk_scorer.py
@@ -12,13 +12,10 @@ predicted label is the positive (last) label, otherwise the negative (first).
 from inspect_ai.scorer import scorer, Score, CORRECT, INCORRECT
 from inspect_ai.solver import TaskState
 from inspect_ai.scorer import Target
-from .risk_scorer import mean_risk_score
-from .calibration_metrics import (
-    expected_calibration_error,
-    risk_calibration_error,
-    brier_score,
-    auc_score,
-)
+
+# numeric_risk_scorer publishes the identical metric suite as risk_scorer, so it
+# reuses the same canonical _METRICS list rather than re-declaring it.
+from .risk_scorer import _METRICS
 
 
 def _parse_risk_score(text: str) -> float | None:
@@ -36,15 +33,7 @@ def _parse_risk_score(text: str) -> float | None:
     return value
 
 
-@scorer(
-    metrics=[
-        mean_risk_score(),
-        expected_calibration_error(),
-        risk_calibration_error(),
-        brier_score(),
-        auc_score(),
-    ]
-)
+@scorer(metrics=[factory() for _, factory in _METRICS])
 def numeric_risk_scorer(labels: tuple[str, str] = ("0", "1")):
     """
     Scorer that parses a numeric probability from the model's text output.

--- a/src/tools/inspect/scorers/numeric_risk_scorer.py
+++ b/src/tools/inspect/scorers/numeric_risk_scorer.py
@@ -14,8 +14,8 @@ from inspect_ai.solver import TaskState
 from inspect_ai.scorer import Target
 
 # numeric_risk_scorer publishes the identical metric suite as risk_scorer, so it
-# reuses the same canonical _METRICS list rather than re-declaring it.
-from .risk_scorer import _METRICS
+# reuses risk_scorer's public suite helper rather than re-declaring the metrics.
+from .risk_scorer import risk_metric_suite
 
 
 def _parse_risk_score(text: str) -> float | None:
@@ -33,7 +33,7 @@ def _parse_risk_score(text: str) -> float | None:
     return value
 
 
-@scorer(metrics=[factory() for _, factory in _METRICS])
+@scorer(metrics=risk_metric_suite())
 def numeric_risk_scorer(labels: tuple[str, str] = ("0", "1")):
     """
     Scorer that parses a numeric probability from the model's text output.

--- a/src/tools/inspect/scorers/risk_scorer.py
+++ b/src/tools/inspect/scorers/risk_scorer.py
@@ -39,7 +39,6 @@ def mean_risk_score() -> Metric:
 # would report as "metric_wrapper"), so introspection can't recover them.
 # Adding one: define/import the @metric factory, then append (name, factory)
 # here — the @scorer registration and METRIC_NAMES are derived from this list.
-# numeric_risk_scorer imports this same list, so the two stay in lockstep.
 _METRICS: list[tuple[str, callable]] = [
     ("mean_risk_score", mean_risk_score),
     ("expected_calibration_error", expected_calibration_error),
@@ -53,7 +52,16 @@ _METRICS: list[tuple[str, callable]] = [
 METRIC_NAMES: frozenset[str] = frozenset(name for name, _ in _METRICS)
 
 
-@scorer(metrics=[factory() for _, factory in _METRICS])
+def risk_metric_suite() -> list[Metric]:
+    """Instantiated metric suite shared by risk_scorer and numeric_risk_scorer.
+
+    Both scorers publish the identical suite; this is the public surface they
+    reuse so neither reaches into the private _METRICS bookkeeping.
+    """
+    return [factory() for _, factory in _METRICS]
+
+
+@scorer(metrics=risk_metric_suite())
 def risk_scorer(option_tokens: list[str] = ("0", "1")):
     """
     Scorer that extracts risk scores from logprobs of the first generated token.

--- a/src/tools/inspect/scorers/risk_scorer.py
+++ b/src/tools/inspect/scorers/risk_scorer.py
@@ -34,15 +34,26 @@ def mean_risk_score() -> Metric:
     return compute
 
 
-@scorer(
-    metrics=[
-        mean_risk_score(),
-        expected_calibration_error(),
-        risk_calibration_error(),
-        brier_score(),
-        auc_score(),
-    ]
-)
+# Source of truth for this scorer's metrics. Names are explicit because
+# inspect-ai's @metric wraps each factory and clobbers __name__ (all five
+# would report as "metric_wrapper"), so introspection can't recover them.
+# Adding one: define/import the @metric factory, then append (name, factory)
+# here — the @scorer registration and METRIC_NAMES are derived from this list.
+# numeric_risk_scorer imports this same list, so the two stay in lockstep.
+_METRICS: list[tuple[str, callable]] = [
+    ("mean_risk_score", mean_risk_score),
+    ("expected_calibration_error", expected_calibration_error),
+    ("risk_calibration_error", risk_calibration_error),
+    ("brier_score", brier_score),
+    ("auc_score", auc_score),
+]
+
+# Exported so viz_helpers can classify columns by scorer category
+# without re-listing names.
+METRIC_NAMES: frozenset[str] = frozenset(name for name, _ in _METRICS)
+
+
+@scorer(metrics=[factory() for _, factory in _METRICS])
 def risk_scorer(option_tokens: list[str] = ("0", "1")):
     """
     Scorer that extracts risk scores from logprobs of the first generated token.

--- a/src/tools/inspect/viz_helpers.py
+++ b/src/tools/inspect/viz_helpers.py
@@ -32,6 +32,8 @@ from inspect_ai.analysis import (
     EvalTask,
 )
 
+from .scorers.risk_scorer import METRIC_NAMES as _RISK_METRIC_NAMES
+
 logger = logging.getLogger(__name__)
 
 
@@ -206,8 +208,15 @@ class DetectedMetrics:
 
     @property
     def has_risk_scorer(self) -> bool:
-        """True when the evaluation used risk_scorer (has AUC metric)."""
-        return any("auc_score" in m for m in self.supplementary)
+        """True when the evaluation used risk_scorer/numeric_risk_scorer.
+
+        Supplementary names have the form ``{scorer_name}/{metric_name}``; we
+        classify by the part after the last ``/`` against the set the
+        risk scorer module exports, so renaming a metric there stays in sync.
+        """
+        return any(
+            m.rsplit("/", 1)[-1] in _RISK_METRIC_NAMES for m in self.supplementary
+        )
 
 
 def detect_metrics(logs_df: pd.DataFrame) -> DetectedMetrics:

--- a/tests/unit/scorers/test_risk_scorer.py
+++ b/tests/unit/scorers/test_risk_scorer.py
@@ -23,7 +23,14 @@ from inspect_ai.model._model_output import (
 from inspect_ai.model._chat_message import ChatMessageAssistant
 from inspect_ai.scorer import Score, CORRECT, INCORRECT, Target
 
-from cruijff_kit.tools.inspect.scorers.risk_scorer import risk_scorer, mean_risk_score
+from inspect_ai._util.registry import registry_info
+
+from cruijff_kit.tools.inspect.scorers.risk_scorer import (
+    risk_scorer,
+    mean_risk_score,
+    risk_metric_suite,
+    METRIC_NAMES,
+)
 
 # =============================================================================
 # Helpers
@@ -489,3 +496,41 @@ class TestMeanRiskScoreMetric:
         metric_fn = mean_risk_score()
         result = metric_fn(scores)
         assert result == pytest.approx(0.73, abs=1e-6)
+
+
+# =============================================================================
+# Metric suite ↔ METRIC_NAMES ↔ inspect-ai registration contract
+# =============================================================================
+
+
+class TestMetricSuiteContract:
+    """The hand-written METRIC_NAMES must agree with what inspect-ai emits.
+
+    METRIC_NAMES is written out by hand because inspect-ai's @metric clobbers
+    each factory's __name__ (all report as "metric_wrapper"), so the names can't
+    be introspected from the factories at runtime. These tests cross the
+    inspect-ai boundary to prove the hand-written names match the names
+    inspect-ai actually keys each metric under — and that key is what lands in
+    the eval-log column that has_risk_scorer later classifies. This is the
+    drift the names exist to prevent; the unit-level "METRIC_NAMES == set of
+    _METRICS names" check is a tautology and would not catch it.
+    """
+
+    def test_suite_size_matches_metric_names(self):
+        assert len(risk_metric_suite()) == len(METRIC_NAMES)
+
+    def test_registered_names_match_metric_names(self):
+        # inspect-ai registers each metric under its factory name; that name is
+        # what appears in the eval-log column. Assert our hand-written names
+        # match what inspect-ai will emit, so a rename on either side is caught.
+        emitted = {
+            registry_info(m).name.rsplit("/", 1)[-1] for m in risk_metric_suite()
+        }
+        assert emitted == set(METRIC_NAMES)
+
+    def test_suite_returns_fresh_instances(self):
+        # Each scorer instantiates its own metrics; a shared module-level list
+        # would alias mutable Metric objects across risk_scorer and
+        # numeric_risk_scorer. Fresh instances per call keep them independent.
+        first, second = risk_metric_suite(), risk_metric_suite()
+        assert all(a is not b for a, b in zip(first, second))

--- a/tests/unit/scorers/test_risk_scorer.py
+++ b/tests/unit/scorers/test_risk_scorer.py
@@ -23,6 +23,10 @@ from inspect_ai.model._model_output import (
 from inspect_ai.model._chat_message import ChatMessageAssistant
 from inspect_ai.scorer import Score, CORRECT, INCORRECT, Target
 
+# Private inspect-ai path: the only way to read the name a @metric is registered
+# under (and thus what lands in the eval-log column). Used solely to verify our
+# hand-written METRIC_NAMES against what inspect-ai actually emits. If a version
+# bump moves this, the test fails loudly at import rather than passing silently.
 from inspect_ai._util.registry import registry_info
 
 from cruijff_kit.tools.inspect.scorers.risk_scorer import (

--- a/tests/unit/test_risk_plots.py
+++ b/tests/unit/test_risk_plots.py
@@ -1,6 +1,7 @@
 """Unit tests for per-sample risk data extraction and plot generation."""
 
 import numpy as np
+import pytest
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -13,6 +14,7 @@ from cruijff_kit.tools.inspect.viz_helpers import (
     generate_calibration_overlay,
     generate_prediction_histogram,
 )
+from cruijff_kit.tools.inspect.scorers.risk_scorer import METRIC_NAMES
 
 
 # =============================================================================
@@ -187,20 +189,29 @@ class TestExtractPerSampleRiskData:
 
 
 class TestHasRiskScorer:
-    def test_true_when_auc_present(self):
+    @pytest.mark.parametrize("metric_name", sorted(METRIC_NAMES))
+    def test_true_for_each_real_risk_metric(self, metric_name):
+        # Any real risk metric trips detection — not just auc_score, which is
+        # all the old substring check caught.
+        dm = DetectedMetrics(supplementary=[f"risk_scorer_cruijff_kit/{metric_name}"])
+        assert dm.has_risk_scorer is True
+
+    def test_true_for_numeric_risk_scorer_prefix(self):
+        # numeric_risk_scorer shares the same metric suite, so its columns
+        # must classify identically.
         dm = DetectedMetrics(
-            accuracy=["match"],
-            supplementary=[
-                "risk_scorer_cruijff_kit/auc_score",
-                "risk_scorer_cruijff_kit/ece",
-            ],
+            supplementary=["numeric_risk_scorer_cruijff_kit/auc_score"]
         )
         assert dm.has_risk_scorer is True
 
-    def test_false_when_no_auc(self):
+    def test_false_for_continuous_metrics(self):
         dm = DetectedMetrics(
-            accuracy=["match"], supplementary=["risk_scorer_cruijff_kit/ece"]
+            supplementary=["continuous_scorer/mae", "continuous_scorer/rmse"]
         )
+        assert dm.has_risk_scorer is False
+
+    def test_false_when_accuracy_only(self):
+        dm = DetectedMetrics(accuracy=["match"], supplementary=[])
         assert dm.has_risk_scorer is False
 
     def test_false_when_empty(self):

--- a/tests/unit/test_viz_helpers.py
+++ b/tests/unit/test_viz_helpers.py
@@ -232,3 +232,69 @@ class TestDeduplicateEvalFiles:
         kept, skipped = deduplicate_eval_files(files)
         assert len(kept) == 1
         assert len(skipped) == 0
+
+
+# =============================================================================
+# detect_metrics() -> has_risk_scorer on realistically-shaped columns
+# =============================================================================
+
+
+class TestRiskDetectionPipeline:
+    """End-to-end detection on columns shaped like evals_df() output.
+
+    Column names mirror what evals_df() produces for a real run:
+    ``score_{scorer}/{metric}``. Exercises the detect_metrics -> has_risk_scorer
+    path the analyze step relies on for plot routing, rather than hand-building
+    a DetectedMetrics. Uses the real metric names (not a synthetic "ece").
+    """
+
+    def test_risk_run_detected_end_to_end(self):
+        df = pd.DataFrame(
+            {
+                "model": ["a"],
+                "score_match_accuracy": [0.8],
+                "score_match_stderr": [0.01],
+                "score_risk_scorer_cruijff_kit/mean_risk_score": [0.5],
+                "score_risk_scorer_cruijff_kit/expected_calibration_error": [0.1],
+                "score_risk_scorer_cruijff_kit/risk_calibration_error": [0.1],
+                "score_risk_scorer_cruijff_kit/brier_score": [0.2],
+                "score_risk_scorer_cruijff_kit/auc_score": [0.7],
+            }
+        )
+        detected = detect_metrics(df)
+        assert detected.accuracy == ["match"]
+        assert detected.has_risk_scorer is True
+
+    def test_numeric_risk_run_detected_end_to_end(self):
+        df = pd.DataFrame(
+            {
+                "model": ["a"],
+                "score_numeric_risk_scorer_cruijff_kit/auc_score": [0.7],
+                "score_numeric_risk_scorer_cruijff_kit/brier_score": [0.2],
+            }
+        )
+        assert detect_metrics(df).has_risk_scorer is True
+
+    def test_continuous_only_not_detected_as_risk(self):
+        df = pd.DataFrame(
+            {
+                "model": ["a"],
+                "score_continuous_scorer/mae": [3.1],
+                "score_continuous_scorer/rmse": [4.2],
+                "score_continuous_scorer/r_squared": [0.3],
+                "score_continuous_scorer/parse_rate": [1.0],
+            }
+        )
+        detected = detect_metrics(df)
+        assert detected.supplementary  # columns were picked up as supplementary
+        assert detected.has_risk_scorer is False
+
+    def test_accuracy_only_not_detected_as_risk(self):
+        df = pd.DataFrame(
+            {
+                "model": ["a"],
+                "score_match_accuracy": [0.8],
+                "score_match_stderr": [0.01],
+            }
+        )
+        assert detect_metrics(df).has_risk_scorer is False


### PR DESCRIPTION
Closes #534

# Description

Mirrors the `continuous_scorer` pattern (PR #533) for the risk side, removing the registry-drift hazard between `viz_helpers.has_risk_scorer` and the metric declarations.

- **`risk_scorer.py`** — adds a single canonical `_METRICS` list (source of truth) and derives both the `@scorer(metrics=...)` registration and an exported `METRIC_NAMES` frozenset from it.
- **`numeric_risk_scorer.py`** — reuses the same `_METRICS` (it publishes the identical 5-metric suite) instead of re-declaring the import block + metric list. Net −13 lines.
- **`viz_helpers.py`** — `has_risk_scorer` now classifies by membership of the suffix-after-`/` against `METRIC_NAMES`, replacing the `"auc_score"` substring scan.

**Decisions** (the issue asked us to make + document them):
- *Canonical home:* `risk_scorer.py` — where the `@scorer` lives, already imports the calibration metrics, defines `mean_risk_score`. Closest mirror to `continuous_scorer`.
- *Sharing:* `numeric_risk_scorer` shares `risk_scorer`'s `_METRICS` rather than exporting its own, since the suites are identical.

**Behavior note:** `has_risk_scorer` is now slightly more sensitive — it fires on any of the 5 risk metric names, not just `auc_score`. Since both risk scorers always ship the full suite together, this never changes real-world routing; it just makes detection robust to a future AUC drop (the point of the issue).

### Bonus: code-comment convention
While mirroring the pattern, I was about to propagate the `(#519)`/`(#534)` style already present in the scorer modules. Added a `## Code Conventions → Code Comments` section to `CLAUDE.md` banning issue/PR numbers in code comments (provenance belongs in commits/PRs, recoverable via `git blame`), and scrubbed the four existing `(#519)` references.

> Out of scope, flagged for a follow-up: one pre-existing `PR A (#254)` comment remains in `src/tools/run/_submit_common.py:363` (different subsystem).

## New Dependencies

None.

# Testing Instructions

```bash
ruff check src/tools/inspect/scorers/*.py src/tools/inspect/viz_helpers.py src/tools/inspect/report_generator.py
ruff format --check src/tools/inspect/scorers/*.py src/tools/inspect/viz_helpers.py src/tools/inspect/report_generator.py
python -m pytest tests/unit/ -k "risk or viz or report or scorer or continuous or metric" -q
```

All 338 selected unit tests pass; lint + format clean.