### PR TITLE
Document naming conventions and fix stale paths (#372)

### DIFF
--- a/.claude/skills/ck-setup/SKILL.md
+++ b/.claude/skills/ck-setup/SKILL.md
@@ -5,6 +5,10 @@ description: First-time setup for new cruijff_kit users — walks through claude
 
 # ck-setup
 
+> **Naming note:** the `ck-` prefix is deliberate. A bare `setup` would collide with a
+> built-in skill of that name, so the prefix is load-bearing — a future naming audit
+> shouldn't "fix" it away.
+
 You help users get a working cruijff_kit environment. There are two modes — pick based on whether `claude.local.md` already exists:
 
 - **Greenfield** — no `claude.local.md`. Walk the user through `claude.local.md.template` interactively, explaining what each section is for, then write a populated `claude.local.md`.

--- a/.claude/skills/create-quiz/logging.md
+++ b/.claude/skills/create-quiz/logging.md
@@ -27,7 +27,7 @@ If `logs/` doesn't exist, create it. Append to the log on re-runs (don't truncat
 
 ```
 [2026-05-03 16:42:08] LOCATE_EXPERIMENT: length_sweep_nth14
-Details: /scratch/gpfs/MSALGANIK/mjs3/ck-experiments/length_sweep_nth14
+Details: /scratch/gpfs/MSALGANIK/mjs3/ck-projects/length_sweep/length_sweep_nth14
 Result: experiment_summary.yaml present, exploration/report.md present, summary.md absent
 
 [2026-05-03 16:42:09] PARSE_INPUTS: length_sweep_nth14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ All notable changes to cruijff_kit will be documented in this file.
 - Evaluation scaffolding (`scaffold-inspect`) no longer reads `setup_finetune.yaml` — `prompt` and `dataset_type` are propagated into `eval_config.yaml` from `experiment_summary.yaml`, decoupling evaluation from the training artifact. (#478)
 - **`controls.dataset_type` is now required** and used uniformly by training and evaluation. It is no longer inferred from the model name or a per-model `MODEL_CONFIGS` default; an absent value is a hard error at every layer (design validation, both scaffold agents, and `setup_finetune.py`), preventing a silent chat-vs-text mismatch from corrupting train/eval parity. **Migration:** existing `experiment_summary.yaml` files must add `controls.dataset_type` (`chat_completion` | `text_completion`). (#478)
 
+### Documentation
+
+- **Naming conventions written down** (no renames — doc-only). `CLAUDE.md` now records the `directory`-over-`dir` preference for names we own, the `directory`-vs-`path` (folder-vs-file) distinction, and — on the "Wrapper-only" principle — the external-contract names that are off-limits to our renames (torchtune recipe keys, inspect-ai `@task`/`@scorer`/`@metric` registry names). Also documented: the deliberate `ck-setup` prefix (avoids a built-in `setup` clash), the `src/tools/<domain>/` folder-naming convention and the `inspect/`-shadows-stdlib hazard (`docs/ARCHITECTURE.md` + `src/tools/inspect/__init__.py`), and a fixed stale `ck-experiments/` path in the `create-quiz` skill docs and a test fixture. (#372)
+
 ## [0.3.3] - 2026-06-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to cruijff_kit will be documented in this file.
 
 ### Documentation
 
-- **Naming conventions written down** (no renames — doc-only). `CLAUDE.md` now records the `directory`-over-`dir` preference for names we own, the `directory`-vs-`path` (folder-vs-file) distinction, and — on the "Wrapper-only" principle — the external-contract names that are off-limits to our renames (torchtune recipe keys, inspect-ai `@task`/`@scorer`/`@metric` registry names). Also documented: the deliberate `ck-setup` prefix (avoids a built-in `setup` clash), the `src/tools/<domain>/` folder-naming convention and the `inspect/`-shadows-stdlib hazard (`docs/ARCHITECTURE.md` + `src/tools/inspect/__init__.py`), and a fixed stale `ck-experiments/` path in the `create-quiz` skill docs and a test fixture. (#372)
+- **Naming conventions written down** (no renames — doc-only). `CLAUDE.md` now records the `dir`-over-`directory` preference for names we own (short idiom, already dominant here, matches the external `output_dir`/`checkpoint_dir`/`log_dir` keys we sit beside), the `dir`-vs-`path` (folder-vs-file) distinction, and — on the "Wrapper-only" principle — the external-contract names that are off-limits to our renames (torchtune recipe keys, inspect-ai `@task`/`@scorer`/`@metric` registry names). Also documented: the deliberate `ck-setup` prefix (avoids a built-in `setup` clash), the `src/tools/<domain>/` folder-naming convention and the `inspect/`-shadows-stdlib hazard (`docs/ARCHITECTURE.md` + `src/tools/inspect/__init__.py`), and a fixed stale `ck-experiments/` path in the `create-quiz` skill docs and a test fixture. (#372)
 
 ## [0.3.3] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,11 @@ All notable changes to cruijff_kit will be documented in this file.
 
 ### Documentation
 
-- **Naming conventions written down** (no renames — doc-only). `CLAUDE.md` now records the `dir`-over-`directory` preference for names we own (short idiom, already dominant here, matches the external `output_dir`/`checkpoint_dir`/`log_dir` keys we sit beside), the `dir`-vs-`path` (folder-vs-file) distinction, and — on the "Wrapper-only" principle — the external-contract names that are off-limits to our renames (torchtune recipe keys, inspect-ai `@task`/`@scorer`/`@metric` registry names). Also documented: the deliberate `ck-setup` prefix (avoids a built-in `setup` clash), the `src/tools/<domain>/` folder-naming convention and the `inspect/`-shadows-stdlib hazard (`docs/ARCHITECTURE.md` + `src/tools/inspect/__init__.py`), and a fixed stale `ck-experiments/` path in the `create-quiz` skill docs and a test fixture. (#372)
+- **Naming conventions written down** (no renames). New `CLAUDE.md` "Naming Conventions" subsection records the `dir`-over-`directory` preference for names we own — the short idiom is already dominant here and matches the external `output_dir`/`checkpoint_dir`/`log_dir` keys we sit beside — plus the `dir`-vs-`path` (folder-vs-file) distinction. (#372)
+- **External-contract naming boundary** added to the "Wrapper-only" principle (`CLAUDE.md`): the names off-limits to our renames because they belong to an external contract — torchtune recipe keys (`lr`, `seed`, `batch_size`, `epochs`, `max_seq_len`, `output_dir`) and inspect-ai's `@task`/`@scorer`/`@metric` registry names. We rename only what we own. (#372)
+- **`ck-setup` prefix rationale** documented (`CLAUDE.md` skills list + `ck-setup/SKILL.md`): the `ck-` prefix is deliberate — a bare `setup` would collide with a built-in skill — so a future audit shouldn't "fix" it. (#372)
+- **Tool-domain folder convention + `inspect/`-shadows-stdlib hazard** (`docs/ARCHITECTURE.md`): how `src/tools/<domain>/` folders are named, and the hazard that `src/tools/inspect/` shadows Python's stdlib `inspect`. The hazard is also noted in `src/tools/inspect/__init__.py` and now locked by a guard test (`tests/unit/test_inspect_no_stdlib_shadow.py`) that fails if any module in the subtree imports the stdlib `inspect` by name. (#372)
+- **Stale `ck-experiments/` path fixed** (storage dir is now `ck-projects/<project>/<experiment>/`): corrected in the `create-quiz` skill docs and a `summarize` test fixture. (#372)
 
 ## [0.3.3] - 2026-06-04
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ When working in this project, the following principles should guide your decisio
 
 5. **Self improving** - Always look for ways to learn from earlier experiments to design new experiments, improve skills, and improve analysis. The more work we do, the easier things should be because we have more designs, results, and logs from which to learn.
 
-6. **Wrapper-only** - cruijff_kit integrates with external tools (torchtune, inspect-ai) by wrapping them, not modifying their internals.
+6. **Wrapper-only** - cruijff_kit integrates with external tools (torchtune, inspect-ai) by wrapping them, not modifying their internals. This extends to naming: names that belong to an external contract are off-limits to our renames — e.g. torchtune recipe keys (`lr`, `seed`, `batch_size`, `epochs`, `max_seq_len`, `output_dir`) and inspect-ai's `@task` / `@scorer` / `@metric` registry names. We rename only the names we own: our YAML schema, our folders, and our wrapper scripts.
 
 ## Terminology
 
@@ -64,7 +64,7 @@ For detailed architecture documentation, see [ARCHITECTURE.md](docs/ARCHITECTURE
 cruijff_kit includes Claude Code skills to streamline common workflows. These skills are optional - all workflows can also be performed manually.
 
 ### Setup
-- **ck-setup** ✅ - First-time setup walkthrough OR validate-existing health check for `claude.local.md` (HPC paths, SLURM defaults, conda env). Run this before anything else.
+- **ck-setup** ✅ - First-time setup walkthrough OR validate-existing health check for `claude.local.md` (HPC paths, SLURM defaults, conda env). Run this before anything else. *(The `ck-` prefix is intentional — it avoids a clash with a built-in `setup` skill; a naming audit shouldn't "fix" it.)*
 
 ### Primary Workflows
 - **design-experiment** ✅ - Plan a series of runs that collectively make up an experiment
@@ -110,6 +110,19 @@ All use Llama-3.2-1B-Instruct with `{ck_data_dir}/capitalization/words_5L_80P_10
 **Purpose:** Catch regressions in skills, ensure documentation changes don't break workflows, validate end-to-end integration.
 
 ## Code Conventions
+
+### Naming Conventions
+
+- **`directory` over `dir` for names we own.** When we choose a name (a YAML key, a
+  CLI flag, a documented folder or constant), prefer the spelled-out `directory` —
+  readability beats the saved keystrokes. Use the abbreviated `dir` / `_dir` only when
+  an external tool's convention dictates it (e.g. torchtune's `output_dir`, inspect-ai
+  keys); see the "Wrapper-only" principle on external-contract names. This is
+  forward-looking guidance for new names — the codebase still uses `_dir` widely, and
+  those existing identifiers are not flagged for renaming here.
+- **`directory` vs `path` — keep them true to their meanings.** `directory` (or `_dir`)
+  names a folder; `path` (or `_path`) names a file. Don't label a folder `path` or a
+  file `directory`.
 
 ### Code Comments
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,16 +113,14 @@ All use Llama-3.2-1B-Instruct with `{ck_data_dir}/capitalization/words_5L_80P_10
 
 ### Naming Conventions
 
-- **`directory` over `dir` for names we own.** When we choose a name (a YAML key, a
-  CLI flag, a documented folder or constant), prefer the spelled-out `directory` —
-  readability beats the saved keystrokes. Use the abbreviated `dir` / `_dir` only when
-  an external tool's convention dictates it (e.g. torchtune's `output_dir`, inspect-ai
-  keys); see the "Wrapper-only" principle on external-contract names. This is
-  forward-looking guidance for new names — the codebase still uses `_dir` widely, and
-  those existing identifiers are not flagged for renaming here.
-- **`directory` vs `path` — keep them true to their meanings.** `directory` (or `_dir`)
-  names a folder; `path` (or `_path`) names a file. Don't label a folder `path` or a
-  file `directory`.
+- **`dir` over `directory` for names we own.** When we choose a name (a YAML key, a
+  CLI flag, a variable, a documented folder or constant), use the short `dir` / `_dir`
+  form. It's the popular idiom, it's already dominant throughout this codebase, and it
+  matches the external tools we wrap (torchtune's `output_dir`, `checkpoint_dir`,
+  `log_dir`), so our names sit consistently beside theirs instead of clashing. Keep the
+  spelled-out `directory` for prose; avoid it in identifiers and keys.
+- **`dir` vs `path` — keep them true to their meanings.** `dir` (or `_dir`) names a
+  folder; `path` (or `_path`) names a file. Don't label a folder `path` or a file `dir`.
 
 ### Code Comments
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -374,6 +374,21 @@ At a high level: hand-write `setup_finetune.yaml` in each run directory under `c
 5. Optional: add `baseline.py` (non-LLM comparison) and/or `modifiers/` (data transforms)
 6. Document the workflow in the blueprint README
 
