### PR TITLE
Add deterministic experiment_summary.yaml propagation (#502)

### DIFF
--- a/.claude/agents/scaffold-inspect.md
+++ b/.claude/agents/scaffold-inspect.md
@@ -32,37 +32,30 @@ This subagent can be invoked in two ways:
 3. **Read claude.local.md** — Get environment-specific settings (conda env, account, etc.).
 4. **Verify inspect-ai tasks exist** — Check if evaluation task scripts are available.
 5. **For each cell, build `eval_config.yaml` in two passes (in this order):**
-   1. **Mandatory: call `propagate_eval_fields(experiment_summary, eval_config)`** to populate experiment-wide defaults. See the "MANDATORY STEP" block immediately below.
+   1. **Call `propagate_eval_fields(experiment_summary, eval_config)` first** to populate experiment-wide defaults (see "Key Pattern: Propagate First" below).
    2. **Then** layer in per-cell judgment fields (`model_path`, `data_path`, `vis_label`, `use_chat_template`, per-task `system_prompt` overrides). Propagation is idempotent — your overrides win.
 6. **Run `setup_inspect.py`** for each cell to render `cell.slurm`.
 7. **Create scaffold log** — Document all actions in `logs/scaffold-inspect.log`. **Log the `propagate_eval_fields()` call explicitly** so the audit trail shows it ran.
-8. **Report summary** — In your report, name the helper call and the count of fields it populated. **Do NOT produce a field-by-field derivation table for EVAL_FIELDS values** — that's an anti-pattern (see "Reporting" below).
+8. **Report summary** — Name the helper call and how many fields it populated; don't tabulate the propagated `EVAL_FIELDS` values (they weren't decisions).
 
-## MANDATORY STEP: Call `propagate_eval_fields()`
+## Key Pattern: Propagate First
 
-Every `eval_config.yaml` you build must be populated by this exact call,
-once, before you write the file:
+Before writing any other field into `eval_config.yaml`, call:
 
 ```python
 from cruijff_kit.tools.experiment.propagate import propagate_eval_fields
 propagate_eval_fields(experiment_summary, eval_config)
 ```
 
-This is not optional, not an example, and not "what the helper would do."
-You must call it. It populates every field in `EVAL_FIELDS`
-(`src/tools/experiment/propagate.py`) — currently `system_prompt`,
-`temperature`, `do_sample`, `max_tokens`, `max_connections`, and `scorer`
-— from `experiment_summary.yaml` into `eval_config`.
+This fills every `EVAL_FIELDS` value (`src/tools/experiment/propagate.py`:
+`system_prompt`, `temperature`, `do_sample`, `max_tokens`, `max_connections`,
+`scorer`) straight from `experiment_summary.yaml`. **Don't hand-copy these** —
+`EVAL_FIELDS` is the single source of truth (add new propagated fields there,
+not in this doc). The helper is idempotent, so per-cell judgment fields you
+write afterward win (e.g. a per-task `system_prompt` override).
 
