### PR TITLE
Pin ruff so CI and local environments agree

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 dev = [
     "pytest",
     "pytest-cov",
-    "ruff",
+    "ruff>=0.15.6,<0.16",  # pinned: 0.16 formats Python inside Markdown, reformatting our skills/agent docs. See #595.
     # Note: GitHub CLI (gh) must be installed via conda separately:
     # conda install -c conda-forge gh -y
 ]


### PR DESCRIPTION
Closes #594

## Description

The dev extra listed `"ruff"` with no version constraint, so CI resolved whatever was newest at install time while local environments kept whatever they had installed. Today that drift broke the `Lint` step of PR Tests on every open PR:

- local: ruff 0.15.6
- CI: ruff 0.16.1

ruff 0.16 formats Python code blocks inside Markdown files; 0.15 did not. `ruff check .` still passes — only `ruff format --check .` fails, on 15 Markdown files (14 under `.claude/`, plus `src/tabular_to_text_gen/TABULAR_DATASET_NAMING.md`). No Python source is affected.

This surfaced on #592 (the `actions/checkout` bump) because dependabot rebased it today and its checks reran with a fresh dependency install. It is unrelated to that PR's contents and would fail on any PR.

This constrains ruff to `>=0.15.6,<0.16`, so lint behavior changes only when we deliberately bump it — a shift toward stricter pinning of tooling rather than a one-off version choice.

Adopting ruff 0.16 and formatting the Markdown snippets is deferred to #595, not declined. It is worth doing; it just needs a review pass, since some of ruff's Markdown changes (stripping deliberate trailing-comment alignment, rewriting `...` to `...,`) read worse as documentation.

**#592 stays red until this lands** — once it does, rerunning its checks should clear the lint failure.

## New Dependencies

None. This constrains an existing dev dependency.

## Testing Instructions

```bash
ruff check .
ruff format --check .
```

Both pass locally on ruff 0.15.6. CI's `Lint` step passing on this PR is the real check, since it installs from `pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)