### PR TITLE
Sweep issue-number references out of src/ comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,12 +113,17 @@ All use Llama-3.2-1B-Instruct with `{ck_data_dir}/capitalization/words_5L_80P_10
 
 ### Code Comments
 
-- **No issue/PR numbers in code comments.** Comments must explain the code as it
-  stands, self-contained. Provenance ("why did this change?") belongs in the
-  commit message and PR description — `git blame` recovers it when needed.
+- **No issue/PR numbers in code comments under `src/`.** Production-code comments
+  must explain the code as it stands, self-contained. Provenance ("why did this
+  change?") belongs in the commit message and PR description — `git blame`
+  recovers it when needed.
   - ❌ `# Exported so viz_helpers (#534) can classify columns without re-listing.`
   - ✅ `# Exported so viz_helpers can classify columns without re-listing.`
   - Pointers to code that still exists are fine (e.g. `# See src/tools/.../inspect_task.py`) — those reference live structure, not ephemeral tracker state.
+  - **Tests are exempt.** Test files may cite the originating issue/PR — a
+    `"""Regression: ... (#447)"""` docstring documents *which bug the test guards*,
+    and the issue holds the repro and discussion. That traceability is worth more
+    in test code than the rot risk costs.
 
 ## Git Workflow
 

--- a/src/tools/experiment/archive_experiment.py
+++ b/src/tools/experiment/archive_experiment.py
@@ -140,8 +140,8 @@ def inventory_experiment(experiment_dir, output_dir_base):
             )
 
     # --- Check completeness ---
-    # Each run's eval/ holds one cell directory per (task, epoch) pair (issue
-    # #498). A run counts as complete when at least one cell has eval logs.
+    # Each run's eval/ holds one cell directory per (task, epoch) pair. A run
+    # counts as complete when at least one cell has eval logs.
     incomplete_runs = []
     for entry in eval_matrix:
         run_name = entry.get("run")

--- a/src/tools/inspect/setup_inspect.py
+++ b/src/tools/inspect/setup_inspect.py
@@ -28,8 +28,8 @@ from cruijff_kit.tools.torchtune.model_configs import MODEL_CONFIGS
 TEMPLATE_PATH = Path(__file__).parent / "templates" / "eval_template.slurm"
 
 # Default ceiling on samples per HF batch for inspect-ai's HF provider.
-# Matches inspect-ai's upstream default. Empirically (see issue #318
-# investigation comment), raising this on variable-length workloads
+# Matches inspect-ai's upstream default. Empirically, raising this on
+# variable-length workloads
 # (e.g. verbose ACS prompts) can slow evals down because larger batches
 # pad to the longest sequence and the forward pass becomes memory-bound.
 # Users can override per experiment via `evaluation.max_connections` in

--- a/src/tools/run/_submit_common.py
+++ b/src/tools/run/_submit_common.py
@@ -157,7 +157,7 @@ def state_key(work_dir: Path, slurm_name: str, experiment_dir: Path) -> str:
     """Stable per-job key for the resume state file.
 
     Using `work_dir.name` collapses all eval entries onto a single key
-    because every run's eval workdir is `<run_dir>/eval` (issue #451 comment).
+    because every run's eval workdir is `<run_dir>/eval`.
     Including the relative path keeps each entry unique.
     """
     rel = work_dir.relative_to(experiment_dir)
