### PR TITLE
Update create-inspect-task skill to current eval_config architecture

### DIFF
--- a/.claude/skills/create-inspect-task/SKILL.md
+++ b/.claude/skills/create-inspect-task/SKILL.md
@@ -361,7 +361,47 @@ Result: Will use hf_dataset with json format and custom record_to_sample functio
 
 **Based on evaluation objective, suggest scorers:**
 
-**For exact matching:**
+**cruijff_kit custom scorers (preferred for experiment tasks — driven by the `scorer:` block in `eval_config.yaml`):**
+
+Rather than hard-coding a scorer in the task, read the `scorer:` list from `config_path` and build it via the shared registry. This lets the experiment design (not the task code) pick the scorer:
+
+```python
+from cruijff_kit.tools.inspect.scorers import (
+    build_scorers,
+    configured_scorers_require_logprobs,
+)
+
+scorers = build_scorers(config)  # falls back to DEFAULT_SCORERS if no scorer: block
+```
+
+The `scorer:` block is a list of `{name, params}` entries:
+
+```yaml
+scorer:
+  - name: match
+  - name: risk_scorer
+    params:
+      option_tokens: ["0", "1"]
+```
+
+Registry names: `match`, `includes`, `risk_scorer`, `numeric_risk_scorer`, `continuous_scorer`.
+
+**logprobs contract:** logprob-based scorers (e.g. `risk_scorer`) set `requires_logprobs = True` on their factory. Call `configured_scorers_require_logprobs(config)` and auto-enable logprob capture when it returns `True`:
+
+```python
+scorer_needs_logprobs = configured_scorers_require_logprobs(config)
+enable_logprobs = bool(logprobs) or (logprobs is None and scorer_needs_logprobs)
+if enable_logprobs:
+    generate_config = GenerateConfig(logprobs=True, top_logprobs=top_logprobs)
+else:
+    generate_config = GenerateConfig()
+# ... and fail loudly if the user passed logprobs=False while configuring a
+# scorer that needs them, rather than silently producing unscored logs.
+```
+
+Note: `risk_scorer` accuracy is exact-string-match (`completion == target`), not argmax — it conflates output format with judgment. Keep that in mind when interpreting its `accuracy`.
+
+**For exact matching (inspect-ai built-ins — fine for standalone tasks without the registry):**
 - `match()` - Target appears at beginning/end; ignores case, whitespace, punctuation
   - Options: `location="begin"/"end"/"any"`, `ignore_case=True/False`
 - `exact()` - Precise matching after normalization
@@ -393,12 +433,25 @@ Result: Will use hf_dataset with json format and custom record_to_sample functio
 
 **Should the task accept parameters for flexibility?**
 
