### PR TITLE
Fix stale experiment.seed references in propagate docs

### DIFF
--- a/src/tools/experiment/propagate.py
+++ b/src/tools/experiment/propagate.py
@@ -17,9 +17,8 @@ branching on dataset type) but no longer touch flat field copies.
 from typing import Any
 
 
-# Canonical run-time seed when neither a stage override nor experiment.seed is
-# set. 14 is Johan Cruijff's kit number and matches setup_finetune.py's
-# historical --seed default.
+# Run-time seed a stage falls back to when it doesn't set its own. 14 is Johan
+# Cruijff's kit number and matches setup_finetune.py's historical --seed default.
 DEFAULT_SEED = 14
 
 
@@ -103,7 +102,7 @@ def propagate_eval_fields(experiment_summary: dict, eval_config: dict) -> dict:
     agent's per-cell decisions (e.g. per-task system_prompt overrides) survive
     propagation.
 
-    The eval seed is resolved (override > experiment.seed > default) and written
+    The eval seed is resolved (evaluation.seed, else DEFAULT_SEED) and written
     unless the agent already set a per-cell seed, which wins.
     """
     _propagate(experiment_summary, eval_config, EVAL_FIELDS)
@@ -122,10 +121,8 @@ def propagate_train_fields(experiment_summary: dict, setup_finetune: dict) -> di
     when the run's `dataset_type` is `text_completion` (base / non-instruct
     models have no chat template to hold a system prompt).
 
-    The training seed is resolved (override > experiment.seed > default) and
-    written unless the agent already set a per-run seed, which wins. This is
-    what makes training deterministic by default — absent any seed, training
-    resolves to DEFAULT_SEED rather than the recipe's historical null.
+    The training seed is resolved (controls.seed, else DEFAULT_SEED) and
+    written unless the agent already set a per-run seed, which wins.
     """
     _propagate(experiment_summary, setup_finetune, TRAIN_FIELDS)
     if setup_finetune.get("seed") is None:

--- a/tests/unit/test_propagate.py
+++ b/tests/unit/test_propagate.py
@@ -168,7 +168,7 @@ def test_source_none_value_is_skipped():
 
 def test_source_missing_root_is_skipped():
     # The flat EVAL_FIELDS copies skip when absent; only the always-resolved
-    # seed lands (default, since neither override nor experiment.seed is set).
+    # seed lands (the default, since the stage seed is unset).
     eval_config: dict = {}
     propagate_eval_fields({}, eval_config)
     assert eval_config == {"seed": DEFAULT_SEED}


### PR DESCRIPTION
Closes #500 follow-up (no separate issue — cleanup of merged #563).

# Description

The #500 rework (PR #563) replaced the canonical `experiment.seed` fan-out with two independent stage seeds (`controls.seed`, `evaluation.seed`), but four comments/docstrings still described the old three-tier precedence (`override > experiment.seed > default`). This corrects them to the actual two-tier resolution (`stage seed, else DEFAULT_SEED`) and drops a misleading "training is deterministic by default rather than the recipe's historical null" claim — training already defaulted to 14.

Doc/comment-only; no behavior change.

## New Dependencies

None.

# Testing Instructions

```bash
python -m pytest tests/unit/test_propagate.py -q
grep -rn "experiment\.seed" src/ tests/   # expect no matches
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)