@@ -332,7 +332,7 @@ def log_oom_retry(
 
     `delta` is the keys we adjusted (e.g. {"batch_size": 64}); `prev_values`
     is the same keys' values before the adjustment. Both dicts forward-compat
-    with multi-key strategies (see #254 PR B).
+    with multi-key strategies.
 
     Block shape (no `Job ID:` line — safe from the analyze-experiment regex,
     which would otherwise harvest the retry as a fresh SUBMIT):
@@ -360,7 +360,7 @@ def log_oom_exhausted(
 
     The run stays in its last terminal state (OUT_OF_MEMORY or FAILED,
     depending on which detection path fired — see `_detect_oom`); other runs
-    keep monitoring. No active escalation in PR A (#254). Block shape:
+    keep monitoring. No active escalation. Block shape:
 
         [YYYY-MM-DD HH:MM:SS] OOM_EXHAUSTED: <name>
         Details: tried [{"batch_size": 64}, {"batch_size": 32}, {"batch_size": 16}] across 3 retries
@@ -672,8 +672,8 @@ def submit_and_monitor(
     - `stagger_sec` between submissions (HF datasets cache race).
     - `poll_sec` when waiting for queue room or for in-flight jobs.
     - Auto-retry: training runs that land in OUT_OF_MEMORY are
-      automatically resubmitted with batch_size halved, up to 3 times
-      (see #254 PR A). Pass `no_retry=True` to disable; that gate will
+      automatically resubmitted with batch_size halved, up to 3 times.
+      Pass `no_retry=True` to disable; that gate will
       also cover future non-OOM retry strategies.
 
     The first three can be overridden mid-run via `<exp_dir>/logs/monitor.json`.
@@ -952,7 +952,7 @@ def _all_terminal(state: dict) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# OOM auto-retry (#254 PR A)
+# OOM auto-retry
 # ---------------------------------------------------------------------------
 #
 # When a job lands in an OOM-equivalent terminal state, we halve `batch_size`

--- a/src/tools/slurm/compute_metrics.py
+++ b/src/tools/slurm/compute_metrics.py
@@ -606,7 +606,7 @@ def harvest_jids_from_run_logs(
       2. Surface them in the rendered report (e.g., as a "*Compute Utilization
          unavailable: ...*" note) instead of silently omitting the section.
 
-    Pre-#451, analyze-experiment's compute step "skipped silently if no run
+    Previously, analyze-experiment's compute step "skipped silently if no run
     logs exist." This helper makes the absence loud.
     """
     finetune_path = experiment_dir / "logs" / "run-torchtune.log"

--- a/src/tools/slurm/estimate_compute.py
+++ b/src/tools/slurm/estimate_compute.py
@@ -415,7 +415,7 @@ def estimate_from_prior(
     # parameter-count ratio (e.g. 8B/1B ≈ 2x at seq=128, not the 6.5x
     # param-count would predict); in compute-bound regimes it approaches
     # param-count. No single correction factor handles both — see
-    # cross_model_calibration.yaml and issue #492.
+    # cross_model_calibration.yaml.
     cross_model = bool(all_finetune_jobs) and not matching_finetune
     if cross_model:
         models_in_prior = sorted(
@@ -430,7 +430,7 @@ def estimate_from_prior(
             "regimes and over-predict in IO-bound regimes. Prefer a "
             "same-model prior when possible. See cross_model_calibration"
             ".yaml in this directory for measured ratios (lookup not "
-            "yet wired in — issue #492)."
+            "yet wired in)."
         )
 
     # --- Fine-tuning estimate ---
@@ -570,7 +570,7 @@ def estimate_from_prior_broadcast(
     )
 
     if not models_in_prior:
-        # No per-job model field (legacy summaries pre-#491). Fall back
+        # No per-job model field (legacy summaries). Fall back
         # to the summary-level model so single-model legacy priors still
         # produce one prediction.
         summary_model = prior_summary.get("model")

--- a/src/tools/slurm/throughput_parsers.py
+++ b/src/tools/slurm/throughput_parsers.py
@@ -8,7 +8,7 @@ These values feed estimate_compute.scale_finetune_time /
 scale_eval_time, which predict wall-time as total_tokens / tps.
 
 v1 supports single-GPU runs only; the torchtune parser hard-fails on
-distributed recipes (see issue #473 for multi-GPU follow-up).
+distributed recipes. Multi-GPU support is a planned follow-up.
 """
 
 import re
@@ -74,7 +74,7 @@ def parse_torchtune_throughput(slurm_out_text: str) -> dict:
         if "Distributed" in recipe_name or "distributed" in recipe_name.lower():
             raise ValueError(
                 f"Distributed recipe {recipe_name!r} is not supported in v1 "
-                "(single-GPU only). See issue #473 for multi-GPU follow-up."
+                "(single-GPU only). Multi-GPU support is a planned follow-up."
             )
 
     tps_match = _WANDB_TPS_RE.search(slurm_out_text)

--- a/src/tools/torchtune/setup_finetune.py
+++ b/src/tools/torchtune/setup_finetune.py
@@ -891,7 +891,7 @@ def main():
             args.custom_recipe = "cruijff_kit.tools.torchtune.custom_recipes.lora_finetune_distributed_stable"
 
     # Warn if validation was requested for a multi-GPU run. The distributed
-    # recipe has no val loop yet (issue #474), so val will be silently skipped
+    # recipe has no val loop yet, so val will be silently skipped
     # at training time. The scaffold-torchtune agent is supposed to emit this
     # warning too, but duplicating it here makes the failure loud even when
     # setup_finetune.py is invoked outside the agent path.
@@ -952,7 +952,7 @@ def main():
 
         # Verify the (possibly auto-switched) recipe resolves to a real module on disk.
         # Without this, e.g. a single-device _nightly recipe with gpus>1 silently rewrites to
-        # _distributed_nightly, which doesn't exist (see issue #474), and the SLURM job
+        # _distributed_nightly, which doesn't exist, and the SLURM job
         # fails late at runtime instead of at scaffold time.
         recipe_module_path = (
             Path(__file__).parent


### PR DESCRIPTION
Closes #541

# Description

Removes all 15 issue/PR-number references from `src/` comments, per the Code Comments convention introduced in #540, and scopes the convention to **`src/` only — tests exempt**.

## The rule, finalized: "tests fine, src never"

After inventorying every inline reference across the codebase, the pattern was clear: in `src/` the numbers mostly rot, but in `tests/` the regression-guard docstrings (`"""Regression: ... (#447)"""`) document *which bug a test guards* — traceability worth more than the rot risk. So:

- `CLAUDE.md` now reads **"No issue/PR numbers in code comments under `src/`"** with an explicit **"Tests are exempt"** clause.

## src/ rewordings (15 across 7 files)

Each keeps the *what/why*, drops the number:

| Flavor | Example before → after |
|---|---|
| Forward-pointer | `no val loop yet (issue #474)` → `no val loop yet` |
| Forward-pointer | `See issue #473 for multi-GPU follow-up` → `Multi-GPU support is a planned follow-up` |
| Superseded behavior | `Pre-#451, analyze-experiment's compute step…` → `Previously, analyze-experiment's compute step…` |
| Provenance | `No active escalation in PR A (#254).` → `No active escalation.` |
| Reference | `Empirically (see issue #318 investigation comment),` → `Empirically,` |

Two edits touch text *inside* runtime strings (the `estimate_compute` cross-model warning, the `throughput_parsers` distributed-recipe error) — verified no test asserts on the removed substrings.

## New Dependencies

None.

# Testing Instructions

```bash
# src/ is clean (only false positives like rsplit("/", 1)):
grep -rnE "#[0-9]+" src/ --include="*.py" | grep -vE "rsplit|\[len|#!/"

ruff check src/ && ruff format --check src/
python -m pytest tests/ -k "estimate_compute or throughput or compute_metrics or setup_inspect or setup_finetune or archive or submit or run_experiment" -q
```

461 tests pass for the affected modules; ruff clean.