### PR TITLE
Fix nightly GPU smoke tests: pass required dataset_type

### DIFF
--- a/tests/integration/gpu/smoke_test_scaffolding.py
+++ b/tests/integration/gpu/smoke_test_scaffolding.py
@@ -31,6 +31,8 @@ def test_setup_finetune(work_dir: Path):
             "test_dataset",
             "--dataset_ext",
             ".json",
+            "--dataset_type",
+            "chat_completion",
             "--input_dir_base",
             "/fake/input/",
             "--project_dir",

--- a/tests/integration/gpu/smoke_test_torchtune.py
+++ b/tests/integration/gpu/smoke_test_torchtune.py
@@ -53,6 +53,8 @@ def main():
                 "words_5L_80P_50",
                 "--dataset_ext",
                 ".json",
+                "--dataset_type",
+                "chat_completion",
                 "--input_dir_base",
                 str(REPO_ROOT / "tests" / "fixtures"),
                 "--input_formatting",


### PR DESCRIPTION
## Description

The **Nightly Torchtune Smoke Test** and **GPU Smoke Test** have failed every night since #478 merged, both with:

```
ValueError: dataset_type is required but was not provided.
```

#478 (commit `78c4739`) promoted `dataset_type` to a hard-required argument of `setup_finetune.py`. The two GPU integration fixtures call `setup_finetune.py` directly and were never updated, so they die on the first scaffold step:

- `tests/integration/gpu/smoke_test_torchtune.py` — scaffold call
- `tests/integration/gpu/smoke_test_scaffolding.py` — `test_setup_finetune`

Both fixtures use `Llama-3.2-1B-Instruct` (a chat model), so the fix passes `--dataset_type chat_completion`, matching the convention in all three `workflow_test*.md` specs.

**Why CI didn't catch it:** these scripts run only on the self-hosted della GPU runner via the scheduled nightlies. The unit suite and PR CI never exercise them, so the required-arg promotion slipped through.

## New Dependencies

None.

## Testing Instructions

- `smoke_test_scaffolding.py` is CPU-only — `python tests/integration/gpu/smoke_test_scaffolding.py` now prints `PASS: setup_finetune.py scaffolding` (verified locally).
- `smoke_test_torchtune.py` uses the identical scaffold call plus a GPU train step; the nightly (or a manual `workflow_dispatch`) will confirm end-to-end.
- `ruff check` / `ruff format --check` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)