-**Do not write these fields by hand. Do not extract them in your parsing
-step. Do not list them in your report's "How I Decided Each Field"
-table.** If you find yourself reading `evaluation.temperature` to copy
-into `eval_config.yaml`, stop — you have skipped this step. Source of
-truth for which fields are propagated lives in `EVAL_FIELDS` itself; add
-or remove there, never in this doc.
-
-(Background: #470 → #502. A field whose only propagation path was a prose
-bullet got silently dropped when the bullet wasn't followed.)
+Background: #470 → #502, where a field whose only propagation path was a prose
+bullet got silently dropped when the bullet wasn't followed.
 
 ## Input Format
 
@@ -104,7 +97,7 @@ Extract the following information from the YAML structure:
    - `evaluation.tasks[]` — List of evaluation tasks (see Parsing Evaluation Tasks below)
    - `evaluation.matrix[]` — Which runs evaluate on which tasks/epochs (see Parsing Evaluation Matrix below)
 
-   **All other `evaluation.*` fields** (`system_prompt`, `temperature`, `do_sample`, `max_tokens`, `max_connections`, `scorer`) are populated by `propagate_eval_fields()` per the MANDATORY STEP above. Do not extract or list them here — the helper reads them straight from `experiment_summary.yaml`. The canonical map lives in `EVAL_FIELDS` (`src/tools/experiment/propagate.py`).
+   **All other `evaluation.*` fields** (`system_prompt`, `temperature`, `do_sample`, `max_tokens`, `max_connections`, `scorer`) are populated by `propagate_eval_fields()` (see "Key Pattern: Propagate First"). Don't extract them here — the helper reads them straight from `experiment_summary.yaml`.
 
 7. **Compute estimates (optional):**
    - `evaluation.compute.time` - Estimated SLURM time limit for eval jobs
@@ -336,36 +329,15 @@ Note: `config_path` and `eval_dir` are **auto-derived** from the location of the
 
 #### Populating eval_config.yaml
 
-The order is fixed: **propagate first, judgment second.** Inverting this
-order is how `EVAL_FIELDS` values get silently dropped — the agent starts
-enumerating fields by hand, never reaches the helper call, and ships an
-`eval_config.yaml` missing half of `EVAL_FIELDS`. This is the #470 →
-#502 failure mode.
+The order is fixed: **propagate first, judgment second.**
 
-**Step 1 — Call the propagation helper (MANDATORY).**
-
-```python
-from cruijff_kit.tools.experiment.propagate import propagate_eval_fields
-propagate_eval_fields(experiment_summary, eval_config)
-```
-
-This populates every `EVAL_FIELDS` value (`src/tools/experiment/propagate.py`)
-— currently `system_prompt`, `temperature`, `do_sample`, `max_tokens`,
-`max_connections`, `scorer` — from `experiment_summary.yaml`. The helper is
-idempotent: source values of `None` or missing dotted paths are skipped,
-and any key your Step 2 overrides (below) will win because the helper
-preserves existing non-None values. Run it once per cell, before writing
-the YAML.
-
-**To add a new propagated field, add an entry to `EVAL_FIELDS` — do not
-add a new bullet to this list.** A field whose only propagation path is
-a prose bullet is one prose-edit away from being silently dropped (which
-is what happened to `evaluation.temperature` in #470).
+**Step 1 — Call `propagate_eval_fields()` first** (see "Key Pattern: Propagate
+First" above for the call and the `EVAL_FIELDS` set it fills). Run it once per
+cell, before writing the YAML.
 
 Note on `temperature`: the helper copies it unconditionally when present.
 `setup_inspect.py` drops `temperature` from rendered task args when
-`do_sample` is false, so an inert value in `eval_config.yaml` is
-harmless.
+`do_sample` is false, so an inert value in `eval_config.yaml` is harmless.
 
 **Step 2 — Write the per-cell judgment fields.** These require composition,
 branching, or per-cell overrides. Because Step 1 ran first and the helper
@@ -392,13 +364,8 @@ overrides take precedence when they set the same key (e.g. a per-task
   here — Step 1's helper already did that.
 - `assistant_prefix` *(per-task override only)*: same shape as `system_prompt`.
 
-**Reporting (anti-pattern alert).** When you report on the cells you
-scaffolded, **do not produce a "How I Decided Each Field" table covering
-`EVAL_FIELDS` values**. Those did not require a decision — the helper
-copied them. A field-by-field table for propagated fields is the
-diagnostic signature that you skipped Step 1. Report instead: "Called
-`propagate_eval_fields()` (populated N fields), then wrote per-cell:
-model_path, data_path, vis_label, … ."
+**Reporting:** name the `propagate_eval_fields()` call and the field count;
+don't tabulate the propagated values per-field — they weren't decisions.
 
 #### setup_inspect.py Usage
 
@@ -782,18 +749,10 @@ Result: {outcome}
 - Verification of inspect-ai task scripts
 - Evaluation matrix analysis (which runs, which epochs, which tasks)
 - Directory creation
-- **`PROPAGATE_EVAL_FIELDS` — one entry per cell, recording that `propagate_eval_fields()` ran and the count/names of `EVAL_FIELDS` values it populated.** This is the audit trail for #502: a missing `PROPAGATE_EVAL_FIELDS` entry means the call was skipped and the YAML is suspect.
+- **`PROPAGATE_EVAL_FIELDS`** — one entry per cell recording that `propagate_eval_fields()` ran and how many `EVAL_FIELDS` it populated. The #502 audit trail: a missing entry means the call was skipped and the YAML is suspect.
 - SLURM script generation for each evaluation
 - Any errors or warnings
 - Final summary of created evaluation configs
-
-Example propagate entry:
-
-```
-[2025-10-24 17:00:18] PROPAGATE_EVAL_FIELDS: rank8_lr1e-5/eval/capitalization_epoch0
-Details: Called propagate_eval_fields(experiment_summary, eval_config)
-Result: Populated 6 EVAL_FIELDS values: system_prompt, temperature, do_sample, max_tokens, max_connections, scorer
-```
 
 ### Example Log Entries
 

--- a/.claude/agents/scaffold-inspect.md
+++ b/.claude/agents/scaffold-inspect.md
@@ -54,9 +54,6 @@ This fills every `EVAL_FIELDS` value (`src/tools/experiment/propagate.py`:
 not in this doc). The helper is idempotent, so per-cell judgment fields you
 write afterward win (e.g. a per-task `system_prompt` override).
 
-Background: #470 → #502, where a field whose only propagation path was a prose
-bullet got silently dropped when the bullet wasn't followed.
-
 ## Input Format
 
 ### Finding the Experiment

--- a/.claude/agents/scaffold-inspect.md
+++ b/.claude/agents/scaffold-inspect.md
@@ -38,6 +38,28 @@ This subagent can be invoked in two ways:
 6. **Create scaffold log** - Document all actions taken in `logs/scaffold-inspect.log`
 7. **Report summary** - Show user what was created and any issues
 
+## Key Pattern: Two-Step Field Population
+
+For each cell's `eval_config.yaml`, the field set is populated in two
+distinct steps:
+
+1. **Agent judgment** — per-cell values requiring composition or branching
+   (model_path, data_path, per-task overrides).
+2. **Deterministic propagation** — call `propagate_eval_fields()` to copy
+   experiment-wide defaults (system_prompt, scorer, temperature, etc.)
+   from `experiment_summary.yaml`.
+
+```python
+from cruijff_kit.tools.experiment.propagate import propagate_eval_fields
+propagate_eval_fields(experiment_summary, eval_config)
+```
+
+**Do not hand-copy fields covered by EVAL_FIELDS.** The map in
+`src/tools/experiment/propagate.py` is the single source of truth — add to
+it when you need a new propagated field. (Background: #470 → #502.)
+
+See "Populating eval_config.yaml" below for the full per-field detail.
+
 ## Input Format
 
 ### Finding the Experiment
@@ -333,6 +355,11 @@ prompt: "{input}\n"
 Note: `config_path` and `eval_dir` are **auto-derived** from the location of the YAML file — do not include them in eval_config.yaml.
 
 #### Populating eval_config.yaml
+
+> **TL;DR — two steps:** Step 1 is per-cell judgment. Step 2 calls
+> `propagate_eval_fields()`. **Don't skip Step 2** or fields in
+> `EVAL_FIELDS` will silently drop. (See the "Key Pattern: Two-Step Field
+> Population" callout near the top of this doc for the shape.)
 
 The work splits cleanly between **agent judgment** (per-cell decisions, path
 composition, branching) and a **deterministic propagation step** (flat field

--- a/.claude/agents/scaffold-inspect.md
+++ b/.claude/agents/scaffold-inspect.md
@@ -334,7 +334,14 @@ Note: `config_path` and `eval_dir` are **auto-derived** from the location of the
 
 #### Populating eval_config.yaml
 
-Extract values from setup_finetune.yaml (fine-tuned runs) or experiment_summary.yaml (control runs):
+The work splits cleanly between **agent judgment** (per-cell decisions, path
+composition, branching) and a **deterministic propagation step** (flat field
+copies from `experiment_summary.yaml`).
+
+**Step 1 — Agent decides per-cell.** Write these into `eval_config` first; the
+propagation step in Step 2 is idempotent and will not overwrite anything the
+agent has already set.
+
 - `task_script`: From `evaluation.tasks[].script` + `@` + task name
 - `task_name`: From `evaluation.tasks[].name`
 - `model_path`: Fine-tuned: `{base_directory}/{run_name}/artifacts/epoch_{N}`. Control: original model path
@@ -347,12 +354,32 @@ Extract values from setup_finetune.yaml (fine-tuned runs) or experiment_summary.
   4. Else — fall back to the dataset path in `setup_finetune.yaml` (fine-tuned runs) or `data.training.path` in `experiment_summary.yaml` (control runs).
 
   Log the resolved path into `logs/scaffold-inspect.log` so the audit trail captures exactly which file backed this evaluation.
-- `system_prompt`: per-cell resolution — start from the run's configuration (may vary per run!), then **override with `task['system_prompt']` if the task entry sets it** (per-task override, see Parsing Evaluation Tasks above). This is how heterogeneous prompts inside one run end up in distinct cells.
+- `system_prompt`: per-cell resolution — start from the run's configuration (may vary per run!), then **override with `task['system_prompt']` if the task entry sets it** (per-task override, see Parsing Evaluation Tasks above). This is how heterogeneous prompts inside one run end up in distinct cells. Write this before Step 2 — propagation will preserve your per-cell value.
 - `assistant_prefix`: same per-cell resolution as `system_prompt` if `task['assistant_prefix']` is set.
-- `scorer`: From `evaluation.scorer` in experiment_summary.yaml
-- `temperature`: From `evaluation.temperature` in experiment_summary.yaml (OPTIONAL). Propagate **only when `do_sample: true`** — temperature is the sampling temperature and is inert under the default greedy decoding (`setup_inspect.py` drops it from the task args when `do_sample` is false). On the sampling path it must be strictly > 0; `setup_inspect.py` hard-errors on a missing or `<= 0` temperature when `do_sample: true`, because HF's `TemperatureLogitsWarper` does `scores / temperature` and raises `ValueError` at zero (division by zero → inf/NaN logits).
-- `do_sample`: From `evaluation.do_sample` in experiment_summary.yaml (OPTIONAL, default `false`). Propagate only if explicitly set; when absent, `setup_inspect.py` emits `-M do_sample=false` (greedy argmax — deterministic, bitwise-reproducible, no RNG). Set `true` only for sampling-based evals.
-- `max_tokens`: From `evaluation.max_tokens` in experiment_summary.yaml (OPTIONAL). Propagate only if explicitly set; otherwise omit and the @task function's per-task default applies.
+
+**Step 2 — Call the propagation helper for experiment-wide defaults.**
+
+```python
+from cruijff_kit.tools.experiment.propagate import propagate_eval_fields
+propagate_eval_fields(experiment_summary, eval_config)
+```
+
+`propagate_eval_fields()` copies every field declared in `EVAL_FIELDS` (in
+`src/tools/experiment/propagate.py`) from `experiment_summary.yaml` into
+`eval_config.yaml`. The current map covers `system_prompt`, `temperature`,
+`do_sample`, `max_tokens`, `max_connections`, and `scorer`. Source values
+that are `None` or whose dotted path is missing are skipped; any key the
+agent already wrote in Step 1 is preserved.
+
+**To add a new propagated field, add an entry to `EVAL_FIELDS` — do not add a
+new bullet to this list.** This was the lesson from #470: a field whose only
+propagation path was a prose bullet got silently dropped when the bullet
+wasn't followed.
+
+Note on `temperature`: the helper copies it unconditionally when present in
+`experiment_summary.yaml`. `setup_inspect.py` is the gatekeeper — it drops
+`temperature` from rendered task args when `do_sample` is false, so an inert
+value in `eval_config.yaml` is harmless.
 
 #### setup_inspect.py Usage
 

--- a/.claude/agents/scaffold-inspect.md
+++ b/.claude/agents/scaffold-inspect.md
@@ -27,38 +27,42 @@ This subagent can be invoked in two ways:
 
 ## Core Responsibilities Workflow
 
-1. **Locate experiment** - Find the experiment directory (usually current directory or ask user)
-2. **Read experiment_summary.yaml** - Parse the experiment plan to extract evaluation configuration
-3. **Read claude.local.md** - Get environment-specific settings (conda env, etc.)
-4. **Verify inspect-ai tasks exist** - Check if evaluation task scripts are available
-5. **For each run and evaluation combination:**
-   - Generate `inspect.slurm` script for that run/epoch
-   - Configure model paths, task parameters, output locations
-   - Verify configuration
-6. **Create scaffold log** - Document all actions taken in `logs/scaffold-inspect.log`
-7. **Report summary** - Show user what was created and any issues
+1. **Locate experiment** — Find the experiment directory (usually current directory or ask user).
+2. **Read experiment_summary.yaml** — Parse only the structural sections you need to make per-cell decisions (matrix, tasks, runs, models). **Do not enumerate or extract fields covered by `EVAL_FIELDS`** — that's step 5's job, not yours.
+3. **Read claude.local.md** — Get environment-specific settings (conda env, account, etc.).
+4. **Verify inspect-ai tasks exist** — Check if evaluation task scripts are available.
+5. **For each cell, build `eval_config.yaml` in two passes (in this order):**
+   1. **Mandatory: call `propagate_eval_fields(experiment_summary, eval_config)`** to populate experiment-wide defaults. See the "MANDATORY STEP" block immediately below.
+   2. **Then** layer in per-cell judgment fields (`model_path`, `data_path`, `vis_label`, `use_chat_template`, per-task `system_prompt` overrides). Propagation is idempotent — your overrides win.
+6. **Run `setup_inspect.py`** for each cell to render `cell.slurm`.
+7. **Create scaffold log** — Document all actions in `logs/scaffold-inspect.log`. **Log the `propagate_eval_fields()` call explicitly** so the audit trail shows it ran.
+8. **Report summary** — In your report, name the helper call and the count of fields it populated. **Do NOT produce a field-by-field derivation table for EVAL_FIELDS values** — that's an anti-pattern (see "Reporting" below).
 
-## Key Pattern: Two-Step Field Population
+## MANDATORY STEP: Call `propagate_eval_fields()`
 
-For each cell's `eval_config.yaml`, the field set is populated in two
-distinct steps:
-
-1. **Agent judgment** — per-cell values requiring composition or branching
-   (model_path, data_path, per-task overrides).
-2. **Deterministic propagation** — call `propagate_eval_fields()` to copy
-   experiment-wide defaults (system_prompt, scorer, temperature, etc.)
-   from `experiment_summary.yaml`.
+Every `eval_config.yaml` you build must be populated by this exact call,
+once, before you write the file:
 
 ```python
 from cruijff_kit.tools.experiment.propagate import propagate_eval_fields
 propagate_eval_fields(experiment_summary, eval_config)
 ```
 
-**Do not hand-copy fields covered by EVAL_FIELDS.** The map in
-`src/tools/experiment/propagate.py` is the single source of truth — add to
-it when you need a new propagated field. (Background: #470 → #502.)
+This is not optional, not an example, and not "what the helper would do."
+You must call it. It populates every field in `EVAL_FIELDS`
+(`src/tools/experiment/propagate.py`) — currently `system_prompt`,
+`temperature`, `do_sample`, `max_tokens`, `max_connections`, and `scorer`
+— from `experiment_summary.yaml` into `eval_config`.
 
-See "Populating eval_config.yaml" below for the full per-field detail.
+**Do not write these fields by hand. Do not extract them in your parsing
+step. Do not list them in your report's "How I Decided Each Field"
+table.** If you find yourself reading `evaluation.temperature` to copy
+into `eval_config.yaml`, stop — you have skipped this step. Source of
+truth for which fields are propagated lives in `EVAL_FIELDS` itself; add
+or remove there, never in this doc.
+
+(Background: #470 → #502. A field whose only propagation path was a prose
+bullet got silently dropped when the bullet wasn't followed.)
 
 ## Input Format
 
@@ -96,14 +100,11 @@ Extract the following information from the YAML structure:
    - `runs[]` - List of all runs (fine-tuned + control)
    - For each run: `name`, `type`, `model`, `parameters`
 
-6. **Evaluation configuration:**
-   - `evaluation.system_prompt` - Must match training
-   - `evaluation.do_sample` - OPTIONAL decoding mode (default false = greedy argmax)
-   - `evaluation.temperature` - OPTIONAL sampling temperature; required only when `do_sample: true`
-   - `evaluation.max_connections` - OPTIONAL ceiling on samples per HF batch. If absent, `setup_inspect.py` defaults to 32 (matching inspect-ai upstream). Propagate to each eval_config.yaml only if explicitly set in experiment_summary.yaml. Note: raising this on variable-length workloads can slow evals due to padding waste; see issue #318 investigation comment.
-   - `evaluation.scorer[]` - List of scorers with optional params (see Parsing Scorer Configuration below)
-   - `evaluation.tasks[]` - List of evaluation tasks
-   - `evaluation.matrix[]` - Which runs evaluate on which tasks/epochs
+6. **Evaluation configuration — structural fields only:**
+   - `evaluation.tasks[]` — List of evaluation tasks (see Parsing Evaluation Tasks below)
+   - `evaluation.matrix[]` — Which runs evaluate on which tasks/epochs (see Parsing Evaluation Matrix below)
+
+   **All other `evaluation.*` fields** (`system_prompt`, `temperature`, `do_sample`, `max_tokens`, `max_connections`, `scorer`) are populated by `propagate_eval_fields()` per the MANDATORY STEP above. Do not extract or list them here — the helper reads them straight from `experiment_summary.yaml`. The canonical map lives in `EVAL_FIELDS` (`src/tools/experiment/propagate.py`).
 
 7. **Compute estimates (optional):**
    - `evaluation.compute.time` - Estimated SLURM time limit for eval jobs
@@ -252,22 +253,19 @@ From the `runs[]` list in experiment_summary.yaml, identify control runs:
 - These runs have no LoRA rank (or LoRA Rank = "-")
 - Example: `| Llama-3.2-1B-Instruct_control | Llama-3.2-1B-Instruct | - | Control | N/A |`
 
-### Extracting Values for All Runs (Fine-tuned and Control)
+### Per-cell agent work (Fine-tuned and Control)
 
-For both fine-tuned and control runs, generate `eval_config.yaml` with configuration for evaluation.
+For every cell — fine-tuned or control — `eval_config.yaml` is built by
+**calling `propagate_eval_fields()` first**, then layering in the per-cell
+judgment fields below. **Do not "copy" or "extract" any `EVAL_FIELDS`
+value by hand** — that is the helper's job.
 
-**For fine-tuned runs:**
-- Copy `prompt` and `system_prompt` from `setup_finetune.yaml`
-- If the cell's task has a `system_prompt` override, use that instead
-- Add scorer configuration from `evaluation.scorer` in experiment_summary.yaml
-- Place in `{experiment_dir}/{run_dir}/eval/{cell_name}/eval_config.yaml`
+The fields that *do* require agent judgment, per cell:
 
-**For control runs:**
-Extract the following from experiment_summary.yaml:
-- `data_path`: Full path from Resources → Dataset → Path
-- `prompt`: From Configuration → prompt (e.g., `"{input}"`)
-- `system_prompt`: From Configuration → System prompt (or the per-task override if set)
-- `model_path`: From Resources → Models (the control model path)
+- `model_path` — Fine-tuned: `{base_directory}/{run_name}/artifacts/epoch_{N}`. Control: `models.base[].path`.
+- `data_path` — resolved per the precedence ladder in "Populating eval_config.yaml" below.
+- `model_hf_name`, `output_dir`, `vis_label`, `use_chat_template`, `epoch`, `finetuned`, `source_model` — composed per the rules in "Populating eval_config.yaml".
+- Per-task overrides (`system_prompt`, `assistant_prefix`) — when an `evaluation.tasks[]` entry sets these, write them *after* the propagation call so they take precedence over the experiment-wide defaults.
 
 1. **Create the cell directory + logs dir for every (task, epoch) pair:**
    ```bash
@@ -312,62 +310,68 @@ output_dir: /outputs/run1/artifacts/
 
 > **Note:** For fine-tuned runs, `setup_inspect.py` derives `output_dir` from `model_path`'s parent at render time and ignores whatever you write in this field. The field is still required for schema consistency and as documentation, but the rendered SLURM's GPU metrics path is guaranteed to match `model_path`. Set `output_dir` to the artifacts directory (`{base}/{run}/artifacts/`) for clarity.
 
-**Optional keys** (task args passed as `-T`, metadata passed as `--metadata`):
+**Agent-supplied optional keys** (task args passed as `-T`, metadata passed as `--metadata`):
 
 ```yaml
-# Task args (-T key=value)
+# Task args (-T key=value) — agent writes these per cell
 data_path: /data/acs_income.json
 vis_label: 1B_ft
 use_chat_template: "true"
-max_tokens: 5          # propagated from evaluation.max_tokens (if set)
-# temperature: omitted under greedy decoding (the default). Propagate it ONLY
-# when do_sample: true — it is the sampling temperature and is otherwise inert.
 
-# Metadata (--metadata key=value)
+# Metadata (--metadata key=value) — agent writes these per cell
 epoch: 0
 finetuned: true
 source_model: Llama-3.2-1B-Instruct
-
-# Model arg (passed as -M do_sample=...)
-# Decoding mode. Defaults to false (greedy argmax — deterministic, no RNG).
-# setup_inspect.py emits -M do_sample=false on every script when absent.
-# Set to true only for sampling-based evals (temperature then applies).
-do_sample: false
-
-# Inspect CLI flag (passed as --max-connections)
-# Omit unless experiment_summary.yaml set evaluation.max_connections explicitly.
-# When absent, setup_inspect.py defaults to 32 (matches inspect-ai upstream).
-max_connections: 32
 ```
 
-**Experiment-specific config** (not used by SLURM renderer, read by inspect task at runtime):
-
-```yaml
-scorer:
-  - name: match
-  - name: risk_scorer
-    params:
-      option_tokens: ["0", "1"]
-system_prompt: ""
-prompt: "{input}\n"
-```
+**Propagated keys** — populated by `propagate_eval_fields()`. The current
+`EVAL_FIELDS` map covers `system_prompt`, `temperature`, `do_sample`,
+`max_tokens`, `max_connections`, `scorer`. You do not write these by
+hand. The downstream tooling tolerates missing/extra values: `do_sample`
+defaults to `false` at the SLURM-render layer when absent;
+`max_connections` defaults to 32. The agent's only responsibility is to
+call the helper.
 
 Note: `config_path` and `eval_dir` are **auto-derived** from the location of the YAML file — do not include them in eval_config.yaml.
 
 #### Populating eval_config.yaml
 
-> **TL;DR — two steps:** Step 1 is per-cell judgment. Step 2 calls
-> `propagate_eval_fields()`. **Don't skip Step 2** or fields in
-> `EVAL_FIELDS` will silently drop. (See the "Key Pattern: Two-Step Field
-> Population" callout near the top of this doc for the shape.)
+The order is fixed: **propagate first, judgment second.** Inverting this
+order is how `EVAL_FIELDS` values get silently dropped — the agent starts
+enumerating fields by hand, never reaches the helper call, and ships an
+`eval_config.yaml` missing half of `EVAL_FIELDS`. This is the #470 →
+#502 failure mode.
 
-The work splits cleanly between **agent judgment** (per-cell decisions, path
-composition, branching) and a **deterministic propagation step** (flat field
-copies from `experiment_summary.yaml`).
+**Step 1 — Call the propagation helper (MANDATORY).**
 
-**Step 1 — Agent decides per-cell.** Write these into `eval_config` first; the
-propagation step in Step 2 is idempotent and will not overwrite anything the
-agent has already set.
+```python
+from cruijff_kit.tools.experiment.propagate import propagate_eval_fields
+propagate_eval_fields(experiment_summary, eval_config)
+```
+
+This populates every `EVAL_FIELDS` value (`src/tools/experiment/propagate.py`)
+— currently `system_prompt`, `temperature`, `do_sample`, `max_tokens`,
+`max_connections`, `scorer` — from `experiment_summary.yaml`. The helper is
+idempotent: source values of `None` or missing dotted paths are skipped,
+and any key your Step 2 overrides (below) will win because the helper
+preserves existing non-None values. Run it once per cell, before writing
+the YAML.
+
+**To add a new propagated field, add an entry to `EVAL_FIELDS` — do not
+add a new bullet to this list.** A field whose only propagation path is
+a prose bullet is one prose-edit away from being silently dropped (which
+is what happened to `evaluation.temperature` in #470).
+
+Note on `temperature`: the helper copies it unconditionally when present.
+`setup_inspect.py` drops `temperature` from rendered task args when
+`do_sample` is false, so an inert value in `eval_config.yaml` is
+harmless.
+
+**Step 2 — Write the per-cell judgment fields.** These require composition,
+branching, or per-cell overrides. Because Step 1 ran first and the helper
+is idempotent, your writes here are not pre-empted *and* per-cell
+overrides take precedence when they set the same key (e.g. a per-task
+`system_prompt`).
 
 - `task_script`: From `evaluation.tasks[].script` + `@` + task name
 - `task_name`: From `evaluation.tasks[].name`
@@ -381,32 +385,20 @@ agent has already set.
   4. Else — fall back to the dataset path in `setup_finetune.yaml` (fine-tuned runs) or `data.training.path` in `experiment_summary.yaml` (control runs).
 
   Log the resolved path into `logs/scaffold-inspect.log` so the audit trail captures exactly which file backed this evaluation.
-- `system_prompt`: per-cell resolution — start from the run's configuration (may vary per run!), then **override with `task['system_prompt']` if the task entry sets it** (per-task override, see Parsing Evaluation Tasks above). This is how heterogeneous prompts inside one run end up in distinct cells. Write this before Step 2 — propagation will preserve your per-cell value.
-- `assistant_prefix`: same per-cell resolution as `system_prompt` if `task['assistant_prefix']` is set.
+- `system_prompt` *(per-task override only)*: write this **only** if the
+  `evaluation.tasks[]` entry sets a task-level `system_prompt`. When
+  present, the per-task override takes precedence over the experiment-wide
+  default the helper propagated. Do not "copy" `evaluation.system_prompt`
+  here — Step 1's helper already did that.
+- `assistant_prefix` *(per-task override only)*: same shape as `system_prompt`.
 
-**Step 2 — Call the propagation helper for experiment-wide defaults.**
-
-```python
-from cruijff_kit.tools.experiment.propagate import propagate_eval_fields
-propagate_eval_fields(experiment_summary, eval_config)
-```
-
-`propagate_eval_fields()` copies every field declared in `EVAL_FIELDS` (in
-`src/tools/experiment/propagate.py`) from `experiment_summary.yaml` into
-`eval_config.yaml`. The current map covers `system_prompt`, `temperature`,
-`do_sample`, `max_tokens`, `max_connections`, and `scorer`. Source values
-that are `None` or whose dotted path is missing are skipped; any key the
-agent already wrote in Step 1 is preserved.
-
-**To add a new propagated field, add an entry to `EVAL_FIELDS` — do not add a
-new bullet to this list.** This was the lesson from #470: a field whose only
-propagation path was a prose bullet got silently dropped when the bullet
-wasn't followed.
-
-Note on `temperature`: the helper copies it unconditionally when present in
-`experiment_summary.yaml`. `setup_inspect.py` is the gatekeeper — it drops
-`temperature` from rendered task args when `do_sample` is false, so an inert
-value in `eval_config.yaml` is harmless.
+**Reporting (anti-pattern alert).** When you report on the cells you
+scaffolded, **do not produce a "How I Decided Each Field" table covering
+`EVAL_FIELDS` values**. Those did not require a decision — the helper
+copied them. A field-by-field table for propagated fields is the
+diagnostic signature that you skipped Step 1. Report instead: "Called
+`propagate_eval_fields()` (populated N fields), then wrote per-cell:
+model_path, data_path, vis_label, … ."
 
 #### setup_inspect.py Usage
 
@@ -790,9 +782,18 @@ Result: {outcome}
 - Verification of inspect-ai task scripts
 - Evaluation matrix analysis (which runs, which epochs, which tasks)
 - Directory creation
+- **`PROPAGATE_EVAL_FIELDS` — one entry per cell, recording that `propagate_eval_fields()` ran and the count/names of `EVAL_FIELDS` values it populated.** This is the audit trail for #502: a missing `PROPAGATE_EVAL_FIELDS` entry means the call was skipped and the YAML is suspect.
 - SLURM script generation for each evaluation
 - Any errors or warnings
 - Final summary of created evaluation configs
+
+Example propagate entry:
+
+```
+[2025-10-24 17:00:18] PROPAGATE_EVAL_FIELDS: rank8_lr1e-5/eval/capitalization_epoch0
+Details: Called propagate_eval_fields(experiment_summary, eval_config)
+Result: Populated 6 EVAL_FIELDS values: system_prompt, temperature, do_sample, max_tokens, max_connections, scorer
+```
 
 ### Example Log Entries
 

--- a/.claude/agents/scaffold-torchtune.md
+++ b/.claude/agents/scaffold-torchtune.md
@@ -20,46 +20,50 @@ This subagent can be invoked in two ways:
 ## Core Responsibilities Workflow
 
 When invoked:
-1. **Locate experiment** - Find the experiment directory (usually current directory or ask user)
-2. **Read experiment_summary.yaml** - Parse the experiment plan to extract run configurations
-3. **Read claude.local.md** - Get environment-specific settings (conda env, output dirs, etc.)
-4. **Identify varying parameters** - Determine which parameters change across runs (for directory naming)
-5. **For each fine-tuning run:**
-   - Create run directory with name from experiment configuration
-   - Generate `setup_finetune.yaml` from appropriate template
-   - **EXECUTE `setup_finetune.py` AUTOMATICALLY using conda run** - This generates `finetune.yaml` and `finetune.slurm`
-   - Verify outputs exist (finetune.yaml and finetune.slurm must be present)
-   - Report status
-6. **Create scaffold log** - Document all actions taken in `logs/scaffold-torchtune.log`
-7. **Report summary** - Show user what was created and any issues
+1. **Locate experiment** — Find the experiment directory (usually current directory or ask user).
+2. **Read experiment_summary.yaml** — Parse only the structural sections you need to make per-run decisions (runs, models, paths). **Do not enumerate or extract fields covered by `TRAIN_FIELDS`** — that's step 5's job, not yours.
+3. **Read claude.local.md** — Get environment-specific settings (conda env, output dirs, etc.).
+4. **Identify varying parameters** — Determine which parameters change across runs (for directory naming).
+5. **For each fine-tuning run, build `setup_finetune.yaml` in two passes (in this order):**
+   1. **Mandatory: call `propagate_train_fields(experiment_summary, setup_finetune)`** to populate experiment-wide controls. See the "MANDATORY STEP" block immediately below.
+   2. **Then** layer in per-run judgment fields (paths, `model_checkpoint`, varying `lora_rank` / `lr`, `custom_recipe` choice, `output_dir_base`, etc.). Propagation is idempotent — your per-run overrides win.
+   3. **Apply the `text_completion` exception**: if `dataset_type` is `text_completion`, `pop("system_prompt", None)` from `setup_finetune` (base models have no chat template — the propagated value has nowhere to go).
+   4. Write `setup_finetune.yaml` to disk.
+6. **EXECUTE `setup_finetune.py` AUTOMATICALLY using conda run** for each run — this generates `finetune.yaml` and `finetune.slurm`. Do NOT create helper scripts for the user to run manually. The scaffolding is INCOMPLETE without finetune.yaml and finetune.slurm files.
+7. **Create scaffold log** — Document all actions in `logs/scaffold-torchtune.log`. **Log the `propagate_train_fields()` call explicitly** so the audit trail shows it ran.
+8. **Report summary** — In your report, name the helper call and the count of fields it populated. **Do NOT produce a field-by-field derivation table for TRAIN_FIELDS values** — that's an anti-pattern (see "Reporting" below).
 
-**CRITICAL: You must execute setup_finetune.py automatically. Do NOT create helper scripts for the user to run manually. The scaffolding is INCOMPLETE without finetune.yaml and finetune.slurm files.**
+## MANDATORY STEP: Call `propagate_train_fields()`
 
-## Key Pattern: Two-Step Field Population
-
-For each fine-tuned run's `setup_finetune.yaml`, the field set is populated
-in two distinct steps:
-
-1. **Agent judgment** — per-run values requiring composition or branching
-   (paths, `model_checkpoint`, per-run `lora_rank` / `lr`, `custom_recipe`
-   choice).
-2. **Deterministic propagation** — call `propagate_train_fields()` to copy
-   experiment-wide controls (epochs, batch_size, prompt, system_prompt,
-   etc.) from `experiment_summary.yaml`.
+Every `setup_finetune.yaml` you build must be populated by this exact
+call, once, before you write the file:
 
 ```python
 from cruijff_kit.tools.experiment.propagate import propagate_train_fields
 propagate_train_fields(experiment_summary, setup_finetune)
 ```
 
-**Do not hand-copy fields covered by TRAIN_FIELDS.** The map in
-`src/tools/experiment/propagate.py` is the single source of truth — add to
-it when you need a new propagated field. (Background: #470 → #502.)
+This is not optional, not an example, and not "what the helper would do."
+You must call it. It populates every field in `TRAIN_FIELDS`
+(`src/tools/experiment/propagate.py`) — currently `epochs`, `batch_size`,
+`batch_size_val`, `gradient_accumulation_steps`, `weight_decay`,
+`lora_dropout`, `prompt`, and `system_prompt` — from
+`experiment_summary.yaml` into `setup_finetune`.
 
-**One exception requires agent judgment after the call:** when
+**Do not write these fields by hand. Do not extract them in your parsing
+step. Do not list them in your report's "How I Decided Each Field"
+table.** If you find yourself reading `controls.epochs` to copy into
+`setup_finetune.yaml`, stop — you have skipped this step. Source of
+truth for which fields are propagated lives in `TRAIN_FIELDS` itself; add
+or remove there, never in this doc.
+
+**One exception requires agent judgment *after* the call:** when
 `dataset_type` is `text_completion`, `pop()` the `system_prompt` (base
 models have no chat template). See "Generating setup_finetune.yaml" →
-Step 4 below for detail.
+text_completion exception below for the deriving rule.
+
+(Background: #470 → #502. A field whose only propagation path was a prose
+bullet got silently dropped when the bullet wasn't followed.)
 
 ## Model-Aware SLURM Resources
 
@@ -110,18 +114,13 @@ Extract the following information from the YAML structure:
    - `tools.preparation` - Should be "torchtune"
    - `tools.evaluation` - Should be "inspect-ai"
 
-3. **Control hyperparameters (held constant):**
-These are *example* parameters that the user might vary. There may be other parameters under `controls`, so check all of them that apply to `setup_finetune.yaml`:
-   - `controls.epochs` - Number of training epochs
-   - `controls.batch_size` - Batch size (if not varied)
-   - `controls.batch_size_val` - Optional larger batch size for validation passes. Honored by `_single_device_nightly` (the default recipe); silently ignored by `_stable` / `_distributed` recipes since their custom-recipe builds don't read the field. Recipe falls back to `controls.batch_size` when absent.
-   - `controls.system_prompt` - Training system prompt. 
-      - Omit this field from `setup_finetune.yaml` when `dataset_type` is `text_completion` or `text_completion_dataset` (i.e. base / non-instruct models). Base models have no chat template, so the system prompt has nowhere to go — `setup_finetune.py` will drop it with a warning.
-   - `controls.prompt` - Prompt template with {input} placeholder (e.g., "Capitalize: {input}\n")
-   - `controls.validation_during_training` - Whether to run validation during training. Translates to `run_val_every_n_steps`: if `true`, set to `50` (the `finetune_template.yaml` default); if `false`, set to `0` (which causes `setup_finetune.py` to drop the validation dataset config). Do not emit `0` when the user requested validation — that silently disables it.
-   - `controls.gradient_accumulation_steps` - Gradient accumulation
-   - `controls.weight_decay` - Optimizer weight decay
-   - `controls.lora_dropout` - LoRA dropout
+3. **Control hyperparameters — non-propagated only:**
+   - `controls.validation_during_training` — Whether to run validation during training. Translates to `run_val_every_n_steps`: if `true`, set to `50` (the `finetune_template.yaml` default); if `false`, set to `0` (which causes `setup_finetune.py` to drop the validation dataset config). Do not emit `0` when the user requested validation — that silently disables it. **Not in `TRAIN_FIELDS`** because it's an agent transformation, not a copy.
+   - `controls.dataset_type` *(optional)* — If set, drives the `text_completion` exception below. If absent, infer from model name (`-Instruct` suffix → `chat_completion`; otherwise → `text_completion`).
+
+   **All other `controls.*` fields** (`epochs`, `batch_size`, `batch_size_val`, `gradient_accumulation_steps`, `weight_decay`, `lora_dropout`, `prompt`, `system_prompt`) are populated by `propagate_train_fields()` per the MANDATORY STEP above. Do not extract or list them here — the helper reads them straight from `experiment_summary.yaml`. The canonical map lives in `TRAIN_FIELDS` (`src/tools/experiment/propagate.py`).
+
+   Note on `controls.batch_size_val`: honored by the `_single_device_nightly` recipe (the default); silently ignored by `_stable` / `_distributed` recipes since their custom-recipe builds don't read the field. Recipe falls back to `controls.batch_size` when absent.
 
 4. **Resources:**
    - `models.base[0].name` - Model identifier
@@ -238,11 +237,30 @@ For each run, create a `setup_finetune.yaml` file by:
    - Extract `input_dir_base` from parent directory of dataset path.
    - Set `input_formatting: ''`.
 
-2. **Populate template with judgment fields.** Write the following fields by
-   hand; these are the ones that require composition, branching, or per-run
-   resolution. Experiment-wide controls (epochs, prompt, system_prompt, etc.)
-   are filled by `propagate_train_fields()` in step 3 — **do not write them
-   inline.**
+2. **Call the propagation helper (MANDATORY).** This is the first thing
+   you write into `setup_finetune`. Run it once, before anything else.
+
+```python
+from cruijff_kit.tools.experiment.propagate import propagate_train_fields
+propagate_train_fields(experiment_summary, setup_finetune)
+```
+
+   This populates every `TRAIN_FIELDS` value (`src/tools/experiment/propagate.py`)
+   — currently `epochs`, `batch_size`, `batch_size_val`,
+   `gradient_accumulation_steps`, `weight_decay`, `lora_dropout`, `prompt`,
+   and `system_prompt` — from `experiment_summary.yaml`. The helper is
+   idempotent: source values of `None` or missing dotted paths are skipped,
+   and any per-run value Step 3 below writes (e.g. a varying `batch_size`)
+   will win because the helper preserves existing non-None values.
+
+   **To add a new propagated control, add an entry to `TRAIN_FIELDS` — do
+   not add a new bullet to this doc.**
+
+3. **Write the per-run judgment fields.** These require composition,
+   branching, or per-run resolution. Because Step 2 ran first and the
+   helper is idempotent, your writes here are not pre-empted *and* per-run
+   overrides take precedence when they set the same key (e.g. a varying
+   `batch_size`).
 
 ```yaml
 # Run identification
@@ -261,10 +279,11 @@ dataset_ext: {resolved extension, e.g., ".json"}
 torchtune_model_name: {from models.base[0].name, e.g., "Llama-3.2-1B-Instruct"}
 model_checkpoint: {from models.base[0].path}
 
-# Varying parameters (per-run; idempotent merge below preserves these)
+# Varying parameters (per-run; helper preserves these because it ran first
+# and your writes happen after — overrides win)
 lora_rank: {from run.parameters.lora_rank, if present}
 lr: {from run.parameters.lr, format as 1e-5 or 5e-5, if present}
-batch_size: {from run.parameters.batch_size if varies, else omit — propagation fills from controls.batch_size}
+batch_size: {from run.parameters.batch_size if varies — overrides the helper-propagated controls.batch_size for this run}
 seed: {from run.parameters.seed, if present}
 
 # Training-loop bookkeeping (not in TRAIN_FIELDS — keep inline)
@@ -301,24 +320,11 @@ cpus_per_task: {from runs[].compute.cpus_per_task, if present, e.g., 8}
 custom_recipe: cruijff_kit.tools.torchtune.custom_recipes.lora_finetune_single_device_nightly  # or lora_finetune_distributed_stable for multi-GPU
 ```
 
-3. **Call the propagation helper for experiment-wide controls.**
-
-```python
-from cruijff_kit.tools.experiment.propagate import propagate_train_fields
-propagate_train_fields(experiment_summary, setup_finetune)
-```
-
-`propagate_train_fields()` copies every field declared in `TRAIN_FIELDS`
-(in `src/tools/experiment/propagate.py`) from `experiment_summary.yaml` into
-`setup_finetune.yaml`. The current map covers `epochs`, `batch_size`,
-`batch_size_val`, `gradient_accumulation_steps`, `weight_decay`,
-`lora_dropout`, `prompt`, and `system_prompt`. Source values that are `None`
-or whose dotted path is missing are skipped; any per-run value the agent
-already wrote in Step 2 (e.g. a varying `batch_size`) is preserved by
-idempotence.
-
-**To add a new propagated control, add an entry to `TRAIN_FIELDS` — do not
-add a new bullet to this list.**
+   **Do NOT write `epochs`, `batch_size_val`, `gradient_accumulation_steps`,
+   `weight_decay`, `lora_dropout`, `prompt`, or `system_prompt` in this
+   step.** Step 2's helper handled them. If you find yourself reaching
+   into `controls.*` to extract one of those, you have skipped Step 2 —
+   stop and run the helper.
 
 4. **Apply the text_completion exception for `system_prompt`.** Base /
    non-instruct models have no chat template to hold a system prompt; the
@@ -337,6 +343,14 @@ if dataset_type in ("text_completion", "text_completion_dataset"):
 ```
 
 5. **Write file** to `{experiment_dir}/{run_directory_name}/setup_finetune.yaml`
+
+**Reporting (anti-pattern alert).** When you report on the runs you
+scaffolded, **do not produce a "How I Decided Each Field" table covering
+`TRAIN_FIELDS` values**. Those did not require a decision — the helper
+copied them. A field-by-field table for propagated fields is the
+diagnostic signature that you skipped Step 2. Report instead: "Called
+`propagate_train_fields()` (populated N fields), then wrote per-run:
+my_wandb_run_name, model_checkpoint, lora_rank, custom_recipe, …."
 
 **Important notes:**
 - Use absolute paths for robustness (e.g., `/scratch/gpfs/MSALGANIK/niznik/GitHub/cruijff_kit/...`) rather than relative paths
@@ -486,10 +500,19 @@ Result: {outcome}
 - Parsing experiment_summary.yaml
 - Run identification (fine-tuned vs control)
 - Directory creation for each run
-- setup_finetune.yaml generation for each run
+- **`PROPAGATE_TRAIN_FIELDS` — one entry per run, recording that `propagate_train_fields()` ran and the count/names of `TRAIN_FIELDS` values it populated.** This is the audit trail for #502: a missing `PROPAGATE_TRAIN_FIELDS` entry means the call was skipped and the YAML is suspect.
+- setup_finetune.yaml generation for each run (post-propagation judgment fields)
 - setup_finetune.py execution and results
 - Any errors or warnings
 - Final summary of created runs
+
+Example propagate entry:
+
+```
+[2025-10-24 16:30:11] PROPAGATE_TRAIN_FIELDS: rank8_lr1e-5
+Details: Called propagate_train_fields(experiment_summary, setup_finetune)
+Result: Populated 8 TRAIN_FIELDS values: epochs, batch_size, batch_size_val, gradient_accumulation_steps, weight_decay, lora_dropout, prompt, system_prompt
+```
 
 ### Example Log Entries
 

--- a/.claude/agents/scaffold-torchtune.md
+++ b/.claude/agents/scaffold-torchtune.md
@@ -25,45 +25,34 @@ When invoked:
 3. **Read claude.local.md** — Get environment-specific settings (conda env, output dirs, etc.).
 4. **Identify varying parameters** — Determine which parameters change across runs (for directory naming).
 5. **For each fine-tuning run, build `setup_finetune.yaml` in two passes (in this order):**
-   1. **Mandatory: call `propagate_train_fields(experiment_summary, setup_finetune)`** to populate experiment-wide controls. See the "MANDATORY STEP" block immediately below.
+   1. **Call `propagate_train_fields(experiment_summary, setup_finetune)` first** to populate experiment-wide controls (see "Key Pattern: Propagate First" below).
    2. **Then** layer in per-run judgment fields (paths, `model_checkpoint`, varying `lora_rank` / `lr`, `custom_recipe` choice, `output_dir_base`, etc.). Propagation is idempotent — your per-run overrides win.
    3. **Apply the `text_completion` exception**: if `dataset_type` is `text_completion`, `pop("system_prompt", None)` from `setup_finetune` (base models have no chat template — the propagated value has nowhere to go).
    4. Write `setup_finetune.yaml` to disk.
 6. **EXECUTE `setup_finetune.py` AUTOMATICALLY using conda run** for each run — this generates `finetune.yaml` and `finetune.slurm`. Do NOT create helper scripts for the user to run manually. The scaffolding is INCOMPLETE without finetune.yaml and finetune.slurm files.
 7. **Create scaffold log** — Document all actions in `logs/scaffold-torchtune.log`. **Log the `propagate_train_fields()` call explicitly** so the audit trail shows it ran.
-8. **Report summary** — In your report, name the helper call and the count of fields it populated. **Do NOT produce a field-by-field derivation table for TRAIN_FIELDS values** — that's an anti-pattern (see "Reporting" below).
+8. **Report summary** — Name the helper call and how many fields it populated; don't tabulate the propagated `TRAIN_FIELDS` values (they weren't decisions).
 
-## MANDATORY STEP: Call `propagate_train_fields()`
+## Key Pattern: Propagate First
 
-Every `setup_finetune.yaml` you build must be populated by this exact
-call, once, before you write the file:
+Before writing any other field into `setup_finetune.yaml`, call:
 
 ```python
 from cruijff_kit.tools.experiment.propagate import propagate_train_fields
 propagate_train_fields(experiment_summary, setup_finetune)
 ```
 
-This is not optional, not an example, and not "what the helper would do."
-You must call it. It populates every field in `TRAIN_FIELDS`
-(`src/tools/experiment/propagate.py`) — currently `epochs`, `batch_size`,
-`batch_size_val`, `gradient_accumulation_steps`, `weight_decay`,
-`lora_dropout`, `prompt`, and `system_prompt` — from
-`experiment_summary.yaml` into `setup_finetune`.
+This fills every `TRAIN_FIELDS` value (`src/tools/experiment/propagate.py`:
+`epochs`, `batch_size`, `batch_size_val`, `gradient_accumulation_steps`,
+`weight_decay`, `lora_dropout`, `prompt`, `system_prompt`) straight from
+`experiment_summary.yaml`. **Don't hand-copy these** — `TRAIN_FIELDS` is the
+single source of truth (add new propagated controls there, not in this doc).
+The helper is idempotent, so per-run judgment fields you write afterward win.
 
-**Do not write these fields by hand. Do not extract them in your parsing
-step. Do not list them in your report's "How I Decided Each Field"
-table.** If you find yourself reading `controls.epochs` to copy into
-`setup_finetune.yaml`, stop — you have skipped this step. Source of
-truth for which fields are propagated lives in `TRAIN_FIELDS` itself; add
-or remove there, never in this doc.
-
-**One exception requires agent judgment *after* the call:** when
-`dataset_type` is `text_completion`, `pop()` the `system_prompt` (base
-models have no chat template). See "Generating setup_finetune.yaml" →
-text_completion exception below for the deriving rule.
-
-(Background: #470 → #502. A field whose only propagation path was a prose
-bullet got silently dropped when the bullet wasn't followed.)
+Exception: for `text_completion` datasets, `pop("system_prompt", None)` after
+the call (base models have no chat template — see the deriving rule below).
+Background: #470 → #502, where a field whose only propagation path was a prose
+bullet got silently dropped when the bullet wasn't followed.
 
 ## Model-Aware SLURM Resources
 
@@ -118,7 +107,7 @@ Extract the following information from the YAML structure:
    - `controls.validation_during_training` — Whether to run validation during training. Translates to `run_val_every_n_steps`: if `true`, set to `50` (the `finetune_template.yaml` default); if `false`, set to `0` (which causes `setup_finetune.py` to drop the validation dataset config). Do not emit `0` when the user requested validation — that silently disables it. **Not in `TRAIN_FIELDS`** because it's an agent transformation, not a copy.
    - `controls.dataset_type` *(optional)* — If set, drives the `text_completion` exception below. If absent, infer from model name (`-Instruct` suffix → `chat_completion`; otherwise → `text_completion`).
 
-   **All other `controls.*` fields** (`epochs`, `batch_size`, `batch_size_val`, `gradient_accumulation_steps`, `weight_decay`, `lora_dropout`, `prompt`, `system_prompt`) are populated by `propagate_train_fields()` per the MANDATORY STEP above. Do not extract or list them here — the helper reads them straight from `experiment_summary.yaml`. The canonical map lives in `TRAIN_FIELDS` (`src/tools/experiment/propagate.py`).
+   **All other `controls.*` fields** (`epochs`, `batch_size`, `batch_size_val`, `gradient_accumulation_steps`, `weight_decay`, `lora_dropout`, `prompt`, `system_prompt`) are populated by `propagate_train_fields()` (see "Key Pattern: Propagate First"). Don't extract them here — the helper reads them straight from `experiment_summary.yaml`.
 
    Note on `controls.batch_size_val`: honored by the `_single_device_nightly` recipe (the default); silently ignored by `_stable` / `_distributed` recipes since their custom-recipe builds don't read the field. Recipe falls back to `controls.batch_size` when absent.
 
@@ -237,24 +226,9 @@ For each run, create a `setup_finetune.yaml` file by:
    - Extract `input_dir_base` from parent directory of dataset path.
    - Set `input_formatting: ''`.
 
-2. **Call the propagation helper (MANDATORY).** This is the first thing
-   you write into `setup_finetune`. Run it once, before anything else.
-
-```python
-from cruijff_kit.tools.experiment.propagate import propagate_train_fields
-propagate_train_fields(experiment_summary, setup_finetune)
-```
-
-   This populates every `TRAIN_FIELDS` value (`src/tools/experiment/propagate.py`)
-   — currently `epochs`, `batch_size`, `batch_size_val`,
-   `gradient_accumulation_steps`, `weight_decay`, `lora_dropout`, `prompt`,
-   and `system_prompt` — from `experiment_summary.yaml`. The helper is
-   idempotent: source values of `None` or missing dotted paths are skipped,
-   and any per-run value Step 3 below writes (e.g. a varying `batch_size`)
-   will win because the helper preserves existing non-None values.
-
-   **To add a new propagated control, add an entry to `TRAIN_FIELDS` — do
-   not add a new bullet to this doc.**
+2. **Call `propagate_train_fields()` first** — the first write into
+   `setup_finetune`, before any field below. See "Key Pattern: Propagate
+   First" above for the call and the `TRAIN_FIELDS` set it fills.
 
 3. **Write the per-run judgment fields.** These require composition,
    branching, or per-run resolution. Because Step 2 ran first and the
@@ -320,12 +294,6 @@ cpus_per_task: {from runs[].compute.cpus_per_task, if present, e.g., 8}
 custom_recipe: cruijff_kit.tools.torchtune.custom_recipes.lora_finetune_single_device_nightly  # or lora_finetune_distributed_stable for multi-GPU
 ```
 
-   **Do NOT write `epochs`, `batch_size_val`, `gradient_accumulation_steps`,
-   `weight_decay`, `lora_dropout`, `prompt`, or `system_prompt` in this
-   step.** Step 2's helper handled them. If you find yourself reaching
-   into `controls.*` to extract one of those, you have skipped Step 2 —
-   stop and run the helper.
-
 4. **Apply the text_completion exception for `system_prompt`.** Base /
    non-instruct models have no chat template to hold a system prompt; the
    propagation helper does not know about the dataset type, so this is the
@@ -344,13 +312,8 @@ if dataset_type in ("text_completion", "text_completion_dataset"):
 
 5. **Write file** to `{experiment_dir}/{run_directory_name}/setup_finetune.yaml`
 
-**Reporting (anti-pattern alert).** When you report on the runs you
-scaffolded, **do not produce a "How I Decided Each Field" table covering
-`TRAIN_FIELDS` values**. Those did not require a decision — the helper
-copied them. A field-by-field table for propagated fields is the
-diagnostic signature that you skipped Step 2. Report instead: "Called
-`propagate_train_fields()` (populated N fields), then wrote per-run:
-my_wandb_run_name, model_checkpoint, lora_rank, custom_recipe, …."
+**Reporting:** name the `propagate_train_fields()` call and the field count;
+don't tabulate the propagated values per-field — they weren't decisions.
 
 **Important notes:**
 - Use absolute paths for robustness (e.g., `/scratch/gpfs/MSALGANIK/niznik/GitHub/cruijff_kit/...`) rather than relative paths
@@ -500,19 +463,11 @@ Result: {outcome}
 - Parsing experiment_summary.yaml
 - Run identification (fine-tuned vs control)
 - Directory creation for each run
-- **`PROPAGATE_TRAIN_FIELDS` — one entry per run, recording that `propagate_train_fields()` ran and the count/names of `TRAIN_FIELDS` values it populated.** This is the audit trail for #502: a missing `PROPAGATE_TRAIN_FIELDS` entry means the call was skipped and the YAML is suspect.
+- **`PROPAGATE_TRAIN_FIELDS`** — one entry per run recording that `propagate_train_fields()` ran and how many `TRAIN_FIELDS` it populated. The #502 audit trail: a missing entry means the call was skipped and the YAML is suspect.
 - setup_finetune.yaml generation for each run (post-propagation judgment fields)
 - setup_finetune.py execution and results
 - Any errors or warnings
 - Final summary of created runs
-
-Example propagate entry:
-
-```
-[2025-10-24 16:30:11] PROPAGATE_TRAIN_FIELDS: rank8_lr1e-5
-Details: Called propagate_train_fields(experiment_summary, setup_finetune)
-Result: Populated 8 TRAIN_FIELDS values: epochs, batch_size, batch_size_val, gradient_accumulation_steps, weight_decay, lora_dropout, prompt, system_prompt
-```
 
 ### Example Log Entries
 

--- a/.claude/agents/scaffold-torchtune.md
+++ b/.claude/agents/scaffold-torchtune.md
@@ -212,7 +212,11 @@ For each run, create a `setup_finetune.yaml` file by:
    - Extract `input_dir_base` from parent directory of dataset path.
    - Set `input_formatting: ''`.
 
-2. **Populate template with run-specific values:**
+2. **Populate template with judgment fields.** Write the following fields by
+   hand; these are the ones that require composition, branching, or per-run
+   resolution. Experiment-wide controls (epochs, prompt, system_prompt, etc.)
+   are filled by `propagate_train_fields()` in step 3 — **do not write them
+   inline.**
 
 ```yaml
 # Run identification
@@ -231,20 +235,13 @@ dataset_ext: {resolved extension, e.g., ".json"}
 torchtune_model_name: {from models.base[0].name, e.g., "Llama-3.2-1B-Instruct"}
 model_checkpoint: {from models.base[0].path}
 
-# Varying parameters (optional, run-specific)
+# Varying parameters (per-run; idempotent merge below preserves these)
 lora_rank: {from run.parameters.lora_rank, if present}
 lr: {from run.parameters.lr, format as 1e-5 or 5e-5, if present}
-batch_size: {from run.parameters.batch_size if varies, if present}
+batch_size: {from run.parameters.batch_size if varies, else omit — propagation fills from controls.batch_size}
 seed: {from run.parameters.seed, if present}
 
-# Additional hyperparameters (optional, only if specified in controls)
-gradient_accumulation_steps: {from controls.gradient_accumulation_steps, if present}
-weight_decay: {from controls.weight_decay, if present}
-lora_dropout: {from controls.lora_dropout, if present}
-batch_size_val: {from controls.batch_size_val or run.parameters.batch_size_val, if present}
-
-# Training configuration (common across runs)
-epochs: {from controls.epochs}
+# Training-loop bookkeeping (not in TRAIN_FIELDS — keep inline)
 log_every_n_steps: {use template default, typically 1}
 run_val_every_n_steps: {50 if controls.validation_during_training else 0}
 
@@ -263,15 +260,6 @@ gpus: {from runs[].compute.gpus, if present}
 mem: {from runs[].compute.mem, if present, e.g., "80G"}
 cpus_per_task: {from runs[].compute.cpus_per_task, if present, e.g., 8}
 
-# System prompt (if specified)
-# If `dataset_type` is `text_completion` or `text_completion_dataset` 
-# (i.e. base / non-instruct models), omit system_prompt. Base models have no chat template, so the system prompt has no slot.
-# Only emit for chat_completion / chat_dataset / instruct_dataset.
-system_prompt: {from controls.system_prompt, often empty string ""}
-
-# Prompt template (if specified)
-prompt: {from controls.prompt, e.g., "Capitalize the given word: {input}\n"}
-
 # Custom Recipe (REQUIRED)
 # Select based on GPU count:
 #   - Single-GPU runs (1B / 3B / 8B): lora_finetune_single_device_nightly
@@ -287,7 +275,36 @@ prompt: {from controls.prompt, e.g., "Capitalize the given word: {input}\n"}
 custom_recipe: cruijff_kit.tools.torchtune.custom_recipes.lora_finetune_single_device_nightly  # or lora_finetune_distributed_stable for multi-GPU
 ```
 
-4. **Write file** to `{experiment_dir}/{run_directory_name}/setup_finetune.yaml`
+3. **Call the propagation helper for experiment-wide controls.**
+
+```python
+from cruijff_kit.tools.experiment.propagate import propagate_train_fields
+propagate_train_fields(experiment_summary, setup_finetune)
+```
+
+`propagate_train_fields()` copies every field declared in `TRAIN_FIELDS`
+(in `src/tools/experiment/propagate.py`) from `experiment_summary.yaml` into
+`setup_finetune.yaml`. The current map covers `epochs`, `batch_size`,
+`batch_size_val`, `gradient_accumulation_steps`, `weight_decay`,
+`lora_dropout`, `prompt`, and `system_prompt`. Source values that are `None`
+or whose dotted path is missing are skipped; any per-run value the agent
+already wrote in Step 2 (e.g. a varying `batch_size`) is preserved by
+idempotence.
+
+**To add a new propagated control, add an entry to `TRAIN_FIELDS` — do not
+add a new bullet to this list.**
+
+4. **Apply the text_completion exception for `system_prompt`.** Base /
+   non-instruct models have no chat template to hold a system prompt; the
+   propagation helper does not know about the dataset type, so this is the
+   agent's call:
+
+```python
+if dataset_type in ("text_completion", "text_completion_dataset"):
+    setup_finetune.pop("system_prompt", None)
+```
+
+5. **Write file** to `{experiment_dir}/{run_directory_name}/setup_finetune.yaml`
 
 **Important notes:**
 - Use absolute paths for robustness (e.g., `/scratch/gpfs/MSALGANIK/niznik/GitHub/cruijff_kit/...`) rather than relative paths

--- a/.claude/agents/scaffold-torchtune.md
+++ b/.claude/agents/scaffold-torchtune.md
@@ -51,8 +51,6 @@ The helper is idempotent, so per-run judgment fields you write afterward win.
 
 Exception: for `text_completion` datasets, `pop("system_prompt", None)` after
 the call (base models have no chat template — see the deriving rule below).
-Background: #470 → #502, where a field whose only propagation path was a prose
-bullet got silently dropped when the bullet wasn't followed.
 
 ## Model-Aware SLURM Resources
 

--- a/.claude/agents/scaffold-torchtune.md
+++ b/.claude/agents/scaffold-torchtune.md
@@ -35,6 +35,32 @@ When invoked:
 
 **CRITICAL: You must execute setup_finetune.py automatically. Do NOT create helper scripts for the user to run manually. The scaffolding is INCOMPLETE without finetune.yaml and finetune.slurm files.**
 
+## Key Pattern: Two-Step Field Population
+
+For each fine-tuned run's `setup_finetune.yaml`, the field set is populated
+in two distinct steps:
+
+1. **Agent judgment** — per-run values requiring composition or branching
+   (paths, `model_checkpoint`, per-run `lora_rank` / `lr`, `custom_recipe`
+   choice).
+2. **Deterministic propagation** — call `propagate_train_fields()` to copy
+   experiment-wide controls (epochs, batch_size, prompt, system_prompt,
+   etc.) from `experiment_summary.yaml`.
+
+```python
+from cruijff_kit.tools.experiment.propagate import propagate_train_fields
+propagate_train_fields(experiment_summary, setup_finetune)
+```
+
+**Do not hand-copy fields covered by TRAIN_FIELDS.** The map in
+`src/tools/experiment/propagate.py` is the single source of truth — add to
+it when you need a new propagated field. (Background: #470 → #502.)
+
+**One exception requires agent judgment after the call:** when
+`dataset_type` is `text_completion`, `pop()` the `system_prompt` (base
+models have no chat template). See "Generating setup_finetune.yaml" →
+Step 4 below for detail.
+
 ## Model-Aware SLURM Resources
 
 The `setup_finetune.py` script automatically sets SLURM resources for memory, CPUs, and GPUs based on model size (from `model_configs.py`). **Partition and constraint are NOT set by model_configs** — they come from the caller.
@@ -297,7 +323,13 @@ add a new bullet to this list.**
 4. **Apply the text_completion exception for `system_prompt`.** Base /
    non-instruct models have no chat template to hold a system prompt; the
    propagation helper does not know about the dataset type, so this is the
-   agent's call:
+   agent's call.
+
+   **Deriving `dataset_type`:** if `controls.dataset_type` is set in
+   `experiment_summary.yaml`, use it verbatim. Otherwise infer from the
+   model name — Instruct models (e.g. `Llama-3.2-1B-Instruct`) get
+   `chat_completion`; base models (e.g. `Llama-3.2-1B`) get
+   `text_completion`.
 
 ```python
 if dataset_type in ("text_completion", "text_completion_dataset"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ packages = [
   "cruijff_kit.tools.inspect",
   "cruijff_kit.tools.inspect.scorers",
   "cruijff_kit.tools.slurm",
+  "cruijff_kit.tools.experiment",
   "cruijff_kit.tools.model_organisms",
   "cruijff_kit.tools.quiz",
   "cruijff_kit.tabular_to_text_gen",

--- a/src/tools/experiment/propagate.py
+++ b/src/tools/experiment/propagate.py
@@ -1,0 +1,92 @@
+"""Deterministic propagation of fields from experiment_summary.yaml into the
+intermediate YAMLs that scaffold-* agents write (eval_config.yaml,
+setup_finetune.yaml).
+
+Background (#502): the scaffold-inspect and scaffold-torchtune agents
+historically hand-copied fields from experiment_summary.yaml into their
+intermediate YAMLs by following prose bullets in their agent docs. If a bullet
+was missing or quietly removed, the field could be silently dropped. That is
+exactly how `evaluation.temperature` vanished in #470.
+
+Moving the dumb copies into code makes the map the single source of truth: add
+or remove an entry here and both agents update behavior in lockstep. Agents
+still own judgment work (per-cell system_prompt overrides, path composition,
+branching on dataset type) but no longer touch flat field copies.
+"""
+
+from typing import Any
+
+
+EVAL_FIELDS: dict[str, str] = {
+    "evaluation.system_prompt": "system_prompt",
+    "evaluation.temperature": "temperature",
+    "evaluation.do_sample": "do_sample",
+    "evaluation.max_tokens": "max_tokens",
+    "evaluation.max_connections": "max_connections",
+    "evaluation.scorer": "scorer",
+}
+
+
+TRAIN_FIELDS: dict[str, str] = {
+    "controls.epochs": "epochs",
+    "controls.batch_size": "batch_size",
+    "controls.batch_size_val": "batch_size_val",
+    "controls.gradient_accumulation_steps": "gradient_accumulation_steps",
+    "controls.weight_decay": "weight_decay",
+    "controls.lora_dropout": "lora_dropout",
+    "controls.prompt": "prompt",
+    "controls.system_prompt": "system_prompt",
+}
+
+
+def _get_dotted(d: dict, path: str) -> Any:
+    """Walk `path` through nested dicts; return None if any step is missing."""
+    cur: Any = d
+    for part in path.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return None
+        cur = cur[part]
+    return cur
+
+
+def _propagate(source: dict, target: dict, fields: dict[str, str]) -> dict:
+    """Copy each (source_path, target_key) pair from source to target.
+
+    Rules (idempotent merge):
+    - Source value of None or missing path: skip.
+    - Target key already present with a non-None value: skip (agent override wins).
+    - Otherwise: copy.
+
+    Returns `target` modified in place.
+    """
+    for source_path, target_key in fields.items():
+        value = _get_dotted(source, source_path)
+        if value is None:
+            continue
+        if target.get(target_key) is not None:
+            continue
+        target[target_key] = value
+    return target
+
+
+def propagate_eval_fields(experiment_summary: dict, eval_config: dict) -> dict:
+    """Copy EVAL_FIELDS from experiment_summary into eval_config in place.
+
+    Idempotent: existing non-None values in eval_config take precedence so the
+    agent's per-cell decisions (e.g. per-task system_prompt overrides) survive
+    propagation.
+    """
+    return _propagate(experiment_summary, eval_config, EVAL_FIELDS)
+
+
+def propagate_train_fields(experiment_summary: dict, setup_finetune: dict) -> dict:
+    """Copy TRAIN_FIELDS from experiment_summary into setup_finetune in place.
+
+    Idempotent (same semantics as propagate_eval_fields).
+
+    Note on `controls.system_prompt`: this is propagated by default. The
+    scaffold-torchtune agent is responsible for removing it after propagation
+    when the run's `dataset_type` is `text_completion` (base / non-instruct
+    models have no chat template to hold a system prompt).
+    """
+    return _propagate(experiment_summary, setup_finetune, TRAIN_FIELDS)

--- a/tests/unit/test_propagate.py
+++ b/tests/unit/test_propagate.py
@@ -135,6 +135,21 @@ def test_train_idempotence_preserves_per_run_value(representative_summary):
     assert setup_finetune["batch_size"] == 999
 
 
+def test_double_propagation_is_stable(representative_summary):
+    """f(f(x)) == f(x): a second pass must not clobber the first.
+
+    The scaffold agents may re-run propagation on the same config; the
+    docstring promises idempotence. Lock it across *two* calls (not just one),
+    and confirm a pre-existing per-cell override survives both passes.
+    """
+    eval_config = {"system_prompt": "Per-cell custom prompt"}
+    propagate_eval_fields(representative_summary, eval_config)
+    after_first = dict(eval_config)
+    propagate_eval_fields(representative_summary, eval_config)
+    assert eval_config == after_first  # second pass is a no-op
+    assert eval_config["system_prompt"] == "Per-cell custom prompt"  # override intact
+
+
 # -----------------------------------------------------------------------------
 # Source-side skip rules
 # -----------------------------------------------------------------------------
@@ -158,6 +173,19 @@ def test_source_partial_missing_path_is_skipped():
     eval_config: dict = {}
     propagate_eval_fields(summary, eval_config)
     assert eval_config == {}
+
+
+def test_malformed_section_is_skipped_not_crashed():
+    """A non-dict section (hand-edited YAML garbage) must skip, not crash.
+
+    _get_dotted's `isinstance(cur, dict)` guard handles this gracefully; lock
+    it so a future refactor can't silently turn the graceful skip into an
+    AttributeError when `evaluation` is a string/list instead of a mapping.
+    """
+    summary = {"evaluation": "oops not a dict"}
+    eval_config: dict = {}
+    result = propagate_eval_fields(summary, eval_config)
+    assert result == {}
 
 
 # -----------------------------------------------------------------------------

--- a/tests/unit/test_propagate.py
+++ b/tests/unit/test_propagate.py
@@ -1,0 +1,211 @@
+"""Tests for cruijff_kit.tools.experiment.propagate.
+
+The parameterized `test_no_*_field_can_silently_drop` suites are the
+regression lock for #470 (#502): every entry in EVAL_FIELDS / TRAIN_FIELDS
+must propagate from experiment_summary.yaml into the intermediate YAML, with
+no quiet drops. Adding a new propagated field requires adding a sample value
+below so the test fails loudly if the field is forgotten.
+"""
+
+import pytest
+
+from cruijff_kit.tools.experiment.propagate import (
+    EVAL_FIELDS,
+    TRAIN_FIELDS,
+    propagate_eval_fields,
+    propagate_train_fields,
+)
+
+
+def _set_dotted(d: dict, path: str, value) -> dict:
+    """Set `value` at a dotted path inside `d` (creates intermediate dicts)."""
+    parts = path.split(".")
+    cur = d
+    for part in parts[:-1]:
+        cur = cur.setdefault(part, {})
+    cur[parts[-1]] = value
+    return d
+
+
+# Representative values per intermediate-YAML key. Shared by EVAL_FIELDS and
+# TRAIN_FIELDS (system_prompt lives in both).
+_SAMPLE_VALUES: dict = {
+    # eval
+    "system_prompt": "Be helpful and concise.",
+    "temperature": 0.7,
+    "do_sample": True,
+    "max_tokens": 5,
+    "max_connections": 16,
+    "scorer": [{"name": "match"}],
+    # train
+    "epochs": 3,
+    "batch_size": 4,
+    "batch_size_val": 8,
+    "gradient_accumulation_steps": 2,
+    "weight_decay": 0.01,
+    "lora_dropout": 0.1,
+    "prompt": "Capitalize: {input}\n",
+}
+
+
+# -----------------------------------------------------------------------------
+# Parameterized regression tests — the #470 silent-drop lock
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("source_path,target_key", list(EVAL_FIELDS.items()))
+def test_no_eval_field_can_silently_drop(source_path, target_key):
+    """Each EVAL_FIELDS entry must propagate (the #470 pattern)."""
+    summary = _set_dotted({}, source_path, _SAMPLE_VALUES[target_key])
+    eval_config: dict = {}
+    propagate_eval_fields(summary, eval_config)
+    assert eval_config[target_key] == _SAMPLE_VALUES[target_key]
+
+
+@pytest.mark.parametrize("source_path,target_key", list(TRAIN_FIELDS.items()))
+def test_no_train_field_can_silently_drop(source_path, target_key):
+    """Each TRAIN_FIELDS entry must propagate (symmetric to eval)."""
+    summary = _set_dotted({}, source_path, _SAMPLE_VALUES[target_key])
+    setup_finetune: dict = {}
+    propagate_train_fields(summary, setup_finetune)
+    assert setup_finetune[target_key] == _SAMPLE_VALUES[target_key]
+
+
+# -----------------------------------------------------------------------------
+# Round-trip with a representative full experiment_summary
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def representative_summary() -> dict:
+    return {
+        "evaluation": {
+            "system_prompt": _SAMPLE_VALUES["system_prompt"],
+            "temperature": _SAMPLE_VALUES["temperature"],
+            "do_sample": _SAMPLE_VALUES["do_sample"],
+            "max_tokens": _SAMPLE_VALUES["max_tokens"],
+            "max_connections": _SAMPLE_VALUES["max_connections"],
+            "scorer": _SAMPLE_VALUES["scorer"],
+        },
+        "controls": {
+            "epochs": _SAMPLE_VALUES["epochs"],
+            "batch_size": _SAMPLE_VALUES["batch_size"],
+            "batch_size_val": _SAMPLE_VALUES["batch_size_val"],
+            "gradient_accumulation_steps": _SAMPLE_VALUES[
+                "gradient_accumulation_steps"
+            ],
+            "weight_decay": _SAMPLE_VALUES["weight_decay"],
+            "lora_dropout": _SAMPLE_VALUES["lora_dropout"],
+            "prompt": _SAMPLE_VALUES["prompt"],
+            "system_prompt": _SAMPLE_VALUES["system_prompt"],
+        },
+    }
+
+
+def test_eval_roundtrip_full(representative_summary):
+    eval_config: dict = {}
+    propagate_eval_fields(representative_summary, eval_config)
+    for target_key in EVAL_FIELDS.values():
+        assert eval_config[target_key] == _SAMPLE_VALUES[target_key]
+
+
+def test_train_roundtrip_full(representative_summary):
+    setup_finetune: dict = {}
+    propagate_train_fields(representative_summary, setup_finetune)
+    for target_key in TRAIN_FIELDS.values():
+        assert setup_finetune[target_key] == _SAMPLE_VALUES[target_key]
+
+
+# -----------------------------------------------------------------------------
+# Idempotence: agent-set per-cell / per-run values survive propagation
+# -----------------------------------------------------------------------------
+
+
+def test_eval_idempotence_preserves_per_cell_value(representative_summary):
+    """Per-cell system_prompt override (agent-written) survives propagation."""
+    eval_config = {"system_prompt": "Per-cell custom prompt"}
+    propagate_eval_fields(representative_summary, eval_config)
+    assert eval_config["system_prompt"] == "Per-cell custom prompt"
+
+
+def test_train_idempotence_preserves_per_run_value(representative_summary):
+    """Per-run batch_size override (agent-written) survives propagation."""
+    setup_finetune = {"batch_size": 999}
+    propagate_train_fields(representative_summary, setup_finetune)
+    assert setup_finetune["batch_size"] == 999
+
+
+# -----------------------------------------------------------------------------
+# Source-side skip rules
+# -----------------------------------------------------------------------------
+
+
+def test_source_none_value_is_skipped():
+    summary = {"evaluation": {"temperature": None}}
+    eval_config: dict = {}
+    propagate_eval_fields(summary, eval_config)
+    assert "temperature" not in eval_config
+
+
+def test_source_missing_root_is_skipped():
+    eval_config: dict = {}
+    propagate_eval_fields({}, eval_config)
+    assert eval_config == {}
+
+
+def test_source_partial_missing_path_is_skipped():
+    summary = {"evaluation": {}}  # no temperature key
+    eval_config: dict = {}
+    propagate_eval_fields(summary, eval_config)
+    assert eval_config == {}
+
+
+# -----------------------------------------------------------------------------
+# Target-side merge rules
+# -----------------------------------------------------------------------------
+
+
+def test_target_none_placeholder_is_overwritten():
+    """YAML null placeholder in target should receive the propagated value."""
+    summary = {"evaluation": {"temperature": 0.7}}
+    eval_config = {"temperature": None}
+    propagate_eval_fields(summary, eval_config)
+    assert eval_config["temperature"] == 0.7
+
+
+# -----------------------------------------------------------------------------
+# Falsy-but-not-None values must still propagate
+# -----------------------------------------------------------------------------
+
+
+def test_zero_temperature_propagates():
+    """0.0 is falsy but not None — should still be copied."""
+    summary = {"evaluation": {"temperature": 0.0}}
+    eval_config: dict = {}
+    propagate_eval_fields(summary, eval_config)
+    assert eval_config["temperature"] == 0.0
+
+
+def test_false_do_sample_propagates():
+    """False is falsy but not None — should still be copied."""
+    summary = {"evaluation": {"do_sample": False}}
+    eval_config: dict = {}
+    propagate_eval_fields(summary, eval_config)
+    assert eval_config["do_sample"] is False
+
+
+# -----------------------------------------------------------------------------
+# In-place semantics
+# -----------------------------------------------------------------------------
+
+
+def test_propagate_eval_returns_same_dict():
+    eval_config: dict = {}
+    result = propagate_eval_fields({"evaluation": {"temperature": 0.7}}, eval_config)
+    assert result is eval_config
+
+
+def test_propagate_train_returns_same_dict():
+    setup_finetune: dict = {}
+    result = propagate_train_fields({"controls": {"epochs": 3}}, setup_finetune)
+    assert result is setup_finetune


### PR DESCRIPTION
<img src="https://raw.githubusercontent.com/niznik-dev/llm-personas/main/fusions/mattie/mattie-icon.png" width="36" align="absmiddle"> 🎻 **MxC** ✳️

Closes #502

## Description

Moves the dumb field-copies from `scaffold-inspect` / `scaffold-torchtune`
prose into a small Python module so the map of "what propagates from
`experiment_summary.yaml`" lives in code instead of agent bullets.

This **narrows** the silent-drop surface that bit us as #470 (temperature):
the failure mode shrinks from "the agent must correctly hand-copy N fields,
each via its own prose bullet" to "the agent must call one helper." The
*what-propagates* map is now deterministic and single-sourced; the *trigger*
(calling the helper) is still agent-driven — see Known Limitation below. This
is a hardening of the failure surface, not a full removal of the
trust-the-agent dependency.

**New module:** `src/tools/experiment/propagate.py`
- `EVAL_FIELDS` (6 entries): `system_prompt`, `temperature`, `do_sample`,
  `max_tokens`, `max_connections`, `scorer`
- `TRAIN_FIELDS` (8 entries): `epochs`, `batch_size`, `batch_size_val`,
  `gradient_accumulation_steps`, `weight_decay`, `lora_dropout`, `prompt`,
  `system_prompt`
- `propagate_eval_fields()`, `propagate_train_fields()` — idempotent
  merge helpers (skip `None` source values; skip target keys already set
  to a non-`None` value)

**Agent doc updates:** both scaffold agent docs now split the work into
"agent judgment" (per-cell path composition, branching by run type, data
path resolution chain) and a single "propagation call." The dumb-copy
bullet lists are gone. The docs were tightened to put the propagation call
first (propagate → judgment) and to scope the parsing sections so the
propagated fields no longer appear in any "extract these" list — the agent
can't hand-copy what the doc never enumerates.

**Tests:** 28 unit tests, including parameterized
`test_no_*_field_can_silently_drop` regression locks over the full
`EVAL_FIELDS` / `TRAIN_FIELDS` maps. Adding a new propagated field now
requires a one-line addition to `_SAMPLE_VALUES` in the test file, or the
suite fails loudly. Also locks idempotence across two calls and graceful
handling of a malformed (non-dict) summary section.

## Known Limitation / follow-up

The helper's only caller is the scaffold agent following its doc. So this
PR reduces — but does not eliminate — the dependency on the agent doing the
right thing. The version where "deterministic propagation" is fully
enforced moves the propagation (or a missing-expected-field assertion) into
the consumer scripts (`setup_inspect.py` / `setup_finetune.py`), which every
run passes through regardless of how the intermediate YAML was produced.
Tracked as a follow-up, intentionally out of scope here to keep this PR a
clean increment.

## Design choices worth flagging

- **Temperature is propagated unconditionally.** `setup_inspect.py`
  already drops `temperature` from rendered task args when
  `do_sample=false`, so the conditional rule has been removed from
  agent prose — `setup_inspect.py` stays the single gatekeeper.
- **`controls.system_prompt` is in `TRAIN_FIELDS`**, with a one-line
  `setup_finetune.pop('system_prompt')` afterward for `text_completion`
  datasets. Keeps the map exhaustive instead of carving out exceptions
  in the helper. (Caveat: this one conditional still lives in agent prose,
  not the helper — the same follow-up above would absorb it.)
- **Parameterized regression tests over the full field maps.**
  `@pytest.mark.parametrize` over `EVAL_FIELDS.items()` /
  `TRAIN_FIELDS.items()` ensures every entry is exercised.

## New Dependencies

None. Adds `cruijff_kit.tools.experiment` to the `pyproject.toml`
packages list (the existing `archive_experiment.py` ran as a script, so
this was the first time the package was needed as a real Python import).

## Testing Instructions

```bash
pip install -e . --no-deps  # if your editable install predates 0.3.x
pytest tests/unit/test_propagate.py -v
```

Expect 28 passing tests. The parameterized suites are the #470 regression
lock — they will fail loudly if any field listed in `EVAL_FIELDS` /
`TRAIN_FIELDS` fails to propagate.

—MxC