### PR TITLE
Rename output_* path vars to match artifacts/ layout (#443)

### DIFF
--- a/.claude/agents/scaffold-torchtune.md
+++ b/.claude/agents/scaffold-torchtune.md
@@ -26,7 +26,7 @@ When invoked:
 4. **Identify varying parameters** — Determine which parameters change across runs (for directory naming).
 5. **For each fine-tuning run, build `setup_finetune.yaml` in two passes (in this order):**
    1. **Call `propagate_train_fields(experiment_summary, setup_finetune)` first** to populate experiment-wide controls (see "Key Pattern: Propagate First" below).
-   2. **Then** layer in per-run judgment fields (paths, `model_checkpoint`, varying `lora_rank` / `lr`, `custom_recipe` choice, `output_dir_base`, etc.). Propagation is idempotent — your per-run overrides win.
+   2. **Then** layer in per-run judgment fields (paths, `model_checkpoint`, varying `lora_rank` / `lr`, `custom_recipe` choice, `project_dir`, etc.). Propagation is idempotent — your per-run overrides win.
    3. **Apply the `text_completion` exception**: if `dataset_type` is `text_completion`, `pop("system_prompt", None)` from `setup_finetune` (base models have no chat template — the propagated value has nowhere to go).
    4. Write `setup_finetune.yaml` to disk.
 6. **EXECUTE `setup_finetune.py` AUTOMATICALLY using conda run** for each run — this generates `finetune.yaml` and `finetune.slurm`. Do NOT create helper scripts for the user to run manually. The scaffolding is INCOMPLETE without finetune.yaml and finetune.slurm files.
@@ -178,7 +178,7 @@ The directory contains the full path: `{scratch_dir}/ck-projects/{project}/{expe
 - Example: `/scratch/gpfs/MSALGANIK/sarahep/ck-projects/{project}/workflow_test_2025-11-28`
 
 Parse this into two components for setup_finetune.yaml:
-- `output_dir_base` = everything up to and including the last directory before experiment name
+- `project_dir` = everything up to and including the last directory before experiment name
   - Extract by splitting on `/` and taking all but the last component, then rejoining with `/` and adding trailing `/`
   - Example: `/scratch/gpfs/MSALGANIK/sarahep/ck-projects/{project}/`
 - `experiment_name` = the final directory component
@@ -263,7 +263,7 @@ log_every_n_steps: {use template default, typically 1}
 run_val_every_n_steps: {50 if controls.validation_during_training else 0}
 
 # Output configuration
-output_dir_base: {parsed from experiment.directory}
+project_dir: {parsed from experiment.directory}
 experiment_name: {parsed from experiment.directory}
 conda_env: {from claude.local.md}
 
@@ -317,7 +317,7 @@ don't tabulate the propagated values per-field — they weren't decisions.
 - Use absolute paths for robustness (e.g., `/scratch/gpfs/MSALGANIK/niznik/GitHub/cruijff_kit/...`) rather than relative paths
 - WandB project: Prefer using `my_wandb_project` from `claude.local.md` for consistency
 - Learning rate format: Keep scientific notation format from experiment summary (1e-5, 5e-5, etc.)
-- Output directory: Parse `experiment.directory` from experiment_summary.yaml to extract both `output_dir_base` and `experiment_name` components
+- Output directory: Parse `experiment.directory` from experiment_summary.yaml to extract both `project_dir` and `experiment_name` components
 
 ### Running setup_finetune.py
 

--- a/src/tools/experiment/archive_experiment.py
+++ b/src/tools/experiment/archive_experiment.py
@@ -52,13 +52,12 @@ def _bytes_to_mb(b):
     return round(b / (1024 * 1024), 1)
 
 
-def inventory_experiment(experiment_dir, output_dir_base):
+def inventory_experiment(experiment_dir):
     """
     Categorize all experiment files as KEEP or DELETE.
 
     Args:
-        experiment_dir: Path to the experiment directory.
-        output_dir_base: Path to the output directory base (contains {run_name}/artifacts/ dirs).
+        experiment_dir: Path to the experiment directory (contains {run_name}/artifacts/ dirs).
 
     Returns:
         Dictionary with:
@@ -127,9 +126,8 @@ def inventory_experiment(experiment_dir, output_dir_base):
 
     # --- DELETE paths: only checkpoint directories ---
     delete_paths = []
-    out_base = Path(output_dir_base)
     for run_name in run_names:
-        out_dir = out_base / run_name / ARTIFACTS_DIR
+        out_dir = exp_dir / run_name / ARTIFACTS_DIR
         if out_dir.exists():
             delete_paths.append(
                 {
@@ -242,13 +240,12 @@ def verify_archive(archive_dir, inventory):
     }
 
 
-def delete_originals(experiment_dir, output_dir_base, run_names):
+def delete_originals(experiment_dir, run_names):
     """
-    Remove the experiment directory and checkpoint output directories.
+    Remove the experiment directory and its checkpoint directories.
 
     Args:
         experiment_dir: Path to the experiment directory.
-        output_dir_base: Path to the output directory base.
         run_names: List of run names.
 
     Returns:
@@ -258,10 +255,11 @@ def delete_originals(experiment_dir, output_dir_base, run_names):
     errors = []
     freed_bytes = 0
 
+    exp_dir = Path(experiment_dir)
+
     # Delete checkpoint directories (the big ones)
-    out_base = Path(output_dir_base)
     for run_name in run_names:
-        out_dir = out_base / run_name / ARTIFACTS_DIR
+        out_dir = exp_dir / run_name / ARTIFACTS_DIR
         if out_dir.exists():
             size = _dir_size_bytes(out_dir)
             try:
@@ -271,16 +269,7 @@ def delete_originals(experiment_dir, output_dir_base, run_names):
             except Exception as e:
                 errors.append({"path": str(out_dir), "error": str(e)})
 
-    # Clean up output base directory if now empty
-    if out_base.exists() and not any(out_base.iterdir()):
-        try:
-            out_base.rmdir()
-            deleted.append(str(out_base))
-        except Exception as e:
-            errors.append({"path": str(out_base), "error": str(e)})
-
     # Delete experiment directory (now archived)
-    exp_dir = Path(experiment_dir)
     if exp_dir.exists():
         size = _dir_size_bytes(exp_dir)
         try:
@@ -343,8 +332,7 @@ def archive_experiment(experiment_dir, archive_base, dry_run=False, force=False)
             "message": f"Failed to parse experiment_summary.yaml: {e}",
         }
 
-    output_dir_base = config.get("experiment", {}).get("directory", "")
-    if not output_dir_base:
+    if not config.get("experiment", {}).get("directory", ""):
         return {
             "status": "error",
             "message": "No experiment.directory found in experiment_summary.yaml",
@@ -359,7 +347,7 @@ def archive_experiment(experiment_dir, archive_base, dry_run=False, force=False)
         }
 
     # Inventory
-    inventory = inventory_experiment(str(exp_dir), output_dir_base)
+    inventory = inventory_experiment(str(exp_dir))
     if inventory["status"] != "success":
         return inventory
 
@@ -409,7 +397,7 @@ def archive_experiment(experiment_dir, archive_base, dry_run=False, force=False)
         }
 
     # Delete originals (checkpoints + experiment dir, now archived)
-    delete_result = delete_originals(str(exp_dir), output_dir_base, inventory["runs"])
+    delete_result = delete_originals(str(exp_dir), inventory["runs"])
 
     return {
         "status": "success",

--- a/src/tools/experiment/archive_experiment.py
+++ b/src/tools/experiment/archive_experiment.py
@@ -322,7 +322,7 @@ def archive_experiment(experiment_dir, archive_base, dry_run=False, force=False)
             "message": f"experiment_summary.yaml not found in {experiment_dir}",
         }
 
-    # Parse to get output directory
+    # Parse and validate required experiment fields
     try:
         with open(summary_path) as f:
             config = yaml.safe_load(f)

--- a/src/tools/torchtune/setup_finetune.py
+++ b/src/tools/torchtune/setup_finetune.py
@@ -224,8 +224,10 @@ def construct_artifacts_dir(project_dir, experiment_name, model_run_name):
         Full artifacts directory path with trailing slash
 
     Raises:
-        ValueError: if experiment_name is empty
+        ValueError: if project_dir or experiment_name is empty
     """
+    if not project_dir:
+        raise ValueError("project_dir is required")
     if not experiment_name:
         raise ValueError("experiment_name is required")
 

--- a/src/tools/torchtune/setup_finetune.py
+++ b/src/tools/torchtune/setup_finetune.py
@@ -207,16 +207,21 @@ def validate_dataset_type(dataset_type):
         )
 
 
-def construct_output_dir(output_dir_base, experiment_name, model_run_name):
-    """Construct the full output directory path.
+def construct_artifacts_dir(project_dir, experiment_name, model_run_name):
+    """Construct the full artifacts directory path for a run.
+
+    Builds {project_dir}/{experiment_name}/{model_run_name}/artifacts/. The
+    returned path becomes torchtune's `output_dir:` in the generated
+    finetune.yaml — that yaml key is torchtune's contract and must NOT be
+    renamed, even though our wrapper-side names here use `artifacts`.
 
     Args:
-        output_dir_base: Base directory for outputs
+        project_dir: Project directory (ck-projects/{project}/) holding experiment dirs
         experiment_name: Experiment name used to group outputs (required)
         model_run_name: Name of this specific model run
 
     Returns:
-        Full output directory path with trailing slash
+        Full artifacts directory path with trailing slash
 
     Raises:
         ValueError: if experiment_name is empty
@@ -224,12 +229,10 @@ def construct_output_dir(output_dir_base, experiment_name, model_run_name):
     if not experiment_name:
         raise ValueError("experiment_name is required")
 
-    if not output_dir_base.endswith("/"):
-        output_dir_base += "/"
+    if not project_dir.endswith("/"):
+        project_dir += "/"
 
-    return (
-        output_dir_base + experiment_name + "/" + model_run_name + f"/{ARTIFACTS_DIR}/"
-    )
+    return project_dir + experiment_name + "/" + model_run_name + f"/{ARTIFACTS_DIR}/"
 
 
 def configure_dataset_for_format(config, dataset_label, dataset_ext, dataset_type):
@@ -330,10 +333,10 @@ def create_parser():
         help="Name of the experiment (used to group outputs in ck-projects/{project}/{experiment_name}/).",
     )
     parser.add_argument(
-        "--output_dir_base",
+        "--project_dir",
         type=str,
         default=None,
-        help="Full path to the output file folders",
+        help="Full path to the project directory (ck-projects/{project}/) under which experiment dirs are created.",
     )
     parser.add_argument(
         "--input_dir_base",
@@ -627,7 +630,7 @@ def main():
     # config file, CLI, or scaffold agent via claude.local.md)
     missing = [
         name
-        for name in ("output_dir_base", "input_dir_base", "models_dir")
+        for name in ("project_dir", "input_dir_base", "models_dir")
         if getattr(args, name) is None
     ]
     if missing:
@@ -698,13 +701,13 @@ def main():
             config["input_dir"] = (
                 value + args.input_formatting + ("/" if args.input_formatting else "")
             )
-        elif key == "output_dir_base":
-            full_output_dir = construct_output_dir(
+        elif key == "project_dir":
+            full_artifacts_dir = construct_artifacts_dir(
                 value, args.experiment_name, model_run_name
             )
-            config["output_dir"] = full_output_dir
+            config["output_dir"] = full_artifacts_dir
         elif key == "experiment_name":
-            pass  # Handled in output_dir_base
+            pass  # Handled in project_dir
         elif key == "dataset_label":
             config = configure_dataset_for_format(
                 config, value, args.dataset_ext, args.dataset_type
@@ -995,7 +998,7 @@ def main():
             "module purge", "module purge" + module_string
         )
 
-    slurm_script = slurm_script.replace("<OUTPUT_DIR>", full_output_dir)
+    slurm_script = slurm_script.replace("<OUTPUT_DIR>", full_artifacts_dir)
     slurm_script = slurm_script.replace("$USER", username)
 
     with open("finetune.slurm", "w") as f:

--- a/tests/fixtures/scaffold/torchtune/rank4/setup_finetune.yaml
+++ b/tests/fixtures/scaffold/torchtune/rank4/setup_finetune.yaml
@@ -2,7 +2,7 @@
 # Path placeholders: __SCRATCH__, __REPO__ (replaced at test time)
 
 torchtune_model_name: "Llama-3.2-1B-Instruct"
-output_dir_base: "__SCRATCH__/ck-projects/capitalization/workflow_test_2026-03-16"
+project_dir: "__SCRATCH__/ck-projects/capitalization/workflow_test_2026-03-16"
 input_dir_base: "__SCRATCH__/ck-projects/capitalization/workflow_test_2026-03-16/"
 models_dir: "__SCRATCH__/pretrained-llms"
 experiment_name: "workflow_test_2026-03-16"

--- a/tests/fixtures/scaffold/torchtune/rank8/setup_finetune.yaml
+++ b/tests/fixtures/scaffold/torchtune/rank8/setup_finetune.yaml
@@ -2,7 +2,7 @@
 # Path placeholders: __SCRATCH__, __REPO__ (replaced at test time)
 
 torchtune_model_name: "Llama-3.2-1B-Instruct"
-output_dir_base: "__SCRATCH__/ck-projects/capitalization/workflow_test_2026-03-16"
+project_dir: "__SCRATCH__/ck-projects/capitalization/workflow_test_2026-03-16"
 input_dir_base: "__SCRATCH__/ck-projects/capitalization/workflow_test_2026-03-16/"
 models_dir: "__SCRATCH__/pretrained-llms"
 experiment_name: "workflow_test_2026-03-16"

--- a/tests/integration/cpu/test_setup_finetune_slurm.py
+++ b/tests/integration/cpu/test_setup_finetune_slurm.py
@@ -42,7 +42,7 @@ def run_setup_finetune(run_dir, model_name="Llama-3.2-1B-Instruct", extra_args=N
         ".json",
         "--input_dir_base",
         "/fake/path/",
-        "--output_dir_base",
+        "--project_dir",
         "/fake/output/",
         "--experiment_name",
         "test_experiment",

--- a/tests/integration/gpu/smoke_test_scaffolding.py
+++ b/tests/integration/gpu/smoke_test_scaffolding.py
@@ -33,7 +33,7 @@ def test_setup_finetune(work_dir: Path):
             ".json",
             "--input_dir_base",
             "/fake/input/",
-            "--output_dir_base",
+            "--project_dir",
             "/fake/output/",
             "--experiment_name",
             "smoke_test",

--- a/tests/integration/gpu/smoke_test_torchtune.py
+++ b/tests/integration/gpu/smoke_test_torchtune.py
@@ -57,7 +57,7 @@ def main():
                 str(REPO_ROOT / "tests" / "fixtures"),
                 "--input_formatting",
                 "",
-                "--output_dir_base",
+                "--project_dir",
                 str(output_dir),
                 "--experiment_name",
                 "smoke_test",
@@ -102,7 +102,7 @@ def main():
         print("PASS: torchtune training")
 
         # Step 3: Verify checkpoint exists and is non-empty
-        # setup_finetune.py creates output under output_dir_base/{experiment_name}/{run_name}/artifacts/
+        # setup_finetune.py creates output under project_dir/{experiment_name}/{run_name}/artifacts/
         artifacts_dirs = list(output_dir.glob("smoke_test/*/artifacts"))
         assert len(artifacts_dirs) > 0, (
             f"No */artifacts directory found in {output_dir}/smoke_test/"

--- a/tests/test_archive_experiment.py
+++ b/tests/test_archive_experiment.py
@@ -448,3 +448,21 @@ def test_archive_missing_project_field(tmp_path):
     assert "project" in result["message"]
     # Original experiment untouched
     assert Path(exp_dir).exists()
+
+
+def test_archive_missing_directory_field(tmp_path):
+    """experiment.directory missing → error before any work happens."""
+    exp_dir = _make_experiment(tmp_path)
+    # Strip the directory field from the yaml
+    summary_path = Path(exp_dir) / "experiment_summary.yaml"
+    config = yaml.safe_load(summary_path.read_text())
+    del config["experiment"]["directory"]
+    summary_path.write_text(yaml.dump(config))
+
+    archive_base = str(tmp_path / "ck-archive")
+    result = archive_experiment(exp_dir, archive_base, dry_run=True)
+
+    assert result["status"] == "error"
+    assert "directory" in result["message"]
+    # Original experiment untouched
+    assert Path(exp_dir).exists()

--- a/tests/test_archive_experiment.py
+++ b/tests/test_archive_experiment.py
@@ -17,17 +17,16 @@ def _make_experiment(tmp_path, run_names=None, include_eval=True, extras=None):
     """
     Create a minimal experiment directory with expected structure.
 
-    Returns (experiment_dir, output_dir_base) as strings.
+    Returns the experiment directory as a string.
     """
     if run_names is None:
         run_names = ["run_rank4", "run_rank8"]
 
     exp_name = "test_experiment_2026-03-23"
-    # Under the unified ck-projects/ layout, experiment dir and output base
-    # point to the same location — outputs nest inside each run's dir.
+    # Under the unified ck-projects/ layout, checkpoints nest inside each run's
+    # dir within the experiment dir itself — there is no separate output base.
     exp_dir = tmp_path / "ck-projects" / "capitalization" / exp_name
     exp_dir.mkdir(parents=True)
-    out_base = exp_dir
 
     # experiment_summary.yaml
     config = {
@@ -97,7 +96,7 @@ def _make_experiment(tmp_path, run_names=None, include_eval=True, extras=None):
         if "findings" in extras:
             (exp_dir / "findings.md").write_text("# Findings\nWe learned stuff.")
 
-    return str(exp_dir), str(out_base)
+    return str(exp_dir)
 
 
 # --- inventory_experiment tests ---
@@ -105,8 +104,8 @@ def _make_experiment(tmp_path, run_names=None, include_eval=True, extras=None):
 
 def test_inventory_complete_experiment(tmp_path):
     """Complete experiment → all files categorized correctly."""
-    exp_dir, out_base = _make_experiment(tmp_path)
-    result = inventory_experiment(exp_dir, out_base)
+    exp_dir = _make_experiment(tmp_path)
+    result = inventory_experiment(exp_dir)
 
     assert result["status"] == "success"
     assert len(result["runs"]) == 2
@@ -129,8 +128,8 @@ def test_inventory_complete_experiment(tmp_path):
 
 def test_inventory_incomplete_experiment(tmp_path):
     """Missing eval logs → incomplete_runs populated."""
-    exp_dir, out_base = _make_experiment(tmp_path, include_eval=False)
-    result = inventory_experiment(exp_dir, out_base)
+    exp_dir = _make_experiment(tmp_path, include_eval=False)
+    result = inventory_experiment(exp_dir)
 
     assert result["status"] == "success"
     assert set(result["incomplete_runs"]) == {"run_rank4", "run_rank8"}
@@ -140,7 +139,7 @@ def test_inventory_missing_summary(tmp_path):
     """No experiment_summary.yaml → error."""
     exp_dir = tmp_path / "empty_experiment"
     exp_dir.mkdir()
-    result = inventory_experiment(str(exp_dir), str(tmp_path))
+    result = inventory_experiment(str(exp_dir))
 
     assert result["status"] == "error"
     assert "experiment_summary.yaml" in result["message"]
@@ -148,8 +147,8 @@ def test_inventory_missing_summary(tmp_path):
 
 def test_inventory_with_analysis(tmp_path):
     """Analysis directory → included in keep files."""
-    exp_dir, out_base = _make_experiment(tmp_path, extras=["exploration"])
-    result = inventory_experiment(exp_dir, out_base)
+    exp_dir = _make_experiment(tmp_path, extras=["exploration"])
+    result = inventory_experiment(exp_dir)
 
     archive_paths = [kf["archive_path"] for kf in result["keep_files"]]
     assert "exploration/report.md" in archive_paths
@@ -164,7 +163,7 @@ def test_inventory_skips_symlinks_under_artifacts(tmp_path):
     experiment dir slipped through and pulled external content into the
     archive.
     """
-    exp_dir_str, out_base = _make_experiment(tmp_path)
+    exp_dir_str = _make_experiment(tmp_path)
     exp_dir = Path(exp_dir_str)
 
     # External target outside the experiment dir
@@ -180,7 +179,7 @@ def test_inventory_skips_symlinks_under_artifacts(tmp_path):
     # And a symlink under eval/ to simulate a stray symlink outside artifacts/
     (exp_dir / "run_rank4" / "eval" / "stray.log").symlink_to(external)
 
-    result = inventory_experiment(str(exp_dir), out_base)
+    result = inventory_experiment(str(exp_dir))
     archive_paths = [kf["archive_path"] for kf in result["keep_files"]]
 
     assert "run_rank4/artifacts/logs/wandb/debug-core.log" not in archive_paths
@@ -192,8 +191,8 @@ def test_inventory_skips_symlinks_under_artifacts(tmp_path):
 
 def test_findings_from_explicit_file(tmp_path):
     """findings.md exists → use it directly."""
-    exp_dir, out_base = _make_experiment(tmp_path, extras=["findings"])
-    result = inventory_experiment(exp_dir, out_base)
+    exp_dir = _make_experiment(tmp_path, extras=["findings"])
+    result = inventory_experiment(exp_dir)
 
     assert result["findings_source"] == str(
         tmp_path
@@ -206,23 +205,23 @@ def test_findings_from_explicit_file(tmp_path):
 
 def test_findings_from_report(tmp_path):
     """No findings.md, but exploration/report.md exists → use report."""
-    exp_dir, out_base = _make_experiment(tmp_path, extras=["exploration"])
-    result = inventory_experiment(exp_dir, out_base)
+    exp_dir = _make_experiment(tmp_path, extras=["exploration"])
+    result = inventory_experiment(exp_dir)
 
     assert result["findings_source"].endswith("exploration/report.md")
 
 
 def test_findings_from_summary(tmp_path):
     """No findings.md or report.md → fall back to summary.md."""
-    exp_dir, out_base = _make_experiment(tmp_path)
-    result = inventory_experiment(exp_dir, out_base)
+    exp_dir = _make_experiment(tmp_path)
+    result = inventory_experiment(exp_dir)
 
     assert result["findings_source"].endswith("summary.md")
 
 
 def test_findings_none_when_nothing_exists(tmp_path):
     """No findings, report, or summary → None."""
-    exp_dir, out_base = _make_experiment(tmp_path)
+    exp_dir = _make_experiment(tmp_path)
     # Remove summary.md
     (
         tmp_path
@@ -231,7 +230,7 @@ def test_findings_none_when_nothing_exists(tmp_path):
         / "test_experiment_2026-03-23"
         / "summary.md"
     ).unlink()
-    result = inventory_experiment(exp_dir, out_base)
+    result = inventory_experiment(exp_dir)
 
     assert result["findings_source"] is None
 
@@ -241,8 +240,8 @@ def test_findings_none_when_nothing_exists(tmp_path):
 
 def test_create_archive(tmp_path):
     """All KEEP files land in correct archive structure."""
-    exp_dir, out_base = _make_experiment(tmp_path)
-    inventory = inventory_experiment(exp_dir, out_base)
+    exp_dir = _make_experiment(tmp_path)
+    inventory = inventory_experiment(exp_dir)
     archive_dir = str(tmp_path / "ck-archive" / "test_experiment")
 
     result = create_archive(archive_dir, inventory)
@@ -272,8 +271,8 @@ def test_create_archive(tmp_path):
 
 def test_create_archive_already_exists(tmp_path):
     """Archive dir already exists → error."""
-    exp_dir, out_base = _make_experiment(tmp_path)
-    inventory = inventory_experiment(exp_dir, out_base)
+    exp_dir = _make_experiment(tmp_path)
+    inventory = inventory_experiment(exp_dir)
     archive_dir = tmp_path / "ck-archive" / "test_experiment"
     archive_dir.mkdir(parents=True)
 
@@ -288,8 +287,8 @@ def test_create_archive_already_exists(tmp_path):
 
 def test_verify_archive(tmp_path):
     """Happy path verification succeeds."""
-    exp_dir, out_base = _make_experiment(tmp_path)
-    inventory = inventory_experiment(exp_dir, out_base)
+    exp_dir = _make_experiment(tmp_path)
+    inventory = inventory_experiment(exp_dir)
     archive_dir = str(tmp_path / "ck-archive" / "test_experiment")
     create_archive(archive_dir, inventory)
 
@@ -302,8 +301,8 @@ def test_verify_archive(tmp_path):
 
 def test_verify_archive_missing_file(tmp_path):
     """Missing file in archive → error."""
-    exp_dir, out_base = _make_experiment(tmp_path)
-    inventory = inventory_experiment(exp_dir, out_base)
+    exp_dir = _make_experiment(tmp_path)
+    inventory = inventory_experiment(exp_dir)
     archive_dir = tmp_path / "ck-archive" / "test_experiment"
     create_archive(str(archive_dir), inventory)
 
@@ -321,11 +320,11 @@ def test_verify_archive_missing_file(tmp_path):
 
 def test_delete_originals(tmp_path):
     """Cleanup removes experiment dir and checkpoint dirs."""
-    exp_dir, out_base = _make_experiment(tmp_path)
-    inventory = inventory_experiment(exp_dir, out_base)
+    exp_dir = _make_experiment(tmp_path)
+    inventory = inventory_experiment(exp_dir)
     run_names = inventory["runs"]
 
-    result = delete_originals(exp_dir, out_base, run_names)
+    result = delete_originals(exp_dir, run_names)
 
     assert result["status"] == "success"
     assert result["freed_bytes"] > 0
@@ -333,7 +332,7 @@ def test_delete_originals(tmp_path):
 
     # Verify the per-run artifact loop ran (not just the final rmtree)
     for rn in run_names:
-        assert str(Path(out_base) / rn / "artifacts") in result["deleted"]
+        assert str(Path(exp_dir) / rn / "artifacts") in result["deleted"]
     assert not Path(exp_dir).exists()
 
 
@@ -342,7 +341,7 @@ def test_delete_originals(tmp_path):
 
 def test_dry_run_no_side_effects(tmp_path):
     """Dry run reports plan without creating or deleting anything."""
-    exp_dir, out_base = _make_experiment(tmp_path)
+    exp_dir = _make_experiment(tmp_path)
     archive_base = str(tmp_path / "ck-archive")
 
     result = archive_experiment(exp_dir, archive_base, dry_run=True)
@@ -365,7 +364,7 @@ def test_dry_run_no_side_effects(tmp_path):
 
 def test_archive_full_workflow(tmp_path):
     """End-to-end: inventory → archive → verify → delete."""
-    exp_dir, out_base = _make_experiment(tmp_path, extras=["exploration"])
+    exp_dir = _make_experiment(tmp_path, extras=["exploration"])
     archive_base = str(tmp_path / "ck-archive")
 
     result = archive_experiment(exp_dir, archive_base)
@@ -390,7 +389,7 @@ def test_archive_full_workflow(tmp_path):
 
 def test_archive_incomplete_without_force(tmp_path):
     """Incomplete experiment without --force → error."""
-    exp_dir, out_base = _make_experiment(tmp_path, include_eval=False)
+    exp_dir = _make_experiment(tmp_path, include_eval=False)
     archive_base = str(tmp_path / "ck-archive")
 
     result = archive_experiment(exp_dir, archive_base)
@@ -402,7 +401,7 @@ def test_archive_incomplete_without_force(tmp_path):
 
 def test_archive_incomplete_with_force(tmp_path):
     """Incomplete experiment with --force → proceeds with warning."""
-    exp_dir, out_base = _make_experiment(tmp_path, include_eval=False)
+    exp_dir = _make_experiment(tmp_path, include_eval=False)
     archive_base = str(tmp_path / "ck-archive")
 
     result = archive_experiment(exp_dir, archive_base, force=True)
@@ -421,7 +420,7 @@ def test_archive_nonexistent_dir(tmp_path):
 
 def test_archive_path_includes_project(tmp_path):
     """Archive path is {archive_base}/{project}/{experiment_name}/."""
-    exp_dir, _ = _make_experiment(tmp_path)
+    exp_dir = _make_experiment(tmp_path)
     archive_base = str(tmp_path / "ck-archive")
 
     result = archive_experiment(exp_dir, archive_base, dry_run=True)
@@ -435,7 +434,7 @@ def test_archive_path_includes_project(tmp_path):
 
 def test_archive_missing_project_field(tmp_path):
     """experiment.project missing → error before any work happens."""
-    exp_dir, _ = _make_experiment(tmp_path)
+    exp_dir = _make_experiment(tmp_path)
     # Strip the project field from the yaml
     summary_path = Path(exp_dir) / "experiment_summary.yaml"
     config = yaml.safe_load(summary_path.read_text())

--- a/tests/unit/test_setup_finetune.py
+++ b/tests/unit/test_setup_finetune.py
@@ -8,7 +8,7 @@ from cruijff_kit.tools.torchtune.setup_finetune import (
     calculate_lora_alpha,
     validate_lr_scheduler,
     validate_dataset_type,
-    construct_output_dir,
+    construct_artifacts_dir,
     configure_dataset_for_format,
     extract_flat_params,
     compute_training_steps,
@@ -137,44 +137,44 @@ def test_validate_dataset_type_invalid():
     assert "invalid_dataset" in str(exc_info.value)
 
 
-# Tests for construct_output_dir()
+# Tests for construct_artifacts_dir()
 
 
-def test_construct_output_dir_with_experiment_and_trailing_slash():
+def test_construct_artifacts_dir_with_experiment_and_trailing_slash():
     """Test output dir construction with experiment name and trailing slash."""
-    result = construct_output_dir(
-        output_dir_base="/scratch/output/",
+    result = construct_artifacts_dir(
+        project_dir="/scratch/output/",
         experiment_name="my_experiment",
         model_run_name="run_123",
     )
     assert result == "/scratch/output/my_experiment/run_123/artifacts/"
 
 
-def test_construct_output_dir_with_experiment_no_trailing_slash():
+def test_construct_artifacts_dir_with_experiment_no_trailing_slash():
     """Test output dir construction with experiment name, no trailing slash."""
-    result = construct_output_dir(
-        output_dir_base="/scratch/output",
+    result = construct_artifacts_dir(
+        project_dir="/scratch/output",
         experiment_name="my_experiment",
         model_run_name="run_123",
     )
     assert result == "/scratch/output/my_experiment/run_123/artifacts/"
 
 
-def test_construct_output_dir_empty_experiment_name_raises():
+def test_construct_artifacts_dir_empty_experiment_name_raises():
     """Empty experiment_name must raise ValueError (legacy fallback retired)."""
     with pytest.raises(ValueError, match="experiment_name is required"):
-        construct_output_dir(
-            output_dir_base="/scratch/output/",
+        construct_artifacts_dir(
+            project_dir="/scratch/output/",
             experiment_name="",
             model_run_name="run_123",
         )
 
 
-def test_construct_output_dir_none_experiment_name_raises():
+def test_construct_artifacts_dir_none_experiment_name_raises():
     """None experiment_name must raise ValueError (legacy fallback retired)."""
     with pytest.raises(ValueError, match="experiment_name is required"):
-        construct_output_dir(
-            output_dir_base="/scratch/output/",
+        construct_artifacts_dir(
+            project_dir="/scratch/output/",
             experiment_name=None,
             model_run_name="run_123",
         )

--- a/tests/unit/test_setup_finetune.py
+++ b/tests/unit/test_setup_finetune.py
@@ -180,6 +180,26 @@ def test_construct_artifacts_dir_none_experiment_name_raises():
         )
 
 
+def test_construct_artifacts_dir_empty_project_dir_raises():
+    """Empty project_dir must raise, not silently root the path at '/'."""
+    with pytest.raises(ValueError, match="project_dir is required"):
+        construct_artifacts_dir(
+            project_dir="",
+            experiment_name="my_experiment",
+            model_run_name="run_123",
+        )
+
+
+def test_construct_artifacts_dir_none_project_dir_raises():
+    """None project_dir must raise ValueError, not AttributeError on .endswith."""
+    with pytest.raises(ValueError, match="project_dir is required"):
+        construct_artifacts_dir(
+            project_dir=None,
+            experiment_name="my_experiment",
+            model_run_name="run_123",
+        )
+
+
 # Tests for configure_dataset_for_format()
 
 

--- a/tests/unit/test_setup_finetune_main.py
+++ b/tests/unit/test_setup_finetune_main.py
@@ -19,7 +19,7 @@ def setup_yaml(tmp_path):
     """Write a minimal setup_finetune.yaml config."""
     config = {
         "torchtune_model_name": "Llama-3.2-1B-Instruct",
-        "output_dir_base": str(tmp_path / "outputs"),
+        "project_dir": str(tmp_path / "outputs"),
         "input_dir_base": str(tmp_path / "inputs") + "/",
         "models_dir": str(tmp_path / "models"),
         "experiment_name": "test_exp",


### PR DESCRIPTION
Closes #443

## Description

Following the `ck-out-{run_name}/` → `{run_name}/artifacts/` folder reorg, the Python that constructs those paths still used `output_*` names that no longer matched the on-disk layout. This renames our wrapper-level names to what the values actually are.

A wrinkle the issue's mapping didn't capture: `output_dir_base` meant **two different things** in the two files — the *project* dir in setup_finetune (parent of the experiment) vs. the *experiment* dir in archive. So a single blanket rename would have been wrong. They get different, accurate names.

### setup_finetune.py
- `--output_dir_base` flag **and** the `setup_finetune.yaml` key → `--project_dir` / `project_dir:` (it's the `ck-projects/{project}/` dir, not the artifacts dir). **Clean break** — breaks manual invocations that hardcode the old flag.
- `construct_output_dir()` → `construct_artifacts_dir()`
- `full_output_dir` → `full_artifacts_dir`

### archive_experiment.py
- `output_dir_base` there held `experiment.directory` — the *same value* already passed in as `experiment_dir`. Collapsed the redundant param into a single `experiment_dir` across `inventory_experiment` and `delete_originals`.
- Re-homed the "`experiment.directory` present" validation guard (kept, no longer bound to a path var).
- Dropped the now-dead "clean up output base if empty" block (unreachable once `out_base == exp_dir`).

### Torchtune contracts — deliberately untouched
- `output_dir:` key in the generated `finetune.yaml` (torchtune reads it)
- `"output"` JSON key in dataset records
- The `<OUTPUT_DIR>` SLURM token (genuinely "where SLURM writes output")

Added a boundary comment on `construct_artifacts_dir` so the next reader doesn't rename the contract.

## New Dependencies

None.

## Testing Instructions

```bash
python -m pytest tests/test_archive_experiment.py tests/unit/test_setup_finetune.py tests/unit/test_setup_finetune_main.py tests/unit/test_experiment_summary_schema.py -q
# 171 passed
```

—MxC