+### Tool Domains
+
+Each subfolder of `src/tools/` is a domain package. Name a domain after the external
+tool when one tool dominates it (`torchtune/`, `inspect/`); otherwise name it after the
+pipeline stage it serves (`experiment/`, `slurm/`) or the framework it provides
+(`model_organisms/`). Code owned by no single domain belongs in `src/utils/`, not a
+tool folder (see below).
+
+> **`inspect/` shadows the stdlib.** `src/tools/inspect/` shares its name with Python's
+> standard-library `inspect` module (it wraps the external inspect-ai tool). No module
+> in that subtree does a bare `import inspect`, and none should rely on one resolving to
+> the stdlib — if that directory ever lands on `sys.path` as a top-level entry, the
+> import could bind to the package instead. Keep stdlib-`inspect` use out of the subtree,
+> or alias it explicitly. The hazard is also recorded in `src/tools/inspect/__init__.py`.
+
 ### Using Utilities
 
 `src/utils/` holds generic, cross-cutting infrastructure owned by no single domain —

--- a/src/tools/inspect/__init__.py
+++ b/src/tools/inspect/__init__.py
@@ -1,0 +1,6 @@
+# Heads-up: this package shares its name with Python's standard-library `inspect`
+# module — it is named after the external inspect-ai tool it wraps. No module in this
+# subtree does a bare `import inspect`, and none should rely on one resolving to the
+# stdlib: if this directory is ever placed on `sys.path` as a top-level entry, that
+# import could bind here instead of to the stdlib. Keep stdlib introspection imports out
+# of this subtree, or alias them explicitly.

