### PR TITLE
Refactor summary_binary to use read_eval_log() API (#317)

### DIFF
--- a/src/tools/inspect/summary_binary.py
+++ b/src/tools/inspect/summary_binary.py
@@ -12,7 +12,8 @@ Metrics computed:
 - Precision(1), Recall(1), Recall(0): per-class metrics
 - Class balance: actual label split (provenance, not a performance metric)
 
-Inspect-ai stores logs as zip archives with samples/*.json containing results.
+Eval logs are read via inspect-ai's read_eval_log() API, which handles the log
+format (and any future format changes) transparently.
 
 Usage:
     python summary_binary.py /path/to/log.eval
@@ -22,26 +23,29 @@ Usage:
 
 import argparse
 import json
-import zipfile
 from pathlib import Path
 
-
-def load_samples(path: Path) -> list:
-    """Load samples from an inspect-ai .eval file (zip archive)."""
-    samples = []
-    with zipfile.ZipFile(path, "r") as z:
-        for name in z.namelist():
-            if name.startswith("samples/") and name.endswith(".json"):
-                with z.open(name) as f:
-                    samples.append(json.load(f))
-    return samples
+from inspect_ai.log import EvalSample, read_eval_log
 
 
-def get_prediction(sample: dict) -> str:
-    """Extract model's prediction from sample (last assistant message)."""
-    for msg in reversed(sample.get("messages", [])):
-        if msg.get("role") == "assistant":
-            return msg.get("content", "").strip()
+def load_samples(path: Path) -> list[EvalSample]:
+    """Load samples from an inspect-ai .eval file via the official API.
+
+    Using read_eval_log() instead of poking at the zip internals keeps this
+    forward-compatible with inspect-ai log-format changes.
+    """
+    return read_eval_log(str(path)).samples or []
+
+
+def get_prediction(sample: EvalSample) -> str:
+    """Extract the model's prediction (its final completion), stripped."""
+    output = getattr(sample, "output", None)
+    if output is not None and output.completion:
+        return output.completion.strip()
+    # Fallback for samples without a model output: last assistant message.
+    for msg in reversed(sample.messages or []):
+        if msg.role == "assistant":
+            return (msg.text or "").strip()
     return ""
 
 
@@ -62,7 +66,7 @@ def compute_metrics(path: Path) -> dict:
     matrix = {"0": {"0": 0, "1": 0, "other": 0}, "1": {"0": 0, "1": 0, "other": 0}}
 
     for s in samples:
-        actual = s["target"]
+        actual = s.target
         pred = get_prediction(s)
         if pred not in ("0", "1"):
             pred = "other"

--- a/tests/unit/test_summary_binary.py
+++ b/tests/unit/test_summary_binary.py
@@ -1,34 +1,54 @@
-"""Tests for cruijff_kit.tools.inspect.summary_binary."""
+"""Tests for cruijff_kit.tools.inspect.summary_binary.
 
-import json
-import zipfile
+Fixtures build genuine inspect-ai eval logs via write_eval_log so the code under
+test exercises the real read_eval_log() path rather than a hand-rolled zip (#317).
+"""
+
 from pathlib import Path
 
 import pytest
+from inspect_ai.log import EvalLog, EvalSample, EvalSpec, write_eval_log
+from inspect_ai.model import ChatMessageAssistant, ChatMessageUser, ModelOutput
 
 from cruijff_kit.tools.inspect.summary_binary import (
-    load_samples,
-    get_prediction,
     compute_metrics,
+    get_prediction,
+    load_samples,
 )
 
+_CREATED = "2026-01-01T00:00:00"
 
-def _make_sample(target: str, prediction: str) -> dict:
-    """Helper to create a sample dict matching inspect-ai format."""
-    return {
-        "target": target,
-        "messages": [
-            {"role": "user", "content": "What is the answer?"},
-            {"role": "assistant", "content": prediction},
+
+def _make_sample(target: str, prediction: str) -> EvalSample:
+    """A single eval sample: the model emitted `prediction` for `target`."""
+    return EvalSample(
+        id=0,
+        epoch=1,
+        input="What is the answer?",
+        target=target,
+        messages=[
+            ChatMessageUser(content="What is the answer?"),
+            ChatMessageAssistant(content=prediction),
         ],
-    }
+        output=ModelOutput.from_content("mockmodel", prediction),
+    )
 
 
-def _write_eval_file(path: Path, samples: list[dict]):
-    """Write samples into a fake .eval zip archive."""
-    with zipfile.ZipFile(path, "w") as z:
-        for i, sample in enumerate(samples):
-            z.writestr(f"samples/{i}.json", json.dumps(sample))
+def _write_eval_file(path: Path, samples: list[EvalSample]):
+    """Write samples into a real inspect-ai .eval log."""
+    for i, sample in enumerate(samples):
+        sample.id = i  # ids must be unique within a log
+    log = EvalLog(
+        eval=EvalSpec(
+            created=_CREATED,
+            task="binary_test",
+            dataset={},
+            model="mockmodel",
+            config={},
+        ),
+        samples=samples,
+    )
+    write_eval_log(log, str(path))
 
 
 @pytest.fixture
@@ -89,10 +109,18 @@ def eval_with_other(tmp_path):
 
 @pytest.fixture
 def empty_eval(tmp_path):
-    """An eval file with no samples."""
+    """A header-only eval file with no samples."""
     path = tmp_path / "empty.eval"
-    with zipfile.ZipFile(path, "w") as z:
-        z.writestr("metadata.json", "{}")
+    log = EvalLog(
+        eval=EvalSpec(
+            created=_CREATED,
+            task="binary_test",
+            dataset={},
+            model="mockmodel",
+            config={},
+        )
+    )
+    write_eval_log(log, str(path))
     return path
 
 
@@ -103,9 +131,9 @@ class TestLoadSamples:
         samples = load_samples(perfect_eval)
         assert len(samples) == 4
 
-    def test_returns_list_of_dicts(self, perfect_eval):
+    def test_returns_list_of_samples(self, perfect_eval):
         samples = load_samples(perfect_eval)
-        assert all(isinstance(s, dict) for s in samples)
+        assert all(isinstance(s, EvalSample) for s in samples)
 
     def test_empty_file(self, empty_eval):
         samples = load_samples(empty_eval)
@@ -115,38 +143,43 @@ class TestLoadSamples:
 class TestGetPrediction:
     """Tests for get_prediction."""
 
-    def test_extracts_assistant_message(self):
-        sample = _make_sample("1", "0")
-        assert get_prediction(sample) == "0"
+    def test_extracts_completion(self):
+        assert get_prediction(_make_sample("1", "0")) == "0"
 
     def test_strips_whitespace(self):
-        sample = {
-            "messages": [
-                {"role": "assistant", "content": "  1  "},
-            ]
-        }
-        assert get_prediction(sample) == "1"
+        assert get_prediction(_make_sample("1", "  1  ")) == "1"
 
-    def test_uses_last_assistant_message(self):
-        sample = {
-            "messages": [
-                {"role": "assistant", "content": "first"},
-                {"role": "user", "content": "try again"},
-                {"role": "assistant", "content": "second"},
-            ]
-        }
+    def test_falls_back_to_last_assistant_message(self):
+        """With no model output, walk messages and take the last assistant turn."""
+        sample = EvalSample(
+            id=0,
+            epoch=1,
+            input="q",
+            target="1",
+            messages=[
+                ChatMessageAssistant(content="first"),
+                ChatMessageUser(content="try again"),
+                ChatMessageAssistant(content="second"),
+            ],
+        )
         assert get_prediction(sample) == "second"
 
     def test_no_assistant_message(self):
-        sample = {"messages": [{"role": "user", "content": "hello"}]}
+        sample = EvalSample(
+            id=0,
+            epoch=1,
+            input="q",
+            target="1",
+            messages=[ChatMessageUser(content="hello")],
+        )
         assert get_prediction(sample) == ""
 
     def test_empty_messages(self):
-        sample = {"messages": []}
+        sample = EvalSample(id=0, epoch=1, input="q", target="1", messages=[])
         assert get_prediction(sample) == ""
 
-    def test_no_messages_key(self):
-        sample = {}
+    def test_no_messages_and_no_output(self):
+        sample = EvalSample(id=0, epoch=1, input="q", target="1")
         assert get_prediction(sample) == ""
 
 


### PR DESCRIPTION
Closes #317

## Description

`summary_binary.py` read inspect-ai `.eval` files by opening them as a raw `zipfile.ZipFile` and hand-parsing `samples/*.json` — reaching into another tool's internals (a wrapper-only violation, Principle #6). That coupling already broke once when inspect-ai changed its log format (plain JSON → zstd ZIP, 0.3.69 → 0.3.179, see #347).

This swaps the hand-rolled reader for inspect-ai's official `read_eval_log()`, which absorbs format changes transparently — the same API `parse_eval_log.py` and `viz_helpers.py` already use.

- `load_samples()` now returns `read_eval_log(path).samples` (a list of `EvalSample`) instead of raw dicts.
- `get_prediction()` reads `EvalSample.output.completion` (falling back to the last assistant message) rather than dict keys.
- `compute_metrics()` reads `sample.target` instead of `sample["target"]`.
- **No behavior change** to the metrics or the output schema (accuracy, balanced accuracy, F1, per-class, `class_balance`, confusion matrix).

Test fixtures previously hand-wrote fake `.eval` zips, which the new code path could not read. They now build **genuine** eval logs via `write_eval_log`, so the suite exercises the real `read_eval_log()` round-trip — closing the same gap #545 raises for the continuous summary.

## New Dependencies

None. `inspect_ai` is already a core dependency.

## Testing Instructions

```bash
ruff check src/tools/inspect/summary_binary.py tests/unit/test_summary_binary.py
ruff format --check src/tools/inspect/summary_binary.py tests/unit/test_summary_binary.py
python -m pytest tests/unit/test_summary_binary.py -q   # 24 passed
```

Also smoke-tested `print_summary` and `--json` end-to-end on a real `write_eval_log`-generated `.eval` file.