-**Common parameters to expose:**
-- `system_prompt` - Allow different system messages
-- `temperature` - Enable temperature tuning
-- `dataset_path` - Support different datasets
-- `grader_model` - For model-graded scoring
-- `config_dir` - (legacy) For runtime config reading; scaffold-inspect uses direct params instead
+**Standard parameters — match the current blueprint tasks so the task drops into the `eval_config.yaml` pipeline** (cleanest reference: `blueprints/capitalization/inspect_task.py`):
+
+- `data_path` — Path to the dataset JSON (required; no default).
+- `config_path` — Path to `eval_config.yaml`. The task reads `prompt`, `system_prompt`, and (optionally) the `scorer:` block from it. `setup_inspect.py` auto-derives this from the config file's own location — you do not pass it by hand.
+- `vis_label` — Optional label appended to the task name (`f"{name}_{vis_label}" if vis_label else name`). **Required for the viz pipeline**: `viz_helpers` reads `vis_label` from the eval log's `task_args` to dedup and label runs. Omit it and multi-variant runs collide in the visualizations.
+- `split` — Which split to evaluate (e.g. `"test"`, `"validation"`).
+- `use_chat_template` — `True` for instruct models (adds a `system_message` solver), `False` for base models (plain text completion).
+- `temperature` / `max_tokens` — Generation params. Greedy default is `temperature=1e-7`.
+- `logprobs` / `top_logprobs` — Capture top logprobs. Leave `logprobs` defaulting to `None` (auto) so it enables only when a configured scorer needs them — see Scorer Selection.
+- `assistant_prefix` — Optional text to seed the assistant turn.
+
+These names are not arbitrary. `setup_inspect.py` maps a fixed `TASK_ARG_KEYS` set onto `-T` flags:
+
+```
+data_path, config_path, vis_label, use_chat_template, split,
+logprobs, top_logprobs, temperature, max_tokens, assistant_prefix
+```
+
+A parameter outside that set will **not** receive a value from `eval_config.yaml` (you'd get a startup warning from `load_eval_config` about an unconsumed key). Add genuinely new task args to `TASK_ARG_KEYS` in `setup_inspect.py` if the task needs them.
 
 **Benefits of parameters:**
 - Run variations without code changes
@@ -419,10 +472,10 @@ inspect eval task.py -T param_name=value
 - `inspect eval task.py --model hf/local -M model_path=/path/to/model`
 - Recommended for most cases
 
-**Option 2: Integration with fine-tuning config (legacy)**
-- Like existing `inspect_task` example
-- Reads from `setup_finetune.yaml` at runtime via `config_dir` parameter
-- Note: scaffold-inspect now bakes values into SLURM instead of using this pattern
+**Option 2: Experiment pipeline (eval_config.yaml)**
+- The model path is baked into the SLURM cell by `setup_inspect.py` from `eval_config.yaml`
+- The task itself only reads `prompt`/`system_prompt`/`scorer` from `config_path` — it never resolves the model
+- This is how `scaffold-inspect` runs tasks; see Generated Task Pattern below
 
 **Option 3: Hard-coded in task**
 - Less flexible but simpler
@@ -468,7 +521,7 @@ def my_task(param1: str = "default"):
     solver = chain(
         system_message("..."),
         prompt_template("{prompt}"),
-        generate({"temperature": 0.0})
+        generate(temperature=0.0)
     )
 
     # Return task
@@ -593,8 +646,10 @@ inspect eval {task_name}_task.py --model hf/local -M model_path=/path/to/model -
 
 **Evaluating fine-tuned model:** {if applicable}
 ```bash
-cd /path/to/experiment/run/epoch_0
-inspect eval {task_name}_task.py --model hf/local -M model_path=$PWD -T config_dir=$PWD
+inspect eval {task_name}_task.py@{task_name} --model hf/local \
+  -M model_path=/path/to/run/artifacts/epoch_0 \
+  -T data_path=/path/to/dataset.json \
+  -T config_path=/path/to/eval_config.yaml
 ```
 
 ## Output Files
@@ -680,7 +735,7 @@ from inspect_ai.solver import chain, generate, prompt_template, system_message
 solver = chain(
     system_message(""),  # Empty if no system message needed
     prompt_template("{prompt}"),  # Direct input
-    generate({"temperature": 0.0})
+    generate(temperature=0.0)
 )
 ```
 
@@ -689,7 +744,7 @@ solver = chain(
 solver = chain(
     system_message("You are an expert classifier. Respond with only the category label."),
     prompt_template("Text: {prompt}\n\nCategory:"),
-    generate({"temperature": 0.0, "max_tokens": 50})
+    generate(temperature=0.0, max_tokens=50)
 )
 ```
 
@@ -699,7 +754,7 @@ from inspect_ai.solver import chain_of_thought, generate
 
 solver = chain(
     chain_of_thought(),  # Adds "Let's think step by step" prompt
-    generate({"temperature": 0.0})
+    generate(temperature=0.0)
 )
 ```
 
@@ -755,105 +810,135 @@ scorer = model_graded_qa(
 
 ### Experiment-Guided Task Creation (Recommended)
 
-When creating tasks for an experiment:
+When creating tasks for an experiment, the task does **not** read fine-tuning configs directly. Instead it reads its prompt/scorer config from the `eval_config.yaml` that `scaffold-inspect` writes, via the auto-derived `config_path`:
 
-1. **Run from experiment directory:**
-   ```bash
-   cd /scratch/gpfs/MSALGANIK/mjs3/my_experiment/
-   # Invoke create-inspect-task skill
-   ```
+1. `design-experiment` produces `experiment_summary.yaml` (research question, data, models, `evaluation.system_prompt`, the `scorer:` block).
+2. `scaffold-inspect` writes one `eval_config.yaml` per (run, task, epoch) cell, carrying `prompt`, `system_prompt`, `scorer`, `data_path`, `vis_label`, etc.
+3. `setup_inspect.py` renders the SLURM script: it auto-derives `config_path` (the path to that `eval_config.yaml`), maps `TASK_ARG_KEYS` onto `-T` flags, and the task reads `prompt`/`system_prompt`/`scorer` back out of `config_path` at runtime.
 
-2. **Skill automatically extracts from experiment_summary.yaml:**
-   - Dataset path and format
-   - System prompt (ensures eval matches training)
-   - Model information
-   - Research objectives
-
-3. **Task parameter modes:**
-   - **Direct parameters (preferred)**: `data_path`, `prompt`, `system_prompt` passed via `-T` flags. scaffold-inspect bakes these into SLURM scripts at scaffolding time.
-   - **config_dir mode (legacy)**: Reads from `setup_finetune.yaml` at runtime. Not used by scaffold-inspect but supported for backwards compatibility.
+So a generated task's job is: accept the standard params, read prompt/system_prompt (and optionally the `scorer:` block) from `config_path`, build the dataset/solver/scorer, and name itself with `vis_label`.
 
 ### Generated Task Pattern
 
-**For tasks integrated with experiments:**
+**For tasks integrated with experiments** (mirrors `blueprints/capitalization/inspect_task.py`, the cleanest reference):
 
 ```python
 import yaml
-from pathlib import Path
+from inspect_ai import Task, task
+from inspect_ai.dataset import hf_dataset, Sample
+from inspect_ai.model import GenerateConfig
+from inspect_ai.solver import chain, generate, system_message
+
+from cruijff_kit.tools.inspect.scorers import (
+    build_scorers,
+    configured_scorers_require_logprobs,
+)
+
 
 @task
 def my_task(
-    config_dir: Optional[str] = None,
-    dataset_path: Optional[str] = None,
-    system_prompt: str = "",
-    temperature: float = 0.0,
-    split: str = "test"
+    data_path: str,
+    config_path: str = "",
+    split: str = "test",
+    temperature: float = 1e-7,
+    max_tokens: int = 20,
+    use_chat_template: bool = True,
+    logprobs: bool | None = None,
+    top_logprobs: int = 20,
+    vis_label: str = "",
 ) -> Task:
     """
-    Evaluate model using configuration from fine-tuning setup or direct paths.
+    Evaluate a model on <task description>.
 
     Args:
-        config_dir: Path to epoch directory (contains ../setup_finetune.yaml).
-                   If provided, reads dataset path and system prompt from config.
-        dataset_path: Direct path to dataset JSON file. Used if config_dir not provided.
-        system_prompt: System message for the model. Overrides config if both provided.
-        temperature: Generation temperature (default: 0.0 for deterministic output).
-        split: Which data split to use (default: "test").
+        data_path: Path to the dataset JSON.
+        config_path: Path to eval_config.yaml (reads prompt/system_prompt/scorer).
+        split: Which split to evaluate (default: "test").
+        temperature: Generation temperature (greedy default 1e-7).
+        max_tokens: Max tokens to generate.
+        use_chat_template: True for instruct models (adds system_message solver),
+            False for base models (plain text completion).
+        logprobs: None = auto (enable iff a configured scorer needs them).
+        top_logprobs: Top-k logprobs to capture when enabled.
+        vis_label: Optional suffix for the task name; read by viz_helpers for
+            dedup/labeling across a multi-variant experiment.
 
     Returns:
         Task: Configured inspect-ai task
     """
+    # Task name carries vis_label so the viz pipeline can label/dedup runs.
+    task_name = f"my_task_{vis_label}" if vis_label else "my_task"
 
-    # Determine configuration source
-    if config_dir:
-        # Mode 1: Read from fine-tuning configuration
-        config_path = Path(config_dir).parent / "setup_finetune.yaml"
+    prompt_str = "{input}"
+    system_prompt = ""
+    config: dict = {}
+    if config_path:
+        with open(config_path, "r") as f:
+            config = yaml.safe_load(f) or {}
+        prompt_str = config.get("prompt", "{input}")
+        system_prompt = config.get("system_prompt", "")
 
-        with open(config_path, 'r') as f:
-            config = yaml.safe_load(f)
+    def record_to_sample(record):
+        return Sample(
+            input=prompt_str.format(input=record["input"]),
+            target=record["output"],
+            metadata=record.get("metadata", {}),
+        )
 
-        # Extract settings from fine-tuning config
-        dataset_path = config['input_dir_base'] + config['dataset_label'] + config['dataset_ext']
+    dataset = hf_dataset(
+        path="json",
+        data_files=data_path,
+        field=split,
+        split="train",  # HuggingFace quirk — always "train" here
+        sample_fields=record_to_sample,
+    )
 
-        # Use system prompt from config unless overridden
-        if not system_prompt:
-            system_prompt = config.get('system_prompt', '')
-
-    elif dataset_path:
-        # Mode 2: Direct dataset path
-        # system_prompt and other params used as provided
-        pass
+    if use_chat_template:
+        solver = chain(
+            system_message(system_prompt),
+            generate(temperature=temperature, max_tokens=max_tokens),
+        )
     else:
-        raise ValueError("Must provide either config_dir or dataset_path")
+        solver = chain(generate(temperature=temperature, max_tokens=max_tokens))
 
-    # Load dataset
-    dataset = ...  # Load using dataset_path
+    # Scorer + logprobs driven by the eval_config scorer: block.
+    scorers = build_scorers(config)
+    scorer_needs_logprobs = configured_scorers_require_logprobs(config)
+    if logprobs is False and scorer_needs_logprobs:
+        raise ValueError(
+            "A configured scorer requires logprobs, but logprobs=False was set. "
+            "Drop the override or remove the logprob-dependent scorer."
+        )
+    enable_logprobs = bool(logprobs) or (logprobs is None and scorer_needs_logprobs)
+    generate_config = (
+        GenerateConfig(logprobs=True, top_logprobs=top_logprobs)
+        if enable_logprobs
+        else GenerateConfig()
+    )
 
     return Task(
+        name=task_name,
         dataset=dataset,
-        solver=chain(
-            system_message(system_prompt),
-            prompt_template("{prompt}"),
-            generate({"temperature": temperature})
-        ),
-        scorer=...
+        solver=solver,
+        scorer=scorers,
+        config=generate_config,
     )
 ```
 
+For a **standalone** task with no experiment context, drop the `config_path`/`build_scorers`/logprobs machinery and hard-code a built-in scorer (e.g. `scorer=match(...)`) — but keep `vis_label` if the eval logs will feed the viz pipeline.
+
 ### Usage Examples
 
-**Evaluating fine-tuned model from experiment:**
-```bash
-cd /path/to/experiment/run_dir/epoch_0
-inspect eval /path/to/my_task.py --model hf/local -M model_path=$PWD -T config_dir=$PWD
-```
+In the experiment pipeline you don't invoke `inspect eval` by hand — `scaffold-inspect` + `setup_inspect.py` generate the SLURM cell. For a quick manual smoke test of a generated task:
 
-**Evaluating base model (control run):**
 ```bash
-inspect eval my_task.py \
+inspect eval my_task.py@my_task \
   --model hf/local \
   -M model_path=/scratch/gpfs/MSALGANIK/pretrained-llms/Llama-3.2-1B-Instruct \
-  -T dataset_path=/path/to/dataset.json
+  -T data_path=/path/to/dataset.json \
+  -T config_path=/path/to/eval_config.yaml \
+  -T vis_label=smoke \
+  --limit 5
 ```
 
 ### Integration with setup_inspect.py
@@ -886,7 +971,9 @@ Additional checks for experiment-guided mode:
 - ✓ experiment_summary.yaml was successfully parsed
 - ✓ Extracted dataset path exists and format matches
 - ✓ System prompt matches training configuration
-- ✓ Task supports both `config_dir` and `dataset_path` parameters
+- ✓ Task accepts `data_path` + `config_path` and reads prompt/system_prompt/scorer from `config_path`
+- ✓ Task accepts `vis_label` and folds it into the task name
+- ✓ Parameter names are within `setup_inspect.py`'s `TASK_ARG_KEYS`
 - ✓ Documentation includes experiment context (research question, runs)
 - ✓ Usage examples show both fine-tuned and base model evaluation
 - ✓ Log includes extraction details and validation results
@@ -940,9 +1027,9 @@ After creating the task, guide user:
 - Always check for experiment_summary.yaml before starting
 - Extract and validate all configuration before proceeding
 - **System prompt consistency is critical** - eval must match training
-- Generated tasks should work for both fine-tuned and base models
+- Generated tasks should work for both fine-tuned and base models (`use_chat_template` toggles instruct vs. base)
 - Include experiment context in documentation (research question, runs)
-- Use `config_dir` parameter pattern for experiment integration
+- Read prompt/system_prompt/scorer from `config_path` (the eval_config.yaml), and fold `vis_label` into the task name
 - Log all extraction and validation steps for reproducibility
 
 ## Error Handling

--- a/.claude/skills/create-inspect-task/SKILL.md
+++ b/.claude/skills/create-inspect-task/SKILL.md
@@ -361,9 +361,9 @@ Result: Will use hf_dataset with json format and custom record_to_sample functio
 
 **Based on evaluation objective, suggest scorers:**
 
-**cruijff_kit custom scorers (preferred for experiment tasks — driven by the `scorer:` block in `eval_config.yaml`):**
+**cruijff_kit custom scorers (preferred for experiment tasks — driven by the `scorers:` block in `eval_config.yaml`):**
 
-Rather than hard-coding a scorer in the task, read the `scorer:` list from `config_path` and build it via the shared registry. This lets the experiment design (not the task code) pick the scorer:
+Rather than hard-coding a scorer in the task, read the `scorers:` list from `config_path` and build it via the shared registry. This lets the experiment design (not the task code) pick the scorer:
 
 ```python
 from cruijff_kit.tools.inspect.scorers import (
@@ -371,13 +371,13 @@ from cruijff_kit.tools.inspect.scorers import (
     configured_scorers_require_logprobs,
 )
 
-scorers = build_scorers(config)  # falls back to DEFAULT_SCORERS if no scorer: block
+scorers = build_scorers(config)  # falls back to DEFAULT_SCORERS if no scorers: block
 ```
 
-The `scorer:` block is a list of `{name, params}` entries:
+The `scorers:` block is a list of `{name, params}` entries:
 
 ```yaml
-scorer:
+scorers:
   - name: match
   - name: risk_scorer
     params:
@@ -436,7 +436,7 @@ Note: `risk_scorer` accuracy is exact-string-match (`completion == target`), not
 **Standard parameters — match the current blueprint tasks so the task drops into the `eval_config.yaml` pipeline** (cleanest reference: `blueprints/capitalization/inspect_task.py`):
 
 - `data_path` — Path to the dataset JSON (required; no default).
-- `config_path` — Path to `eval_config.yaml`. The task reads `prompt`, `system_prompt`, and (optionally) the `scorer:` block from it. `setup_inspect.py` auto-derives this from the config file's own location — you do not pass it by hand.
+- `config_path` — Path to `eval_config.yaml`. The task reads `prompt`, `system_prompt`, and (optionally) the `scorers:` block from it. `setup_inspect.py` auto-derives this from the config file's own location — you do not pass it by hand.
 - `vis_label` — Optional label appended to the task name (`f"{name}_{vis_label}" if vis_label else name`). **Required for the viz pipeline**: `viz_helpers` reads `vis_label` from the eval log's `task_args` to dedup and label runs. Omit it and multi-variant runs collide in the visualizations.
 - `split` — Which split to evaluate (e.g. `"test"`, `"validation"`).
 - `use_chat_template` — `True` for instruct models (adds a `system_message` solver), `False` for base models (plain text completion).
@@ -444,14 +444,13 @@ Note: `risk_scorer` accuracy is exact-string-match (`completion == target`), not
 - `logprobs` / `top_logprobs` — Capture top logprobs. Leave `logprobs` defaulting to `None` (auto) so it enables only when a configured scorer needs them — see Scorer Selection.
 - `assistant_prefix` — Optional text to seed the assistant turn.
 
-These names are not arbitrary. `setup_inspect.py` maps a fixed `TASK_ARG_KEYS` set onto `-T` flags:
+These names are not arbitrary. `setup_inspect.py` maps a fixed `TASK_ARG_KEYS` set onto `-T` flags — commonly the likes of:
 
 ```
-data_path, config_path, vis_label, use_chat_template, split,
-logprobs, top_logprobs, temperature, max_tokens, assistant_prefix
+data_path, config_path, vis_label, use_chat_template, split, logprobs, …
 ```
 
-A parameter outside that set will **not** receive a value from `eval_config.yaml` (you'd get a startup warning from `load_eval_config` about an unconsumed key). Add genuinely new task args to `TASK_ARG_KEYS` in `setup_inspect.py` if the task needs them.
+`TASK_ARG_KEYS` in `setup_inspect.py` is the source of truth for the full set — read it there rather than trusting this list to stay complete. A parameter outside that set will **not** receive a value from `eval_config.yaml` (you'd get a startup warning from `load_eval_config` about an unconsumed key); add genuinely new task args to `TASK_ARG_KEYS` if the task needs them.
 
 **Benefits of parameters:**
 - Run variations without code changes
@@ -474,7 +473,7 @@ inspect eval task.py -T param_name=value
 
 **Option 2: Experiment pipeline (eval_config.yaml)**
 - The model path is baked into the SLURM cell by `setup_inspect.py` from `eval_config.yaml`
-- The task itself only reads `prompt`/`system_prompt`/`scorer` from `config_path` — it never resolves the model
+- The task itself only reads `prompt`/`system_prompt`/`scorers` from `config_path` — it never resolves the model
 - This is how `scaffold-inspect` runs tasks; see Generated Task Pattern below
 
 **Option 3: Hard-coded in task**
@@ -810,13 +809,13 @@ scorer = model_graded_qa(
 
 ### Experiment-Guided Task Creation (Recommended)
 
-When creating tasks for an experiment, the task does **not** read fine-tuning configs directly. Instead it reads its prompt/scorer config from the `eval_config.yaml` that `scaffold-inspect` writes, via the auto-derived `config_path`:
+When creating tasks for an experiment, the task does **not** read fine-tuning configs directly. Instead it reads its prompt/scorers config from the `eval_config.yaml` that `scaffold-inspect` writes, via the auto-derived `config_path`:
 
-1. `design-experiment` produces `experiment_summary.yaml` (research question, data, models, `evaluation.system_prompt`, the `scorer:` block).
-2. `scaffold-inspect` writes one `eval_config.yaml` per (run, task, epoch) cell, carrying `prompt`, `system_prompt`, `scorer`, `data_path`, `vis_label`, etc.
-3. `setup_inspect.py` renders the SLURM script: it auto-derives `config_path` (the path to that `eval_config.yaml`), maps `TASK_ARG_KEYS` onto `-T` flags, and the task reads `prompt`/`system_prompt`/`scorer` back out of `config_path` at runtime.
+1. `design-experiment` produces `experiment_summary.yaml` (research question, data, models, `evaluation.system_prompt`, the `scorers:` block).
+2. `scaffold-inspect` writes one `eval_config.yaml` per (run, task, epoch) cell, carrying `prompt`, `system_prompt`, `scorers`, `data_path`, `vis_label`, etc.
+3. `setup_inspect.py` renders the SLURM script: it auto-derives `config_path` (the path to that `eval_config.yaml`), maps `TASK_ARG_KEYS` onto `-T` flags, and the task reads `prompt`/`system_prompt`/`scorers` back out of `config_path` at runtime.
 
-So a generated task's job is: accept the standard params, read prompt/system_prompt (and optionally the `scorer:` block) from `config_path`, build the dataset/solver/scorer, and name itself with `vis_label`.
+So a generated task's job is: accept the standard params, read prompt/system_prompt (and optionally the `scorers:` block) from `config_path`, build the dataset/solver/scorer, and name itself with `vis_label`.
 
 ### Generated Task Pattern
 
@@ -852,7 +851,7 @@ def my_task(
 
     Args:
         data_path: Path to the dataset JSON.
-        config_path: Path to eval_config.yaml (reads prompt/system_prompt/scorer).
+        config_path: Path to eval_config.yaml (reads prompt/system_prompt/scorers).
         split: Which split to evaluate (default: "test").
         temperature: Generation temperature (greedy default 1e-7).
         max_tokens: Max tokens to generate.
@@ -901,7 +900,7 @@ def my_task(
     else:
         solver = chain(generate(temperature=temperature, max_tokens=max_tokens))
 
-    # Scorer + logprobs driven by the eval_config scorer: block.
+    # Scorer + logprobs driven by the eval_config scorers: block.
     scorers = build_scorers(config)
     scorer_needs_logprobs = configured_scorers_require_logprobs(config)
     if logprobs is False and scorer_needs_logprobs:
@@ -925,7 +924,48 @@ def my_task(
     )
 ```
 
-For a **standalone** task with no experiment context, drop the `config_path`/`build_scorers`/logprobs machinery and hard-code a built-in scorer (e.g. `scorer=match(...)`) — but keep `vis_label` if the eval logs will feed the viz pipeline.
+For a **standalone** task with no experiment context, drop the `config_path`/`build_scorers`/logprobs machinery and hard-code a built-in scorer (e.g. `scorer=match(...)`) — but keep `vis_label` if the eval logs will feed the viz pipeline:
+
+```python
+from inspect_ai import Task, task
+from inspect_ai.dataset import hf_dataset, Sample
+from inspect_ai.scorer import match
+from inspect_ai.solver import generate
+
+
+@task
+def my_task(
+    data_path: str,
+    split: str = "test",
+    temperature: float = 1e-7,
+    max_tokens: int = 20,
+    vis_label: str = "",
+) -> Task:
+    """Standalone eval on <task description> (no eval_config.yaml)."""
+    task_name = f"my_task_{vis_label}" if vis_label else "my_task"
+
+    def record_to_sample(record):
+        return Sample(
+            input=record["input"],
+            target=record["output"],
+            metadata=record.get("metadata", {}),
+        )
+
+    dataset = hf_dataset(
+        path="json",
+        data_files=data_path,
+        field=split,
+        split="train",  # HuggingFace quirk — always "train" here
+        sample_fields=record_to_sample,
+    )
+
+    return Task(
+        name=task_name,
+        dataset=dataset,
+        solver=generate(temperature=temperature, max_tokens=max_tokens),
+        scorer=match(),  # hard-coded — no scorers: block to read
+    )
+```
 
 ### Usage Examples
 
@@ -971,7 +1011,7 @@ Additional checks for experiment-guided mode:
 - ✓ experiment_summary.yaml was successfully parsed
 - ✓ Extracted dataset path exists and format matches
 - ✓ System prompt matches training configuration
-- ✓ Task accepts `data_path` + `config_path` and reads prompt/system_prompt/scorer from `config_path`
+- ✓ Task accepts `data_path` + `config_path` and reads prompt/system_prompt/scorers from `config_path`
 - ✓ Task accepts `vis_label` and folds it into the task name
 - ✓ Parameter names are within `setup_inspect.py`'s `TASK_ARG_KEYS`
 - ✓ Documentation includes experiment context (research question, runs)
@@ -1029,7 +1069,7 @@ After creating the task, guide user:
 - **System prompt consistency is critical** - eval must match training
 - Generated tasks should work for both fine-tuned and base models (`use_chat_template` toggles instruct vs. base)
 - Include experiment context in documentation (research question, runs)
-- Read prompt/system_prompt/scorer from `config_path` (the eval_config.yaml), and fold `vis_label` into the task name
+- Read prompt/system_prompt/scorers from `config_path` (the eval_config.yaml), and fold `vis_label` into the task name
 - Log all extraction and validation steps for reproducibility
 
 ## Error Handling

--- a/.claude/skills/create-inspect-task/SKILL.md
+++ b/.claude/skills/create-inspect-task/SKILL.md
@@ -447,7 +447,7 @@ Note: `risk_scorer` accuracy is exact-string-match (`completion == target`), not
 These names are not arbitrary. `setup_inspect.py` maps a fixed `TASK_ARG_KEYS` set onto `-T` flags — commonly the likes of:
 
 ```
-data_path, config_path, vis_label, use_chat_template, split, logprobs, …
+data_path, config_path, vis_label, split, temperature, max_tokens, …
 ```
 
 `TASK_ARG_KEYS` in `setup_inspect.py` is the source of truth for the full set — read it there rather than trusting this list to stay complete. A parameter outside that set will **not** receive a value from `eval_config.yaml` (you'd get a startup warning from `load_eval_config` about an unconsumed key); add genuinely new task args to `TASK_ARG_KEYS` if the task needs them.
@@ -924,7 +924,7 @@ def my_task(
     )
 ```
 
-For a **standalone** task with no experiment context, drop the `config_path`/`build_scorers`/logprobs machinery and hard-code a built-in scorer (e.g. `scorer=match(...)`) — but keep `vis_label` if the eval logs will feed the viz pipeline:
+For a **standalone** task with no experiment context, drop the `config_path`/`build_scorers`/logprobs machinery and hard-code a built-in scorer (e.g. `scorer=match(...)`) — but keep `vis_label` (and pass it yourself via `-T vis_label=…`, since there's no `eval_config.yaml` to auto-map it) if the eval logs will feed the viz pipeline:
 
 ```python
 from inspect_ai import Task, task

--- a/blueprints/capitalization/inspect_task.py
+++ b/blueprints/capitalization/inspect_task.py
@@ -2,19 +2,19 @@
 Eval task for capitalization.
 
 Supports both instruct models (chat_completion) and base models (text_completion).
-Reads prompt and system_prompt from setup_finetune.yaml to ensure train/eval parity.
+Reads prompt and system_prompt from eval_config.yaml to ensure train/eval parity.
 
 Usage:
     # For instruct models (chat_completion, default):
     inspect eval inspect_task.py --model hf/local \
         -M model_path=/path/to/checkpoint \
-        -T config_path=/path/to/setup_finetune.yaml \
+        -T config_path=/path/to/eval_config.yaml \
         -T data_path=/path/to/words_5L_80P_1000.json
 
     # For base models (text_completion):
     inspect eval inspect_task.py --model hf/local \
         -M model_path=/path/to/checkpoint \
-        -T config_path=/path/to/setup_finetune.yaml \
+        -T config_path=/path/to/eval_config.yaml \
         -T data_path=/path/to/words_5L_80P_1000.json \
         -T use_chat_template=false
 """
@@ -41,7 +41,7 @@ def capitalization(
 
     Args:
         data_path: Path to JSON file with {"train": [...], "validation": [...], "test": [...]}
-        config_path: Path to setup_finetune.yaml (reads prompt/system_prompt from it)
+        config_path: Path to eval_config.yaml (reads prompt/system_prompt from it)
         split: Which split to evaluate on (default: test)
         temperature: Generation temperature
         max_tokens: Max tokens to generate

--- a/tests/unit/scorers/test_continuous_scorer.py
+++ b/tests/unit/scorers/test_continuous_scorer.py
@@ -241,6 +241,20 @@ class TestRegistry:
         """An explicit empty list also falls back to DEFAULT_SCORERS."""
         assert len(build_scorers({"scorers": []})) == 2
 
+    def test_build_scorers_ignores_legacy_singular_scorer_key(self):
+        """Regression (#372): build_scorers reads `scorers` (plural) only.
+
+        `evaluation.scorer` was renamed to `scorers` (#567), so a pre-rename
+        singular `scorer:` block is now ignored and silently falls back to
+        DEFAULT_SCORERS rather than the user's chosen scorer (e.g. `risk_scorer`
+        -> default match/includes, wrong calibration, no crash). This pins that
+        soft-fail as deliberate, giving a baseline to flip the day a stale
+        `scorer:` should instead hard-error.
+        """
+        legacy = build_scorers({"scorer": [{"name": "risk_scorer"}]})
+        assert legacy == build_scorers({})  # identical to the no-key case
+        assert len(legacy) == 2  # match + includes, NOT the requested risk_scorer
+
     def test_build_scorers_ignores_legacy_singular_key(self):
         """Regression: a pre-rename `scorer:` (singular) is NOT honored (#372).
 


### PR DESCRIPTION
Closes #565

## Description

The `create-inspect-task` skill predated the #437 reorg and the unified `eval_config.yaml` evaluation architecture. A task generated by following it would not integrate with `scaffold-inspect` / `setup_inspect.py`, would miss `vis_label` (breaking viz dedup/labeling), and would steer users toward a legacy `config_dir` → `setup_finetune.yaml` pattern the current tasks no longer use.

This reworks the skill so a generated task mirrors the live blueprint tasks (`blueprints/capitalization/inspect_task.py` as the reference). All 7 audited gaps are addressed:

| # | Gap | Fix |
|---|---|---|
| 1 | `vis_label` missing | Task accepts `vis_label`, names itself `f"{name}_{vis_label}"`; documented as required for the viz pipeline |
| 2 | `config_dir` vs `config_path` | Replaced legacy `config_dir`/`setup_finetune.yaml` guidance with `config_path` (the eval_config.yaml, auto-derived by `setup_inspect.py`) |
| 3 | `eval_config.yaml` contract | Documented the `eval_config.yaml` → `setup_inspect.py` `TASK_ARG_KEYS` → `-T` mapping |
| 4 | Custom scorers | Added the `scorer:` YAML block + `build_scorers` registry (`match`, `includes`, `risk_scorer`, `numeric_risk_scorer`, `continuous_scorer`) |
| 5 | logprobs contract | Documented `configured_scorers_require_logprobs` auto-enable + the `logprobs=False`-with-logprob-scorer guard |
| 6 | Newer params | Added `assistant_prefix`, `use_chat_template`, `split`, `logprobs`/`top_logprobs` to the standard set |
| 7 | inspect-ai API drift | Fixed `generate({"temperature": 0.0})` dict-arg form → `generate(temperature=0.0)` kwargs |

Primarily a skill-doc change; also fixes 4 stale docstring lines in the reference task `blueprints/capitalization/inspect_task.py` (`setup_finetune.yaml` → `eval_config.yaml`). No `src/` code touched. Rebased onto main + freshened `scorer:` → `scorers:` (#567); see the latest PR comment for full review-response notes.

## New Dependencies

None.

## Testing Instructions

This is a skill-documentation change, so "testing" is review + a spot exercise:

1. Read the reworked **Generated Task Pattern** and confirm it matches `blueprints/capitalization/inspect_task.py` (param set, `config_path` read, `vis_label` naming, `build_scorers`/logprobs block).
2. Sanity-check no stale references remain: `grep -n "config_dir\|setup_finetune\|generate({" .claude/skills/create-inspect-task/SKILL.md` should be empty.
3. Optional end-to-end: invoke the `create-inspect-task` skill in standalone mode and confirm the generated task carries `vis_label` + `config_path` and uses kwargs-form `generate(...)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)