--- a/tests/fixtures/summarize/eval_result.json
+++ b/tests/fixtures/summarize/eval_result.json
@@ -8,5 +8,5 @@
   "metrics": {
     "accuracy": 0.85
   },
-  "path": "__SCRATCH__/ck-experiments/workflow_test_2026-03-16/Llama-3.2-1B-Instruct_rank4/eval/logs/test.eval"
+  "path": "__SCRATCH__/ck-projects/workflow_test/workflow_test_2026-03-16/Llama-3.2-1B-Instruct_rank4/eval/logs/test.eval"
 }

--- a/tests/unit/test_inspect_no_stdlib_shadow.py
+++ b/tests/unit/test_inspect_no_stdlib_shadow.py
@@ -1,0 +1,39 @@
+"""Guard the `src/tools/inspect/` vs stdlib-`inspect` name shadow (#372).
+
+`src/tools/inspect/` is named after the external inspect-ai tool it wraps, so it
+shares its name with Python's standard-library `inspect` module. If that directory
+ever lands on `sys.path` as a top-level entry, a bare `import inspect` inside the
+subtree could bind to the package instead of the stdlib. The hazard is documented in
+`docs/ARCHITECTURE.md` and `src/tools/inspect/__init__.py`; this test makes the
+invariant executable so a future `import inspect` fails loudly instead of silently.
+"""
+
+import ast
+from pathlib import Path
+
+INSPECT_SUBTREE = Path(__file__).parent.parent.parent / "src" / "tools" / "inspect"
+
+
+def _inspect_imports(py_file):
+    """Return import statements in py_file that bind the name `inspect`."""
+    tree = ast.parse(py_file.read_text(), filename=str(py_file))
+    offenders = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if any(alias.name == "inspect" for alias in node.names):
+                offenders.append(f"{py_file}:{node.lineno}: import inspect")
+        elif isinstance(node, ast.ImportFrom):
+            if node.module == "inspect" and node.level == 0:
+                offenders.append(f"{py_file}:{node.lineno}: from inspect import ...")
+    return offenders
+
+
+def test_no_stdlib_inspect_import_in_inspect_subtree():
+    """No module under src/tools/inspect/ may import the stdlib `inspect` by name."""
+    offenders = []
+    for py_file in INSPECT_SUBTREE.rglob("*.py"):
+        offenders.extend(_inspect_imports(py_file))
+    assert not offenders, (
+        "src/tools/inspect/ shadows stdlib `inspect`; these imports could bind to "
+        "the package instead. Alias explicitly or remove:\n  " + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
Part of #372

# Description

The last actionable, near-doc-only piece of the #372 naming audit. **No renames, no code-behavior change** — the six renames (A–G) already shipped, and the remaining design questions live in their own issues (#571 artifact rename, #572 config-file rename, #579 `dir`-vs-`directory`). This PR writes the conventions down, clears one stale path, and adds one guard test that locks a documented invariant.

**1. Naming conventions (`CLAUDE.md` → Code Conventions).** New "Naming Conventions" subsection:
- Prefer the short `dir`/`_dir` form for names we own (YAML keys, CLI flags, variables, documented folders/constants) — it's the popular idiom, already dominant throughout the codebase, and it matches the external torchtune keys we sit beside (`output_dir`, `checkpoint_dir`, `log_dir`).
- Keep `dir` vs `path` true to their meanings — `dir`/`_dir` = folder, `path`/`_path` = file.
- This PR itself renames nothing; it documents the rule. The one spelled-out holdout key (`experiment.directory`) is renamed to `experiment.dir` separately under #579.

**2. External-contract naming boundary (`CLAUDE.md` → Principle #6 "Wrapper-only").** Records the names that are off-limits to our renames because they belong to an external contract: torchtune recipe keys (`lr`, `seed`, `batch_size`, `epochs`, `max_seq_len`, `output_dir`) and inspect-ai's `@task`/`@scorer`/`@metric` registry names. We rename only what we own.

**3. `ck-setup` prefix rationale (`CLAUDE.md` skills list + `ck-setup/SKILL.md`).** Notes the `ck-` prefix is deliberate — a bare `setup` would collide with a built-in skill — so a future audit shouldn't "fix" it.

**4. Tool-domain folder convention + `inspect` stdlib shadow (`docs/ARCHITECTURE.md`).** Documents how `src/tools/<domain>/` folders are named (external tool when one dominates, else the pipeline stage/framework), alongside the existing `utils/` charter. Records the hazard that `src/tools/inspect/` shadows Python's stdlib `inspect`, with a matching note in `src/tools/inspect/__init__.py`. The invariant is now **enforced, not just described**: a new guard test (`tests/unit/test_inspect_no_stdlib_shadow.py`) fails if any module in that subtree imports the stdlib `inspect` by name (`import inspect`, `import inspect as X`, or `from inspect import ...`), so a future regression trips CI instead of resolving silently.

**5. Stale `ck-experiments/` path fix.** The storage dir is now `ck-projects/<project>/<experiment>/`. Fixed the deprecated name in `create-quiz/logging.md` (an example log) and a `summarize` test fixture (`eval_result.json`). `test_has_path` asserts only that the `path` key is **present and a string**, never its value, so swapping the path string can't change test behavior.

### Audit notes

- **The `dir` decision:** the `directory`-vs-`dir` direction was the one open call here. Resolved on #372 — standardize on **`dir` over `directory`** (existing-codebase idiom + external-tool consistency), reverting to what the audit's original Decision 2 proposed. The lone holdout key `experiment.directory` → `experiment.dir` is applied under #579; the rest of the codebase already complies.
- **`claude.local.md.della`** (tracked example config) still uses the deprecated `ck-experiments/` / `ck-sanity-checks/` / `ck-outputs/` working-dir names (and a pre-#437 `tools/` path). Left untouched here — it's a personal-example config whose fuller refresh is out of scope for a doc-conventions PR. Happy to file/fix on request.

## New Dependencies

None.

# Testing Instructions

- `python -m pytest tests/unit -q` → **1234 passed** (was 1233; +1 is the new `test_inspect_no_stdlib_shadow.py` guard).
- `ruff check` / `ruff format --check` clean on the two Python files touched (`src/tools/inspect/__init__.py`, `tests/unit/test_inspect_no_stdlib_shadow.py`).
